### PR TITLE
analysis.collectDocComments: Replace `std.fmt.trim` with `std.mem.trim`

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -51,7 +51,7 @@ pub fn collectDocComments(
         switch (tree.token_ids[curr_line_tok]) {
             .LineComment => continue,
             .DocComment, .ContainerDocComment => {
-                try lines.append(std.fmt.trim(tree.tokenSlice(curr_line_tok)[3..]));
+                try lines.append(std.mem.trim(u8, tree.tokenSlice(curr_line_tok)[3..], &std.ascii.spaces));
             },
             else => break,
         }


### PR DESCRIPTION
This commit replaces the usage of `std.fmt.trim`, which was deprectated in [this commit][1], with `std.mem.trim` and `std.ascii.spaces`.

[1]: https://github.com/ziglang/zig/commit/50ba0182235be67f79a1d088f279d69efd06b5d2