### PR TITLE
std.fmt.trim is now deprectated

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -51,7 +51,7 @@ pub fn collectDocComments(
         switch (tree.token_ids[curr_line_tok]) {
             .LineComment => continue,
             .DocComment, .ContainerDocComment => {
-                try lines.append(std.fmt.trim(tree.tokenSlice(curr_line_tok)[3..]));
+                try lines.append(std.mem.trim(u8, tree.tokenSlice(curr_line_tok)[3..], &[_]u8{ ' ', '\t', '\n', '\r' }));
             },
             else => break,
         }

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -51,7 +51,7 @@ pub fn collectDocComments(
         switch (tree.token_ids[curr_line_tok]) {
             .LineComment => continue,
             .DocComment, .ContainerDocComment => {
-                try lines.append(std.mem.trim(u8, tree.tokenSlice(curr_line_tok)[3..], &[_]u8{ ' ', '\t', '\n', '\r' }));
+                try lines.append(std.mem.trim(u8, tree.tokenSlice(curr_line_tok)[3..], &std.ascii.spaces));
             },
             else => break,
         }


### PR DESCRIPTION
`std.fmt.trim` was replaced with a `@compileError` in commit https://github.com/ziglang/zig/commit/d530e7f9c7e19b2c9d9117c3120cd75855f4023b

Now it looks like there is no easy string trim function...