### PR TITLE
Fix @This() completions, do half the work in global completions

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -262,17 +262,14 @@ fn findReturnStatement(base_node: *ast.Node) ?*ast.Node.ControlFlowExpression {
 }
 
 /// Resolves the return type of a function
-fn resolveReturnType(analysis_ctx: *AnalysisContext, fn_decl: *ast.Node.FnProto) ?*ast.Node {
+fn resolveReturnType(analysis_ctx: *AnalysisContext, fn_decl: *ast.Node.FnProto, current_container: *ast.Node) ?*ast.Node {
     if (isTypeFunction(analysis_ctx.tree, fn_decl) and fn_decl.body_node != null) {
         // If this is a type function and it only contains a single return statement that returns
         // a container declaration, we will return that declaration.
         const ret = findReturnStatement(fn_decl.body_node.?) orelse return null;
         if (ret.rhs) |rhs|
-            if (resolveTypeOfNode(analysis_ctx, rhs)) |res_rhs| switch (res_rhs.id) {
-                .ContainerDecl => {
-                    analysis_ctx.onContainer(res_rhs.cast(ast.Node.ContainerDecl).?) catch return null;
-                    return res_rhs;
-                },
+            if (resolveTypeOfNode(analysis_ctx, rhs, current_container)) |res_rhs| switch (res_rhs.id) {
+                .ContainerDecl => return res_rhs,
                 else => return null,
             };
 
@@ -280,44 +277,44 @@ fn resolveReturnType(analysis_ctx: *AnalysisContext, fn_decl: *ast.Node.FnProto)
     }
 
     return switch (fn_decl.return_type) {
-        .Explicit, .InferErrorSet => |return_type| resolveTypeOfNode(analysis_ctx, return_type),
+        .Explicit, .InferErrorSet => |return_type| resolveTypeOfNode(analysis_ctx, return_type, current_container),
         .Invalid => null,
     };
 }
 
 /// Resolves the type of a node
-pub fn resolveTypeOfNode(analysis_ctx: *AnalysisContext, node: *ast.Node) ?*ast.Node {
+pub fn resolveTypeOfNode(analysis_ctx: *AnalysisContext, node: *ast.Node, current_container: *ast.Node) ?*ast.Node {
     switch (node.id) {
         .VarDecl => {
             const vari = node.cast(ast.Node.VarDecl).?;
 
-            return resolveTypeOfNode(analysis_ctx, vari.type_node orelse vari.init_node.?) orelse null;
+            return resolveTypeOfNode(analysis_ctx, vari.type_node orelse vari.init_node.?, current_container) orelse null;
         },
         .ParamDecl => {
             const decl = node.cast(ast.Node.ParamDecl).?;
             switch (decl.param_type) {
                 .var_type, .type_expr => |var_type| {
-                    return resolveTypeOfNode(analysis_ctx, var_type) orelse null;
+                    return resolveTypeOfNode(analysis_ctx, var_type, current_container) orelse null;
                 },
                 else => {},
             }
         },
         .Identifier => {
             if (getChildOfSlice(analysis_ctx.tree, analysis_ctx.scope_nodes, analysis_ctx.tree.getNodeSource(node))) |child| {
-                return resolveTypeOfNode(analysis_ctx, child);
+                return resolveTypeOfNode(analysis_ctx, child, current_container);
             } else return null;
         },
         .ContainerField => {
             const field = node.cast(ast.Node.ContainerField).?;
-            return resolveTypeOfNode(analysis_ctx, field.type_expr orelse return null);
+            return resolveTypeOfNode(analysis_ctx, field.type_expr orelse return null, current_container);
         },
         .SuffixOp => {
             const suffix_op = node.cast(ast.Node.SuffixOp).?;
             switch (suffix_op.op) {
                 .Call, .StructInitializer => {
-                    const decl = resolveTypeOfNode(analysis_ctx, suffix_op.lhs.node) orelse return null;
+                    const decl = resolveTypeOfNode(analysis_ctx, suffix_op.lhs.node, current_container) orelse return null;
                     return switch (decl.id) {
-                        .FnProto => resolveReturnType(analysis_ctx, decl.cast(ast.Node.FnProto).?),
+                        .FnProto => resolveReturnType(analysis_ctx, decl.cast(ast.Node.FnProto).?, current_container),
                         else => decl,
                     };
                 },
@@ -333,8 +330,9 @@ pub fn resolveTypeOfNode(analysis_ctx: *AnalysisContext, node: *ast.Node) ?*ast.
                     var rhs_str = nodeToString(analysis_ctx.tree, infix_op.rhs) orelse return null;
                     // Use the analysis context temporary arena to store the rhs string.
                     rhs_str = std.mem.dupe(&analysis_ctx.arena.allocator, u8, rhs_str) catch return null;
-                    const left = resolveTypeOfNode(analysis_ctx, infix_op.lhs) orelse return null;
-                    return resolveTypeOfNode(analysis_ctx, getChild(analysis_ctx.tree, left, rhs_str) orelse return null);
+                    const left = resolveTypeOfNode(analysis_ctx, infix_op.lhs, current_container) orelse return null;
+                    const child = getChild(analysis_ctx.tree, left, rhs_str) orelse return null;
+                    return resolveTypeOfNode(analysis_ctx, child, current_container);
                 },
                 else => {},
             }
@@ -346,13 +344,13 @@ pub fn resolveTypeOfNode(analysis_ctx: *AnalysisContext, node: *ast.Node) ?*ast.
                 .PtrType => {
                     const op_token = analysis_ctx.tree.tokens.at(prefix_op.op_token);
                     switch (op_token.id) {
-                        .Asterisk => return resolveTypeOfNode(analysis_ctx, prefix_op.rhs),
+                        .Asterisk => return resolveTypeOfNode(analysis_ctx, prefix_op.rhs, current_container),
                         .LBracket, .AsteriskAsterisk => return null,
                         else => unreachable,
                     }
                 },
                 .Try => {
-                    const rhs_type = resolveTypeOfNode(analysis_ctx, prefix_op.rhs) orelse return null;
+                    const rhs_type = resolveTypeOfNode(analysis_ctx, prefix_op.rhs, current_container) orelse return null;
                     switch (rhs_type.id) {
                         .InfixOp => {
                             const infix_op = rhs_type.cast(ast.Node.InfixOp).?;
@@ -370,7 +368,7 @@ pub fn resolveTypeOfNode(analysis_ctx: *AnalysisContext, node: *ast.Node) ?*ast.
             const call_name = analysis_ctx.tree.tokenSlice(builtin_call.builtin_token);
             if (std.mem.eql(u8, call_name, "@This")) {
                 if (builtin_call.params.len != 0) return null;
-                return analysis_ctx.last_this_node;
+                return current_container;
             }
 
             if (!std.mem.eql(u8, call_name, "@import")) return null;
@@ -385,10 +383,7 @@ pub fn resolveTypeOfNode(analysis_ctx: *AnalysisContext, node: *ast.Node) ?*ast.
                 break :block null;
             };
         },
-        .ContainerDecl => {
-            analysis_ctx.onContainer(node.cast(ast.Node.ContainerDecl).?) catch return null;
-            return node;
-        },
+        .ContainerDecl => return node,
         .MultilineStringLiteral, .StringLiteral, .ErrorSetDecl, .FnProto => return node,
         else => std.debug.warn("Type resolution case not implemented; {}\n", .{node.id}),
     }
@@ -441,7 +436,7 @@ pub fn getFieldAccessTypeNode(
     tokenizer: *std.zig.Tokenizer,
     line_length: usize,
 ) ?*ast.Node {
-    var current_node = &analysis_ctx.tree.root_node.base;
+    var current_node = analysis_ctx.in_container;
 
     while (true) {
         var next = tokenizer.next();
@@ -449,7 +444,7 @@ pub fn getFieldAccessTypeNode(
             .Eof => return current_node,
             .Identifier => {
                 if (getChildOfSlice(analysis_ctx.tree, analysis_ctx.scope_nodes, tokenizer.buffer[next.start..next.end])) |child| {
-                    if (resolveTypeOfNode(analysis_ctx, child)) |node_type| {
+                    if (resolveTypeOfNode(analysis_ctx, child, current_node)) |node_type| {
                         current_node = node_type;
                     } else return null;
                 } else return null;
@@ -463,7 +458,7 @@ pub fn getFieldAccessTypeNode(
                     if (after_period.end == line_length) return current_node;
 
                     if (getChild(analysis_ctx.tree, current_node, tokenizer.buffer[after_period.start..after_period.end])) |child| {
-                        if (resolveTypeOfNode(analysis_ctx, child)) |child_type| {
+                        if (resolveTypeOfNode(analysis_ctx, child, current_node)) |child_type| {
                             current_node = child_type;
                         } else return null;
                     } else return null;
@@ -518,9 +513,16 @@ pub fn nodeToString(tree: *ast.Tree, node: *ast.Node) ?[]const u8 {
     return null;
 }
 
-pub fn declsFromIndexInternal(decls: *std.ArrayList(*ast.Node), tree: *ast.Tree, node: *ast.Node, source_index: usize) error{OutOfMemory}!void {
+pub fn declsFromIndexInternal(
+    decls: *std.ArrayList(*ast.Node),
+    tree: *ast.Tree,
+    node: *ast.Node,
+    container: **ast.Node,
+    source_index: usize,
+) error{OutOfMemory}!void {
     switch (node.id) {
         .Root, .ContainerDecl => {
+            container.* = node;
             var node_index: usize = 0;
             while (node.iterate(node_index)) |child_node| : (node_index += 1) {
                 // Skip over container fields, we can only dot access those.
@@ -530,7 +532,7 @@ pub fn declsFromIndexInternal(decls: *std.ArrayList(*ast.Node), tree: *ast.Tree,
                 // If the cursor is in a variable decls it will insert itself anyway, we don't need to take care of it.
                 if ((is_contained and child_node.id != .VarDecl) or !is_contained) try decls.append(child_node);
                 if (is_contained) {
-                    try declsFromIndexInternal(decls, tree, child_node, source_index);
+                    try declsFromIndexInternal(decls, tree, child_node, container, source_index);
                 }
             }
         },
@@ -539,45 +541,45 @@ pub fn declsFromIndexInternal(decls: *std.ArrayList(*ast.Node), tree: *ast.Tree,
 
             var param_index: usize = 0;
             while (param_index < func.params.len) : (param_index += 1)
-                try declsFromIndexInternal(decls, tree, func.params.at(param_index).*, source_index);
+                try declsFromIndexInternal(decls, tree, func.params.at(param_index).*, container, source_index);
 
             if (func.body_node) |body_node| {
                 if (!nodeContainsSourceIndex(tree, body_node, source_index)) return;
-                try declsFromIndexInternal(decls, tree, body_node, source_index);
+                try declsFromIndexInternal(decls, tree, body_node, container, source_index);
             }
         },
         .TestDecl => {
             const test_decl = node.cast(ast.Node.TestDecl).?;
             if (!nodeContainsSourceIndex(tree, test_decl.body_node, source_index)) return;
-            try declsFromIndexInternal(decls, tree, test_decl.body_node, source_index);
+            try declsFromIndexInternal(decls, tree, test_decl.body_node, container, source_index);
         },
         .Block => {
             var index: usize = 0;
             while (node.iterate(index)) |inode| : (index += 1) {
                 if (nodeComesAfterSourceIndex(tree, inode, source_index)) return;
-                try declsFromIndexInternal(decls, tree, inode, source_index);
+                try declsFromIndexInternal(decls, tree, inode, container, source_index);
             }
         },
         .Comptime => {
             const comptime_stmt = node.cast(ast.Node.Comptime).?;
             if (nodeComesAfterSourceIndex(tree, comptime_stmt.expr, source_index)) return;
-            try declsFromIndexInternal(decls, tree, comptime_stmt.expr, source_index);
+            try declsFromIndexInternal(decls, tree, comptime_stmt.expr, container, source_index);
         },
         .If => {
             const if_node = node.cast(ast.Node.If).?;
             if (nodeContainsSourceIndex(tree, if_node.body, source_index)) {
                 if (if_node.payload) |payload| {
-                    try declsFromIndexInternal(decls, tree, payload, source_index);
+                    try declsFromIndexInternal(decls, tree, payload, container, source_index);
                 }
-                return try declsFromIndexInternal(decls, tree, if_node.body, source_index);
+                return try declsFromIndexInternal(decls, tree, if_node.body, container, source_index);
             }
 
             if (if_node.@"else") |else_node| {
                 if (nodeContainsSourceIndex(tree, else_node.body, source_index)) {
                     if (else_node.payload) |payload| {
-                        try declsFromIndexInternal(decls, tree, payload, source_index);
+                        try declsFromIndexInternal(decls, tree, payload, container, source_index);
                     }
-                    return try declsFromIndexInternal(decls, tree, else_node.body, source_index);
+                    return try declsFromIndexInternal(decls, tree, else_node.body, container, source_index);
                 }
             }
         },
@@ -585,33 +587,33 @@ pub fn declsFromIndexInternal(decls: *std.ArrayList(*ast.Node), tree: *ast.Tree,
             const while_node = node.cast(ast.Node.While).?;
             if (nodeContainsSourceIndex(tree, while_node.body, source_index)) {
                 if (while_node.payload) |payload| {
-                    try declsFromIndexInternal(decls, tree, payload, source_index);
+                    try declsFromIndexInternal(decls, tree, payload, container, source_index);
                 }
-                return try declsFromIndexInternal(decls, tree, while_node.body, source_index);
+                return try declsFromIndexInternal(decls, tree, while_node.body, container, source_index);
             }
 
             if (while_node.@"else") |else_node| {
                 if (nodeContainsSourceIndex(tree, else_node.body, source_index)) {
                     if (else_node.payload) |payload| {
-                        try declsFromIndexInternal(decls, tree, payload, source_index);
+                        try declsFromIndexInternal(decls, tree, payload, container, source_index);
                     }
-                    return try declsFromIndexInternal(decls, tree, else_node.body, source_index);
+                    return try declsFromIndexInternal(decls, tree, else_node.body, container, source_index);
                 }
             }
         },
         .For => {
             const for_node = node.cast(ast.Node.For).?;
             if (nodeContainsSourceIndex(tree, for_node.body, source_index)) {
-                try declsFromIndexInternal(decls, tree, for_node.payload, source_index);
-                return try declsFromIndexInternal(decls, tree, for_node.body, source_index);
+                try declsFromIndexInternal(decls, tree, for_node.payload, container, source_index);
+                return try declsFromIndexInternal(decls, tree, for_node.body, container, source_index);
             }
 
             if (for_node.@"else") |else_node| {
                 if (nodeContainsSourceIndex(tree, else_node.body, source_index)) {
                     if (else_node.payload) |payload| {
-                        try declsFromIndexInternal(decls, tree, payload, source_index);
+                        try declsFromIndexInternal(decls, tree, payload, container, source_index);
                     }
-                    return try declsFromIndexInternal(decls, tree, else_node.body, source_index);
+                    return try declsFromIndexInternal(decls, tree, else_node.body, container, source_index);
                 }
             }
         },
@@ -622,9 +624,9 @@ pub fn declsFromIndexInternal(decls: *std.ArrayList(*ast.Node), tree: *ast.Tree,
                 const case_node = case.*.cast(ast.Node.SwitchCase).?;
                 if (nodeContainsSourceIndex(tree, case_node.expr, source_index)) {
                     if (case_node.payload) |payload| {
-                        try declsFromIndexInternal(decls, tree, payload, source_index);
+                        try declsFromIndexInternal(decls, tree, payload, container, source_index);
                     }
-                    return try declsFromIndexInternal(decls, tree, case_node.expr, source_index);
+                    return try declsFromIndexInternal(decls, tree, case_node.expr, container, source_index);
                 }
             }
         },
@@ -642,7 +644,7 @@ pub fn declsFromIndexInternal(decls: *std.ArrayList(*ast.Node), tree: *ast.Tree,
             try decls.append(node);
             if (node.cast(ast.Node.VarDecl).?.init_node) |child| {
                 if (nodeContainsSourceIndex(tree, child, source_index)) {
-                    try declsFromIndexInternal(decls, tree, child, source_index);
+                    try declsFromIndexInternal(decls, tree, child, container, source_index);
                 }
             }
         },
@@ -658,9 +660,10 @@ pub fn addChildrenNodes(decls: *std.ArrayList(*ast.Node), tree: *ast.Tree, node:
     }
 }
 
-pub fn declsFromIndex(decls: *std.ArrayList(*ast.Node), tree: *ast.Tree, source_index: usize) !void {
-    var node = &tree.root_node.base;
-    try declsFromIndexInternal(decls, tree, &tree.root_node.base, source_index);
+pub fn declsFromIndex(decls: *std.ArrayList(*ast.Node), tree: *ast.Tree, source_index: usize) !*ast.Node {
+    var result = &tree.root_node.base;
+    try declsFromIndexInternal(decls, tree, &tree.root_node.base, &result, source_index);
+    return result;
 }
 
 fn nodeContainsSourceIndex(tree: *ast.Tree, node: *ast.Node, source_index: usize) bool {

--- a/src/main.zig
+++ b/src/main.zig
@@ -245,7 +245,7 @@ fn nodeToCompletion(
                 break :block var_decl.init_node.?;
             };
 
-            if (analysis.resolveTypeOfNode(&child_analysis_context, current_container, child_node)) |resolved_node| {
+            if (analysis.resolveTypeOfNode(&child_analysis_context, child_node, current_container)) |resolved_node| {
                 // Special case for function aliases
                 // In the future it might be used to print types of values instead of their declarations
                 if (resolved_node.id == .FnProto) {


### PR DESCRIPTION
Also removes onContainer.
This has currently broken alias function completions (e.g. std.ArrayList, you need to do std.ArrayList.ArrayList and it will complete as expected)  

We were calling declsFromIndex twice unnecessarily in global completions.  

EDIT: This was simply wrong ordering on arguments, fixed.