### PR TITLE
LSP 3.16 semantic tokens

### DIFF
--- a/src/requests.zig
+++ b/src/requests.zig
@@ -186,7 +186,7 @@ const TextDocumentIdentifierRequest = struct {
 
 pub const SaveDocument = TextDocumentIdentifierRequest;
 pub const CloseDocument = TextDocumentIdentifierRequest;
-pub const SemanticTokens = TextDocumentIdentifierRequest;
+pub const SemanticTokensFull = TextDocumentIdentifierRequest;
 
 const TextDocumentIdentifierPositionRequest = struct {
     params: struct {

--- a/src/semantic_tokens.zig
+++ b/src/semantic_tokens.zig
@@ -32,7 +32,16 @@ const TokenModifiers = packed struct {
     generic: bool = false,
 
     fn toInt(self: TokenModifiers) u32 {
-        return @as(u32, @bitCast(u4, self));
+        var res: u32 = 0;
+        if (self.definition)
+            res |= 1 << 0;
+        if (self.@"async")
+            res |= 1 << 1;
+        if (self.documentation)
+            res |= 1 << 2;
+        if (self.generic)
+            res |= 1 << 3;
+        return res;
     }
 
     inline fn set(self: *TokenModifiers, comptime field: []const u8) void {

--- a/src/types.zig
+++ b/src/types.zig
@@ -56,7 +56,7 @@ pub const ResponseParams = union(enum) {
     Location: Location,
     Hover: Hover,
     DocumentSymbols: []DocumentSymbol,
-    SemanticTokens: struct { data: []const u32 },
+    SemanticTokensFull: struct { data: []const u32 },
     TextEdits: []TextEdit,
     Locations: []Location,
     WorkspaceEdit: WorkspaceEdit,

--- a/tests/sessions.zig
+++ b/tests/sessions.zig
@@ -92,7 +92,7 @@ test "Open file, ask for semantic tokens" {
     const new_file_req = \\{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"file://./tests/test.zig","languageId":"zig","version":420,"text":"const std = @import(\"std\");"}}}
     ;
     try sendRequest(new_file_req, process);
-    const sem_toks_req = \\{"jsonrpc":"2.0","id":2,"method":"textDocument/semanticTokens","params":{"textDocument":{"uri":"file://./tests/test.zig"}}}
+    const sem_toks_req = \\{"jsonrpc":"2.0","id":2,"method":"textDocument/semanticTokens/full","params":{"textDocument":{"uri":"file://./tests/test.zig"}}}
     ;
     try sendRequest(sem_toks_req, process);
     try sendRequest(shutdown_message, process);


### PR DESCRIPTION
Closes #162.

Only tested with kak-lsp, and only implements full, not range.