### PR TITLE
update setevalbranchquota: usize -> u32 for master

### DIFF
--- a/src/data/master.zig
+++ b/src/data/master.zig
@@ -893,8 +893,8 @@ pub const builtins = [_]Builtin{
     },
     .{
         .name = "@setEvalBranchQuota",
-        .signature = "@setEvalBranchQuota(new_quota: usize)",
-        .snippet = "@setEvalBranchQuota(${1:new_quota: usize})",
+        .signature = "@setEvalBranchQuota(new_quota: u32)",
+        .snippet = "@setEvalBranchQuota(${1:new_quota: u32})",
         .documentation =
         \\ Changes the maximum number of backwards branches that compile-time code execution can use before giving up and making a compile error.
         \\ If the new_quota is smaller than the default quota (1000) or a previously explicitly set quota, it is ignored.


### PR DESCRIPTION
This was a difference from 0.7.0 to 0.71.
Release notes: `stage1: Resolve @setEvalBranchQuota to u32, not usize.`