### PR TITLE
Fixed crash when field access completing on a local variable with a type from another import

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -254,9 +254,7 @@ pub fn resolveTypeOfNode(analysis_ctx: *AnalysisContext, node: *ast.Node) ?*ast.
             }
         },
         .Identifier => {
-            const identifier = std.mem.dupe(&analysis_ctx.arena.allocator, u8, analysis_ctx.tree.getNodeSource(node)) catch return null;
-
-            if (getChildOfSlice(analysis_ctx.tree, analysis_ctx.scope_nodes, identifier)) |child| {
+            if (getChildOfSlice(analysis_ctx.tree, analysis_ctx.scope_nodes, analysis_ctx.tree.getNodeSource(node))) |child| {
                 return resolveTypeOfNode(analysis_ctx, child);
             } else return null;
         },
@@ -386,8 +384,7 @@ pub fn getFieldAccessTypeNode(analysis_ctx: *AnalysisContext, tokenizer: *std.zi
         switch (next.id) {
             .Eof => return current_node,
             .Identifier => {
-                const identifier = std.mem.dupe(&analysis_ctx.arena.allocator, u8, tokenizer.buffer[next.start..next.end]) catch return null;
-                if (getChildOfSlice(analysis_ctx.tree, analysis_ctx.scope_nodes, identifier)) |child| {
+                if (getChildOfSlice(analysis_ctx.tree, analysis_ctx.scope_nodes, tokenizer.buffer[next.start..next.end])) |child| {
                     if (resolveTypeOfNode(analysis_ctx, child)) |node_type| {
                         current_node = node_type;
                     } else return null;

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -206,7 +206,6 @@ pub fn getChild(tree: *ast.Tree, node: *ast.Node, name: []const u8) ?*ast.Node {
 
 /// Gets the child of slice
 pub fn getChildOfSlice(tree: *ast.Tree, nodes: []*ast.Node, name: []const u8) ?*ast.Node {
-    // var index: usize = 0;
     for (nodes) |child| {
         switch (child.id) {
             .VarDecl => {
@@ -227,7 +226,6 @@ pub fn getChildOfSlice(tree: *ast.Tree, nodes: []*ast.Node, name: []const u8) ?*
             },
             else => {},
         }
-        // index += 1;
     }
     return null;
 }
@@ -386,9 +384,7 @@ pub fn getFieldAccessTypeNode(analysis_ctx: *AnalysisContext, tokenizer: *std.zi
     while (true) {
         var next = tokenizer.next();
         switch (next.id) {
-            .Eof => {
-                return current_node;
-            },
+            .Eof => return current_node,
             .Identifier => {
                 const identifier = std.mem.dupe(&analysis_ctx.arena.allocator, u8, tokenizer.buffer[next.start..next.end]) catch return null;
                 if (getChildOfSlice(analysis_ctx.tree, analysis_ctx.scope_nodes, identifier)) |child| {
@@ -409,9 +405,7 @@ pub fn getFieldAccessTypeNode(analysis_ctx: *AnalysisContext, tokenizer: *std.zi
                     } else return null;
                 }
             },
-            else => {
-                std.debug.warn("Not implemented; {}\n", .{next.id});
-            },
+            else => std.debug.warn("Not implemented; {}\n", .{next.id}),
         }
     }
 
@@ -481,11 +475,11 @@ pub fn declsFromIndexInternal(decls: *std.ArrayList(*ast.Node), tree: *ast.Tree,
             }
         },
         .VarDecl, .ParamDecl => try decls.append(node),
-        else => try getCompletionsFromNode(decls, tree, node),
+        else => try addChildrenNodes(decls, tree, node),
     }
 }
 
-pub fn getCompletionsFromNode(decls: *std.ArrayList(*ast.Node), tree: *ast.Tree, node: *ast.Node) !void {
+pub fn addChildrenNodes(decls: *std.ArrayList(*ast.Node), tree: *ast.Tree, node: *ast.Node) !void {
     var index: usize = 0;
     while (node.iterate(index)) |child_node| : (index += 1) {
         try decls.append(child_node);
@@ -495,7 +489,7 @@ pub fn getCompletionsFromNode(decls: *std.ArrayList(*ast.Node), tree: *ast.Tree,
 pub fn declsFromIndex(decls: *std.ArrayList(*ast.Node), tree: *ast.Tree, index: usize) !void {
     var node = &tree.root_node.base;
 
-    try getCompletionsFromNode(decls, tree, node);
+    try addChildrenNodes(decls, tree, node);
     var node_index: usize = 0;
     while (node.iterate(node_index)) |inode| : (node_index += 1) {
         if (tree.tokens.at(inode.firstToken()).start < index and index < tree.tokens.at(inode.lastToken()).end) {

--- a/src/document_store.zig
+++ b/src/document_store.zig
@@ -259,7 +259,7 @@ pub const AnalysisContext = struct {
 
     fn refreshScopeNodes(self: *AnalysisContext) !void {
         var scope_nodes = std.ArrayList(*std.zig.ast.Node).init(&self.arena.allocator);
-        try analysis.getCompletionsFromNode(&scope_nodes, self.tree, &self.tree.root_node.base);
+        try analysis.addChildrenNodes(&scope_nodes, self.tree, &self.tree.root_node.base);
         self.scope_nodes = scope_nodes.items;
     }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -280,9 +280,9 @@ fn completeGlobal(id: i64, pos_index: usize, handle: DocumentStore.Handle, confi
     // Deallocate all temporary data.
     defer arena.deinit();
 
-    // var decls = tree.root_node.decls.iterator(0);
-    var decls = try analysis.declsFromIndex(&arena.allocator, tree, pos_index);
-    for (decls) |decl_ptr| {
+    var decl_nodes = std.ArrayList(*std.zig.ast.Node).init(&arena.allocator);
+    try analysis.declsFromIndex(&decl_nodes, tree, pos_index);
+    for (decl_nodes.items) |decl_ptr| {
         var decl = decl_ptr.*;
         try nodeToCompletion(&completions, tree, decl_ptr, config);
     }
@@ -310,7 +310,6 @@ fn completeFieldAccess(id: i64, handle: *DocumentStore.Handle, position: types.P
     const line = try handle.document.getLine(@intCast(usize, position.line));
     var tokenizer = std.zig.Tokenizer.init(line[line_start_idx..]);
 
-    // var decls = try analysis.declsFromIndex(&arena.allocator, analysis_ctx.tree, try handle.document.positionToIndex(position));
     if (analysis.getFieldAccessTypeNode(&analysis_ctx, &tokenizer)) |node| {
         try nodeToCompletion(&completions, analysis_ctx.tree, node, config);
     }


### PR DESCRIPTION
This code was assuming the original tree remains valid, we need to switch the scope_decls when hitting an import.