### PR TITLE
Mention that zls must be built with zig master

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ zig build
 
 Then, you can use the `zls` executable in an editor of your choice that has a Zig language server client!
 
+*Note:`zls` itself must be built using the master branch of zig currently due to a bug in `std.json` which was [fixed](https://github.com/ziglang/zig/pull/5167) after 0.6.0 was released.*
+
 ### Configuration Options
 
 You can configure zls by providing a zls.json file in the same directory as the executable.  


### PR DESCRIPTION
This caused some confusion for me while setting up `zls` with `kak-lsp` and I thought it would be good to mention in the readme.