### PR TITLE
offsets: fix integer overflow

### DIFF
--- a/src/offsets.zig
+++ b/src/offsets.zig
@@ -81,7 +81,7 @@ pub fn tokenRelativeLocation(tree: *std.zig.ast.Tree, start_index: usize, token:
     const token_start = token_loc.start;
     const source = tree.source[start_index..];
     var i: usize = 0;
-    while (i < token_start - start_index) {
+    while (i + start_index < token_start) {
         const c = source[i];
         if (c == '\n') {
             loc.line += 1;


### PR DESCRIPTION
```
integer overflow
/home/kenta/Desktop/zls/src/offsets.zig:84:28: 0x3085f4 in offsets.tokenRelativeLocation (zls)
    while (i < token_start - start_index) {
                           ^
/home/kenta/Desktop/zls/src/semantic_tokens.zig:63:56: 0x33c873 in semantic_tokens.Builder.add (zls)
        const delta_loc = offsets.tokenRelativeLocation(self.handle.tree, start_idx, token, self.encoding) catch return;
                                                       ^
/home/kenta/Desktop/zls/src/semantic_tokens.zig:85:24: 0x2efc4d in semantic_tokens.writeContainerField (zls)
        try builder.add(ti, tok_type, tok_mod);
                       ^
/home/kenta/Desktop/zls/src/semantic_tokens.zig:307:44: 0x2e0861 in semantic_tokens.writeNodeTokens (zls)
                    try writeContainerField(builder, arena, store, container_field, field_token_type, child_frame);
                                           ^
/home/kenta/Desktop/zls/src/semantic_tokens.zig:274:23: 0x2dfb21 in semantic_tokens.writeNodeTokens (zls)
            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, var_decl.getInitNode() });
                      ^
/home/kenta/Desktop/zls/src/semantic_tokens.zig:309:31: 0x2e08fe in semantic_tokens.writeNodeTokens (zls)
                    try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, child });
```