### PR TITLE
Completion support when a function with multiple arguments is completed

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -382,7 +382,7 @@ pub fn getFieldAccessTypeNode(
             },
             .Period => {
                 var after_period = tokenizer.next();
-                if (after_period.id == .Eof) {
+                if (after_period.id == .Eof or after_period.id == .Comma) {
                     return current_node;
                 } else if (after_period.id == .Identifier) {
                     // TODO: This works for now, maybe we should filter based on the partial identifier ourselves?


### PR DESCRIPTION
When completing a function foo: `fo<tab>` -> `foo(arg1: u8, arg2: u8)` and filling in arg1 with `std.` no completion would show up, because only EOF was considered as the end.