### PR TITLE
Added path of zls exec to Installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ zig build
 # To configure zls:
 zig build config
 ```
+The `zls` executable will be saved to `zls\zig-cache\bin`. 
 
 ### Build Options
 


### PR DESCRIPTION
For people new to zig and language servers, the hint where the .exe will be located is helpful. It is the path that has to be added to the editors.