### PR TITLE
Reworked position context to use tokenizer, works in more contexts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
         FILE=zig-cache/bin/zls
 
         if test -f "$FILE"; then
-          if zig test; then
+          if zig build test; then
             exit 0
           else
             exit 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,11 @@ jobs:
         FILE=zig-cache/bin/zls
 
         if test -f "$FILE"; then
-          exit 0
+          if zig test; then
+            exit 0
+          else
+            exit 1
+          fi
         else
           exit 1
         fi

--- a/build.zig
+++ b/build.zig
@@ -131,7 +131,15 @@ pub fn build(b: *std.build.Builder) !void {
     const run_step = b.step("run", "Run the app");
     run_step.dependOn(&run_cmd.step);
 
-    // const configure_step = std.build.Step.init("config", b.allocator, config);
     const configure_step = b.step("config", "Configure zls");
     configure_step.makeFn = config;
+
+    const test_step = b.step("test", "Run all the tests");
+    test_step.dependOn(&exe.step);
+
+    var unit_tests = b.addTest("tests/unit_tests.zig");
+    unit_tests.addPackage(.{  .name = "analysis", .path = "src/analysis.zig" });
+    unit_tests.addPackage(.{  .name = "types", .path = "src/types.zig" });
+    unit_tests.setBuildMode(.Debug);
+    test_step.dependOn(&unit_tests.step);
 }

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -810,13 +810,6 @@ fn peek(arr: *std.ArrayList(StackState)) !*StackState {
     return &arr.items[arr.items.len - 1];
 }
 
-fn tokenRange(token: std.zig.Token) SourceRange {
-    return .{
-        .start = token.loc.start,
-        .end = token.loc.end,
-    };
-}
-
 fn tokenRangeAppend(prev: SourceRange, token: std.zig.Token) SourceRange {
     return .{
         .start = prev.start,
@@ -859,13 +852,13 @@ pub fn documentPositionContext(allocator: *std.mem.Allocator, document: types.Te
         // State changes
         var curr_ctx = try peek(&stack);
         switch (tok.id) {
-            .StringLiteral, .MultilineStringLiteralLine => curr_ctx.ctx = .{ .string_literal = tokenRange(tok) },
+            .StringLiteral, .MultilineStringLiteralLine => curr_ctx.ctx = .{ .string_literal = tok.loc },
             .Identifier => switch (curr_ctx.ctx) {
-                .empty => curr_ctx.ctx = .{ .var_access = tokenRange(tok) },
+                .empty => curr_ctx.ctx = .{ .var_access = tok.loc },
                 else => {},
             },
             .Builtin => switch (curr_ctx.ctx) {
-                .empty => curr_ctx.ctx = .{ .builtin = tokenRange(tok) },
+                .empty => curr_ctx.ctx = .{ .builtin = tok.loc },
                 else => {},
             },
             .Period, .PeriodAsterisk => switch (curr_ctx.ctx) {

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -491,7 +491,7 @@ pub fn getFieldAccessTypeNode(
                                 } else if (next.id == .LParen) {
                                     paren_count += 1;
                                 }
-                            } else unreachable;
+                            } else return null;
                         } else return null;
                     },
                     else => {},
@@ -784,8 +784,7 @@ const PositionContext = union(enum) {
     other,
     empty,
 
-    // @TODO remove pub
-    pub fn range(self: PositionContext) ?SourceRange {
+    fn range(self: PositionContext) ?SourceRange {
         return switch (self) {
             .builtin => |r| r,
             .comment => null,
@@ -825,7 +824,6 @@ fn tokenRangeAppend(prev: SourceRange, token: std.zig.Token) SourceRange {
     };
 }
 
-// @TODO Test this thoroughly
 pub fn documentPositionContext(allocator: *std.mem.Allocator, document: types.TextDocument, position: types.Position) !PositionContext {
     const line = try document.getLine(@intCast(usize, position.line));
     const pos_char = @intCast(usize, position.character) + 1;
@@ -837,7 +835,6 @@ pub fn documentPositionContext(allocator: *std.mem.Allocator, document: types.Te
     var tokenizer = std.zig.Tokenizer.init(line[0..idx]);
     var stack = try std.ArrayList(StackState).initCapacity(&arena.allocator, 8);
 
-    // @TODO What happens when we don't close a string? (probably an .Eof)
     while (true) {
         const tok = tokenizer.next();
         // Early exits.

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -353,7 +353,7 @@ fn resolveBracketAccessType(
                             if (rhs == .Single) {
                                 return resolveTypeOfNode(analysis_ctx, child_pop.rhs);
                             }
-                            return makeSliceType(analysis_ctx, child_pop.rhs);
+                            return lhs;
                         },
                         else => {},
                     }

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -910,7 +910,7 @@ pub fn getImportStr(tree: *ast.Tree, source_index: usize) ?[]const u8 {
 const types = @import("types.zig");
 pub const SourceRange = std.zig.Token.Loc;
 
-const PositionContext = union(enum) {
+pub const PositionContext = union(enum) {
     builtin: SourceRange,
     comment,
     string_literal: SourceRange,
@@ -920,7 +920,7 @@ const PositionContext = union(enum) {
     other,
     empty,
 
-    fn range(self: PositionContext) ?SourceRange {
+    pub fn range(self: PositionContext) ?SourceRange {
         return switch (self) {
             .builtin => |r| r,
             .comment => null,

--- a/src/main.zig
+++ b/src/main.zig
@@ -273,6 +273,20 @@ fn nodeToCompletion(
             });
         },
         .PrefixOp => {
+            const prefix_op = node.cast(std.zig.ast.Node.PrefixOp).?;
+            switch (prefix_op.op) {
+                .ArrayType, .SliceType => {},
+                .PtrType => {
+                    if (prefix_op.rhs.cast(std.zig.ast.Node.PrefixOp)) |child_pop| {
+                        switch (child_pop.op) {
+                            .ArrayType => {},
+                            else => return,
+                        }
+                    } else return;
+                },
+                else => return,
+            }
+
             try list.append(.{
                 .label = "len",
                 .kind = .Field,

--- a/src/main.zig
+++ b/src/main.zig
@@ -389,7 +389,7 @@ fn hoverDefinitionGlobal(id: i64, pos_index: usize, handle: *DocumentStore.Handl
 fn getSymbolFieldAccess(
     analysis_ctx: *DocumentStore.AnalysisContext,
     position: types.Position,
-    line_start_idx: usize,
+    range: analysis.SourceRange,
     config: Config,
 ) !?*std.zig.ast.Node {
     const pos_index = try analysis_ctx.handle.document.positionToIndex(position);
@@ -397,12 +397,10 @@ fn getSymbolFieldAccess(
     if (name.len == 0) return null;
 
     const line = try analysis_ctx.handle.document.getLine(@intCast(usize, position.line));
-    var tokenizer = std.zig.Tokenizer.init(line[line_start_idx..]);
+    var tokenizer = std.zig.Tokenizer.init(line[range.start..range.end]);
 
-    const line_length = @ptrToInt(name.ptr) - @ptrToInt(line.ptr) + name.len - line_start_idx;
     name = try std.mem.dupe(&analysis_ctx.arena.allocator, u8, name);
-
-    if (analysis.getFieldAccessTypeNode(analysis_ctx, &tokenizer, line_length)) |container| {
+    if (analysis.getFieldAccessTypeNode(analysis_ctx, &tokenizer)) |container| {
         return analysis.getChild(analysis_ctx.tree(), container, name);
     }
     return null;
@@ -412,14 +410,14 @@ fn gotoDefinitionFieldAccess(
     id: i64,
     handle: *DocumentStore.Handle,
     position: types.Position,
-    line_start_idx: usize,
+    range: analysis.SourceRange,
     config: Config,
 ) !void {
     var arena = std.heap.ArenaAllocator.init(allocator);
     defer arena.deinit();
 
     var analysis_ctx = try document_store.analysisContext(handle, &arena, try handle.document.positionToIndex(position), config.zig_lib_path);
-    const decl = (try getSymbolFieldAccess(&analysis_ctx, position, line_start_idx, config)) orelse return try respondGeneric(id, null_result_response);
+    const decl = (try getSymbolFieldAccess(&analysis_ctx, position, range, config)) orelse return try respondGeneric(id, null_result_response);
     return try gotoDefinitionSymbol(id, &analysis_ctx, decl);
 }
 
@@ -427,14 +425,14 @@ fn hoverDefinitionFieldAccess(
     id: i64,
     handle: *DocumentStore.Handle,
     position: types.Position,
-    line_start_idx: usize,
+    range: analysis.SourceRange,
     config: Config,
 ) !void {
     var arena = std.heap.ArenaAllocator.init(allocator);
     defer arena.deinit();
 
     var analysis_ctx = try document_store.analysisContext(handle, &arena, try handle.document.positionToIndex(position), config.zig_lib_path);
-    const decl = (try getSymbolFieldAccess(&analysis_ctx, position, line_start_idx, config)) orelse return try respondGeneric(id, null_result_response);
+    const decl = (try getSymbolFieldAccess(&analysis_ctx, position, range, config)) orelse return try respondGeneric(id, null_result_response);
     return try hoverSymbol(id, &analysis_ctx, decl);
 }
 
@@ -490,7 +488,7 @@ fn completeGlobal(id: i64, pos_index: usize, handle: *DocumentStore.Handle, conf
     });
 }
 
-fn completeFieldAccess(id: i64, handle: *DocumentStore.Handle, position: types.Position, line_start_idx: usize, config: Config) !void {
+fn completeFieldAccess(id: i64, handle: *DocumentStore.Handle, position: types.Position, range: analysis.SourceRange, config: Config) !void {
     var arena = std.heap.ArenaAllocator.init(allocator);
     defer arena.deinit();
 
@@ -498,10 +496,9 @@ fn completeFieldAccess(id: i64, handle: *DocumentStore.Handle, position: types.P
     var completions = std.ArrayList(types.CompletionItem).init(&arena.allocator);
 
     const line = try handle.document.getLine(@intCast(usize, position.line));
-    var tokenizer = std.zig.Tokenizer.init(line[line_start_idx..]);
-    const line_length = line.len - line_start_idx;
+    var tokenizer = std.zig.Tokenizer.init(line[range.start..range.end]);
 
-    if (analysis.getFieldAccessTypeNode(&analysis_ctx, &tokenizer, line_length)) |node| {
+    if (analysis.getFieldAccessTypeNode(&analysis_ctx, &tokenizer)) |node| {
         try nodeToCompletion(&completions, &analysis_ctx, handle, node, config);
     }
     try send(types.Response{
@@ -549,136 +546,6 @@ const builtin_completions = block: {
         without_snippets, with_snippets,
     };
 };
-
-const PositionContext = union(enum) {
-    builtin,
-    comment,
-    string_literal,
-    field_access: usize,
-    var_access,
-    other,
-    empty,
-};
-
-const token_separators = [_]u8{
-    ' ', '\t', '(', ')', '[', ']',
-    '{', '}',  '|', '=', '!', ';',
-    ',', '?',  ':', '%', '+', '*',
-    '>', '<',  '~', '-', '/', '&',
-};
-
-fn documentPositionContext(doc: types.TextDocument, pos_index: usize) PositionContext {
-    // First extract the whole current line up to the cursor.
-    var curr_position = pos_index;
-    while (curr_position > 0) : (curr_position -= 1) {
-        if (doc.text[curr_position - 1] == '\n') break;
-    }
-
-    var line = doc.text[curr_position .. pos_index + 1];
-    // Strip any leading whitespace.
-    var skipped_ws: usize = 0;
-    while (skipped_ws < line.len and (line[skipped_ws] == ' ' or line[skipped_ws] == '\t')) : (skipped_ws += 1) {}
-    if (skipped_ws >= line.len) return .empty;
-    line = line[skipped_ws..];
-
-    // Quick exit for comment lines and multi line string literals.
-    if (line.len >= 2 and line[0] == '/' and line[1] == '/')
-        return .comment;
-    if (line.len >= 2 and line[0] == '\\' and line[1] == '\\')
-        return .string_literal;
-
-    // TODO: This does not detect if we are in a string literal over multiple lines.
-    // Find out what context we are in.
-    // Go over the current line character by character
-    // and determine the context.
-    curr_position = 0;
-    var expr_start: usize = skipped_ws;
-
-    // std.debug.warn("{}", .{curr_position});
-
-    if (pos_index != 0 and doc.text[pos_index - 1] == ')')
-        return .{ .field_access = expr_start };
-
-    var new_token = true;
-    var context: PositionContext = .other;
-    var string_pop_ctx: PositionContext = .other;
-    while (curr_position < line.len) : (curr_position += 1) {
-        const c = line[curr_position];
-        const next_char = if (curr_position < line.len - 1) line[curr_position + 1] else null;
-
-        if (context != .string_literal and c == '"') {
-            expr_start = curr_position + skipped_ws;
-            context = .string_literal;
-            continue;
-        }
-
-        if (context == .string_literal) {
-            // Skip over escaped quotes
-            if (c == '\\' and next_char != null and next_char.? == '"') {
-                curr_position += 1;
-            } else if (c == '"') {
-                context = string_pop_ctx;
-                string_pop_ctx = .other;
-                new_token = true;
-            }
-
-            continue;
-        }
-
-        if (c == '/' and next_char != null and next_char.? == '/') {
-            context = .comment;
-            break;
-        }
-
-        if (std.mem.indexOfScalar(u8, &token_separators, c) != null) {
-            expr_start = curr_position + skipped_ws + 1;
-            new_token = true;
-            context = .other;
-            continue;
-        }
-
-        if (c == '.' and (!new_token or context == .string_literal)) {
-            new_token = true;
-            if (next_char != null and next_char.? == '.') continue;
-            context = .{ .field_access = expr_start };
-            continue;
-        }
-
-        if (new_token) {
-            const access_ctx: PositionContext = if (context == .field_access)
-                .{ .field_access = expr_start }
-            else
-                .var_access;
-
-            new_token = false;
-
-            if (c == '_' or std.ascii.isAlpha(c)) {
-                context = access_ctx;
-            } else if (c == '@') {
-                // This checks for @"..." identifiers by controlling
-                // the context the string will set after it is over.
-                if (next_char != null and next_char.? == '"') {
-                    string_pop_ctx = access_ctx;
-                }
-                context = .builtin;
-            } else {
-                context = .other;
-            }
-            continue;
-        }
-
-        if (context == .field_access or context == .var_access or context == .builtin) {
-            if (c != '_' and !std.ascii.isAlNum(c)) {
-                context = .other;
-            }
-            continue;
-        }
-
-        context = .other;
-    }
-
-    return context;
-}
 
 fn loadConfig(folder_path: []const u8) ?Config {
     var folder = std.fs.cwd().openDir(folder_path, .{}) catch return null;
@@ -851,7 +718,7 @@ fn processJsonRpc(parser: *std.json.Parser, json: []const u8, config: Config) !v
         };
         if (pos.character >= 0) {
             const pos_index = try handle.document.positionToIndex(pos);
-            const pos_context = documentPositionContext(handle.document, pos_index);
+            const pos_context = try analysis.documentPositionContext(allocator, handle.document, pos);
 
             const this_config = configFromUriOr(uri, config);
             switch (pos_context) {
@@ -865,7 +732,7 @@ fn processJsonRpc(parser: *std.json.Parser, json: []const u8, config: Config) !v
                     },
                 }),
                 .var_access, .empty => try completeGlobal(id, pos_index, handle, this_config),
-                .field_access => |start_idx| try completeFieldAccess(id, handle, pos, start_idx, this_config),
+                .field_access => |range| try completeFieldAccess(id, handle, pos, range, this_config),
                 else => try respondGeneric(id, no_completions_response),
             }
         } else {
@@ -894,7 +761,7 @@ fn processJsonRpc(parser: *std.json.Parser, json: []const u8, config: Config) !v
         };
         if (pos.character >= 0) {
             const pos_index = try handle.document.positionToIndex(pos);
-            const pos_context = documentPositionContext(handle.document, pos_index);
+            const pos_context = try analysis.documentPositionContext(allocator, handle.document, pos);
 
             switch (pos_context) {
                 .var_access => try gotoDefinitionGlobal(
@@ -903,16 +770,18 @@ fn processJsonRpc(parser: *std.json.Parser, json: []const u8, config: Config) !v
                     handle,
                     configFromUriOr(uri, config),
                 ),
-                .field_access => |start_idx| try gotoDefinitionFieldAccess(
+                .field_access => |range| try gotoDefinitionFieldAccess(
                     id,
                     handle,
                     pos,
-                    start_idx,
+                    range,
                     configFromUriOr(uri, config),
                 ),
                 .string_literal => try gotoDefinitionString(id, pos_index, handle, config),
                 else => try respondGeneric(id, null_result_response),
             }
+        } else {
+            try respondGeneric(id, null_result_response);
         }
     } else if (std.mem.eql(u8, method, "textDocument/hover")) {
         const document = params.getValue("textDocument").?.Object;
@@ -930,7 +799,7 @@ fn processJsonRpc(parser: *std.json.Parser, json: []const u8, config: Config) !v
         };
         if (pos.character >= 0) {
             const pos_index = try handle.document.positionToIndex(pos);
-            const pos_context = documentPositionContext(handle.document, pos_index);
+            const pos_context = try analysis.documentPositionContext(allocator, handle.document, pos);
 
             switch (pos_context) {
                 .var_access => try hoverDefinitionGlobal(
@@ -939,15 +808,17 @@ fn processJsonRpc(parser: *std.json.Parser, json: []const u8, config: Config) !v
                     handle,
                     configFromUriOr(uri, config),
                 ),
-                .field_access => |start_idx| try hoverDefinitionFieldAccess(
+                .field_access => |range| try hoverDefinitionFieldAccess(
                     id,
                     handle,
                     pos,
-                    start_idx,
+                    range,
                     configFromUriOr(uri, config),
                 ),
                 else => try respondGeneric(id, null_result_response),
             }
+        } else {
+            try respondGeneric(id, null_result_response);
         }
     } else if (root.Object.getValue("id")) |_| {
         std.debug.warn("Method with return value not implemented: {}", .{method});

--- a/tests/unit_tests.zig
+++ b/tests/unit_tests.zig
@@ -1,0 +1,102 @@
+const analysis = @import("analysis");
+const types = @import("types");
+
+const std = @import("std");
+
+const allocator = std.testing.allocator;
+
+fn makeDocument(uri: []const u8, text: []const u8) !types.TextDocument {
+    const mem = try allocator.alloc(u8, text.len);
+    std.mem.copy(u8, mem, text);
+
+    return types.TextDocument{
+        .uri = uri,
+        .mem = mem,
+        .text = mem[0..],
+    };
+}
+
+fn freeDocument(doc: types.TextDocument) void {
+    allocator.free(doc.text);
+}
+
+fn makeUnnamedDocument(text: []const u8) !types.TextDocument {
+    return try makeDocument("test", text);
+}
+
+fn testContext(comptime line: []const u8, comptime tag: var, comptime range: ?[]const u8) !void {
+    const cursor_idx = comptime std.mem.indexOf(u8, line, "<cursor>").?;
+    const final_line = line[0..cursor_idx] ++ line[cursor_idx + "<cursor>".len ..];
+
+    const doc = try makeUnnamedDocument(final_line);
+    defer freeDocument(doc);
+
+    const ctx = try analysis.documentPositionContext(allocator, doc, types.Position{
+        .line = 0,
+        .character = @intCast(i64, cursor_idx - 1),
+    });
+
+    if (std.meta.activeTag(ctx) != tag) {
+        std.debug.warn("Expected tag {}, got {}\n", .{ tag, std.meta.activeTag(ctx) });
+        return error.DifferentTag;
+    }
+
+    if (ctx.range()) |ctx_range| {
+        if (range == null) {
+            std.debug.warn("Expected null range, got `{}`\n", .{
+                doc.text[ctx_range.start..ctx_range.end],
+            });
+        } else {
+            const range_start = comptime std.mem.indexOf(u8, final_line, range.?).?;
+            const range_end = range_start + range.?.len;
+
+            if (range_start != ctx_range.start or range_end != ctx_range.end) {
+                std.debug.warn("Expected range `{}` ({}..{}), got `{}` ({}..{})\n", .{
+                    doc.text[range_start..range_end],         range_start,     range_end,
+                    doc.text[ctx_range.start..ctx_range.end], ctx_range.start, ctx_range.end,
+                });
+                return error.DifferentRange;
+            }
+        }
+    } else if (range != null) {
+        std.debug.warn("Unexpected null range\n", .{});
+        return error.DifferentRange;
+    }
+}
+
+test "documentPositionContext" {
+    try testContext(
+        \\const this_var = id<cursor>entifier;
+    ,
+        .var_access,
+        "id",
+    );
+
+    try testContext(
+        \\if (displ.*.?.c.*[0].<cursor>@"a" == foo) {
+    ,
+        .field_access,
+        "displ.*.?.c.*[0].",
+    );
+
+    try testContext(
+        \\const arr = std.ArrayList(SomeStruct(a, b, c, d)).in<cursor>it(allocator);
+    ,
+        .field_access,
+        "std.ArrayList(SomeStruct(a, b, c, d)).in",
+    );
+
+    try testContext(
+        \\try erroringFn(the_first[arg], second[a..<cursor>]);
+    ,
+        .empty,
+        null,
+    );
+
+    try testContext(
+        \\    fn add(lhf: lself, rhs: rself) !Se<cursor> {
+    ,
+        .var_access,
+        "Se",
+    );
+}


### PR DESCRIPTION
Example of a completion that is now enabled:  
![image](https://user-images.githubusercontent.com/265903/82957542-dd605480-9fbb-11ea-829c-c069802561fb.png)

Here we see multiple functions chained with working completions, goto definition and hover support.  
I will implement the `TODO`s in `getFieldAccessTypeNode` as well as start the testsuite with tests of this function.  
