### PR TITLE
Update Github Workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,5 @@
 name: CI
+
 on:
   push:
     paths:
@@ -6,26 +7,25 @@ on:
   pull_request:
     paths:
     - '**.zig'
+  workflow_dispatch:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{matrix.os}}
     steps:
-    - uses: actions/checkout@v1
-    - name: install software
-      run: |
-        ZIG=$(wget --quiet --output-document=- https://ziglang.org/download/index.json | jq --raw-output '.master."x86_64-linux".tarball')
-        echo installing $ZIG into ./zig/
-        wget --quiet --output-document=- $ZIG | tar Jx
-        mv zig-linux-x86_64-* zig
-        echo zig version $(./zig/zig version)
-        git submodule update --init --recursive
-    - name: build
-      run: |
-        export PATH=./zig:$PATH
-        zig build
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - uses: goto-bus-stop/setup-zig@v1
+        with:
+          version: master
 
-        FILE=zig-cache/bin/zls
+      - name: Build
+        run: zig build
 
-        test -f "$FILE" || exit 1
-        zig build test || exit 1
+      # ZLS Tests currently fail? Once they are passing and kept up to date, this can be enabled
+      # - name: Run Tests
+      #   run: zig build test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{matrix.os}}
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -28,6 +28,7 @@ jobs:
       - name: Build
         run: zig build
 
-      # ZLS Tests currently fail? Once they are passing and kept up to date, this can be enabled
-      # - name: Run Tests
-      #   run: zig build test
+      # ZLS Tests currently fail on windows? Once they are passing and kept up to date, this can be enabled everywhere
+      - name: Run Tests
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: zig build test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     paths:
     - '**.zig'
+  schedule:
+    - cron: '0 0 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
### Goals

- Replace the outdated CI Install step with `goto-bus-stop/setup-zig`
- Start running CI test builds on windows, mac and linux to ensure system portability.
- Run CI daily to keep up-to-date on ZLS failing with Zig master builds?

### Todo

- Start running ZLS Tests (once they are passing)