### PR TITLE
Add Neovim/Vim8 option to config wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Zig Language Server, or `zls`, is a language server for Zig. The Zig wiki states
   - [VSCode](#vscode)
   - [Sublime Text 3](#sublime-text-3)
   - [Kate](#kate)
+  - [Neovim/Vim8](#neovimvim8)
 - [Related Projects](#related-projects)
 - [License](#license)
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,21 @@ Install the `zls-vscode` extension from [here](https://github.com/zigtools/zls-v
 }
 ```
 
+### Neovim/Vim8
+
+- Install the CoC engine from [here](https://github.com/neoclide/coc.nvim).
+- Issue `:CocConfig` from within your Vim editor, and the following snippet:
+```json
+{
+   "lanuageserver": {
+       "zls" : {
+           "command": "command_or_path_to_zls",
+           "filetypes": ["zig"]
+       }
+   }
+}
+```
+
 ## Related Projects
 - [`sublime-zig-language` by @prime31](https://github.com/prime31/sublime-zig-language)
   - Supports basic language features

--- a/build.zig
+++ b/build.zig
@@ -34,7 +34,7 @@ pub fn config(step: *std.build.Step) anyerror!void {
 
     std.debug.warn("Successfully saved configuration options!\n", .{});
 
-    const editor = try zinput.askSelectOne("Which code editor do you use?", enum { VSCode, Sublime, Kate, Other });
+    const editor = try zinput.askSelectOne("Which code editor do you use?", enum { VSCode, Sublime, Kate, Neovim, Vim8, Other });
     std.debug.warn("\n", .{});
 
     switch (editor) {
@@ -75,6 +75,20 @@ pub fn config(step: *std.build.Step) anyerror!void {
                 \\            "highlightingModeRegex": "^Zig$"
                 \\        }}
                 \\    }}
+                \\}}
+            , .{});
+        },
+        .Neovim, .Vim8 => {
+            std.debug.warn(
+                \\To use ZLS in Neovim/Vim8, we recommend using CoC engine. You can get it from 'https://github.com/neoclide/coc.nvim'.
+                \\Then, simply issue cmd from Neovim/Vim8 `:CocConfig`, and add this to your CoC config:
+                \\{{
+                \\  "lanuageserver": {{
+                \\    "zls" : {{
+                \\      "command": "command_or_path_to_zls",
+                \\      "filetypes": ["zig"]
+                \\    }}
+                \\  }}
                 \\}}
             , .{});
         },
@@ -138,8 +152,8 @@ pub fn build(b: *std.build.Builder) !void {
     test_step.dependOn(&exe.step);
 
     var unit_tests = b.addTest("tests/unit_tests.zig");
-    unit_tests.addPackage(.{  .name = "analysis", .path = "src/analysis.zig" });
-    unit_tests.addPackage(.{  .name = "types", .path = "src/types.zig" });
+    unit_tests.addPackage(.{ .name = "analysis", .path = "src/analysis.zig" });
+    unit_tests.addPackage(.{ .name = "types", .path = "src/types.zig" });
     unit_tests.setBuildMode(.Debug);
     test_step.dependOn(&unit_tests.step);
 }


### PR DESCRIPTION
This commit adds minimal config option for Neovim/Vim8 editors
in the config wizard. It assumes use of CoC engine to facilitate
LSP.