### PR TITLE
Fix Sublime Text 3 install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Install the `zls-vscode` extension from [here](https://github.com/zigtools/zls-v
             "enabled": true,
             "languageId": "zig",
             "scopes": ["source.zig"],
-            "syntaxes": ["Packages/Zig/Syntaxes/Zig.tmLanguage"]
+            "syntaxes": ["Packages/Zig Language/Syntaxes/Zig.tmLanguage"]
         }
     }
 }


### PR DESCRIPTION
The name of the Zig package is "Zig Language": https://github.com/wbond/package_control_channel/blob/1d8871756d78e7088a685392b8a5ae4b67a498e6/repository/z.json#L156