### PR TITLE
Check that the goto definition cursor is within bounds

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -283,6 +283,7 @@ fn nodeToCompletion(list: *std.ArrayList(types.CompletionItem), analysis_ctx: *D
 }
 
 fn identifierFromPosition(pos_index: usize, handle: DocumentStore.Handle) []const u8 {
+    if (pos_index + 1 >= handle.document.text.len) return &[0]u8{};
     var start_idx = pos_index;
 
     while (start_idx > 0 and

--- a/src/main.zig
+++ b/src/main.zig
@@ -291,7 +291,7 @@ fn identifierFromPosition(pos_index: usize, handle: DocumentStore.Handle) []cons
     {}
 
     var end_idx = pos_index;
-    while (end_idx < handle.document.text.len and
+    while (end_idx < handle.document.text.len - 1 and
         (std.ascii.isAlNum(handle.document.text[end_idx]) or handle.document.text[end_idx] == '_')) : (end_idx += 1)
     {}
 


### PR DESCRIPTION
This should fix the random crashes in VSCode.