### PR TITLE
Remove -Dallocation_info from CI build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     - name: build
       run: |
         export PATH=./zig:$PATH
-        zig build -Dallocation_info
+        zig build
 
         FILE=zig-cache/bin/zls
 


### PR DESCRIPTION
With the removal of the debug allocator, this was also removed from the build.zig, and causes the CI to fail.