### PR TITLE
Fixed string printing with {s} format specifier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 # Zig magic stuff
 /zig-cache
+debug
+release

--- a/build.zig
+++ b/build.zig
@@ -23,7 +23,7 @@ pub fn config(step: *std.build.Step) anyerror!void {
         defer allocator.free(env_path);
 
         const exe_extension = @as(std.zig.CrossTarget, .{}).exeFileExt();
-        const zig_exe = try std.fmt.allocPrint(allocator, "zig{}", .{exe_extension});
+        const zig_exe = try std.fmt.allocPrint(allocator, "zig{s}", .{exe_extension});
         defer allocator.free(zig_exe);
 
         var it = std.mem.tokenize(env_path, &[_]u8{std.fs.path.delimiter});
@@ -51,7 +51,7 @@ pub fn config(step: *std.build.Step) anyerror!void {
         std.debug.print("Could not find 'zig' in PATH\n", .{});
         zig_exe_path = try zinput.askString(builder.allocator, "What is the path to the 'zig' executable you would like to use?", 512);
     } else {
-        std.debug.print("Found zig executable '{}'\n", .{zig_exe_path.?});
+        std.debug.print("Found zig executable '{s}'\n", .{zig_exe_path.?});
     }
     const snippets = try zinput.askBool("Do you want to enable snippets?");
     const style = try zinput.askBool("Do you want to enable style warnings?");

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -813,7 +813,7 @@ pub fn resolveTypeOfNodeInternal(
 
             const import_str = handle.tree.tokenSlice(import_param.castTag(.StringLiteral).?.token);
             const new_handle = (store.resolveImport(handle, import_str[1 .. import_str.len - 1]) catch |err| {
-                log.debug("Error {} while processing import {}", .{ err, import_str });
+                log.debug("Error {} while processing import {s}", .{ err, import_str });
                 return null;
             }) orelse return null;
 
@@ -2005,8 +2005,8 @@ pub const DocumentScope = struct {
             var idx: usize = 0;
             while (decl_it.next()) |name_decl| : (idx += 1) {
                 if (idx != 0) log.debug(", ", .{});
-                log.debug("{}", .{name_decl.key});
             }
+                log.debug("{s}", .{name_decl.key});
             log.debug("\n--------------------------\n", .{});
         }
     }

--- a/src/document_store.zig
+++ b/src/document_store.zig
@@ -107,7 +107,7 @@ fn loadPackages(context: LoadPackagesContext) !void {
     switch (zig_run_result.term) {
         .Exited => |exit_code| {
             if (exit_code == 0) {
-                log.debug("Finished zig run for build file {}", .{build_file.uri});
+                log.debug("Finished zig run for build file {s}", .{build_file.uri});
 
                 for (build_file.packages.items) |old_pkg| {
                     allocator.free(old_pkg.name);
@@ -145,7 +145,7 @@ fn loadPackages(context: LoadPackagesContext) !void {
 /// This function asserts the document is not open yet and takes ownership
 /// of the uri and text passed in.
 fn newDocument(self: *DocumentStore, uri: []const u8, text: []u8) anyerror!*Handle {
-    log.debug("Opened document: {}", .{uri});
+    log.debug("Opened document: {s}", .{uri});
 
     var handle = try self.allocator.create(Handle);
     errdefer self.allocator.destroy(handle);
@@ -195,7 +195,7 @@ fn newDocument(self: *DocumentStore, uri: []const u8, text: []u8) anyerror!*Hand
             .build_runner_path = self.build_runner_path,
             .zig_exe_path = self.zig_exe_path.?,
         }) catch |err| {
-            log.debug("Failed to load packages of build file {} (error: {})", .{ build_file.uri, err });
+            log.debug("Failed to load packages of build file {s} (error: {})", .{ build_file.uri, err });
         };
     } else if (self.zig_exe_path != null and !in_std) associate_build_file: {
         // Look into build files to see if we already have one that fits
@@ -203,7 +203,7 @@ fn newDocument(self: *DocumentStore, uri: []const u8, text: []u8) anyerror!*Hand
             const build_file_base_uri = build_file.uri[0 .. std.mem.lastIndexOfScalar(u8, build_file.uri, '/').? + 1];
 
             if (std.mem.startsWith(u8, uri, build_file_base_uri)) {
-                log.debug("Found an associated build file: {}", .{build_file.uri});
+                log.debug("Found an associated build file: {s}", .{build_file.uri});
                 build_file.refs += 1;
                 handle.associated_build_file = build_file;
                 break :associate_build_file;
@@ -255,7 +255,7 @@ fn newDocument(self: *DocumentStore, uri: []const u8, text: []u8) anyerror!*Hand
 
 pub fn openDocument(self: *DocumentStore, uri: []const u8, text: []const u8) !*Handle {
     if (self.handles.getEntry(uri)) |entry| {
-        log.debug("Document already open: {}, incrementing count", .{uri});
+        log.debug("Document already open: {s}, incrementing count", .{uri});
         entry.value.count += 1;
         if (entry.value.is_build_file) |build_file| {
             build_file.refs += 1;
@@ -275,7 +275,7 @@ pub fn openDocument(self: *DocumentStore, uri: []const u8, text: []const u8) !*H
 fn decrementBuildFileRefs(self: *DocumentStore, build_file: *BuildFile) void {
     build_file.refs -= 1;
     if (build_file.refs == 0) {
-        log.debug("Freeing build file {}", .{build_file.uri});
+        log.debug("Freeing build file {s}", .{build_file.uri});
         for (build_file.packages.items) |pkg| {
             self.allocator.free(pkg.name);
             self.allocator.free(pkg.uri);
@@ -301,7 +301,7 @@ fn decrementCount(self: *DocumentStore, uri: []const u8) void {
         if (entry.value.count > 0)
             return;
 
-        log.debug("Freeing document: {}", .{uri});
+        log.debug("Freeing document: {s}", .{uri});
 
         if (entry.value.associated_build_file) |build_file| {
             self.decrementBuildFileRefs(build_file);
@@ -338,7 +338,7 @@ pub fn getHandle(self: *DocumentStore, uri: []const u8) ?*Handle {
 
 // Check if the document text is now sane, move it to sane_text if so.
 fn refreshDocument(self: *DocumentStore, handle: *Handle, zig_lib_path: ?[]const u8) !void {
-    log.debug("New text for document {}", .{handle.uri()});
+    log.debug("New text for document {s}", .{handle.uri()});
     handle.tree.deinit();
     handle.tree = try std.zig.parse(self.allocator, handle.document.text);
 
@@ -384,7 +384,7 @@ fn refreshDocument(self: *DocumentStore, handle: *Handle, zig_lib_path: ?[]const
     while (idx < still_exist.len) : (idx += 1) {
         if (still_exist[idx]) continue;
 
-        log.debug("Import removed: {}", .{handle.import_uris.items[idx - offset]});
+        log.debug("Import removed: {s}", .{handle.import_uris.items[idx - offset]});
         const uri = handle.import_uris.orderedRemove(idx - offset);
         offset += 1;
 
@@ -401,7 +401,7 @@ pub fn applySave(self: *DocumentStore, handle: *Handle) !void {
             .build_runner_path = self.build_runner_path,
             .zig_exe_path = self.zig_exe_path.?,
         }) catch |err| {
-            log.debug("Failed to load packages of build file {} (error: {})", .{ build_file.uri, err });
+            log.debug("Failed to load packages of build file {s} (error: {})", .{ build_file.uri, err });
         };
     }
 }
@@ -549,7 +549,7 @@ pub fn resolveImport(self: *DocumentStore, handle: *Handle, import_str: []const 
     defer allocator.free(file_path);
 
     var file = std.fs.cwd().openFile(file_path, .{}) catch {
-        log.debug("Cannot open import file {}", .{file_path});
+        log.debug("Cannot open import file {s}", .{file_path});
         return null;
     };
 
@@ -561,7 +561,7 @@ pub fn resolveImport(self: *DocumentStore, handle: *Handle, import_str: []const 
         errdefer allocator.free(file_contents);
 
         file.reader().readNoEof(file_contents) catch {
-            log.debug("Could not read from file {}", .{file_path});
+            log.debug("Could not read from file {s}", .{file_path});
             return null;
         };
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -43,7 +43,7 @@ pub fn log(
     var arena = std.heap.ArenaAllocator.init(allocator);
     defer arena.deinit();
 
-    var message = std.fmt.allocPrint(&arena.allocator, "[{}-{}] " ++ format, .{ @tagName(message_level), @tagName(scope) } ++ args) catch |err| {
+    var message = std.fmt.allocPrint(&arena.allocator, "[{s}-{s}] " ++ format, .{ @tagName(message_level), @tagName(scope) } ++ args) catch |err| {
         std.debug.print("Failed to allocPrint message.", .{});
         return;
     };
@@ -159,7 +159,7 @@ fn respondGeneric(id: types.RequestId, response: []const u8) !void {
     try stdout_stream.print("Content-Length: {}\r\n\r\n" ++ json_fmt, .{response.len + id_len + json_fmt.len - 1});
     switch (id) {
         .Integer => |int| try stdout_stream.print("{}", .{int}),
-        .String => |str| try stdout_stream.print("\"{}\"", .{str}),
+        .String => |str| try stdout_stream.print("\"{s}\"", .{str}),
         else => unreachable,
     }
 
@@ -596,9 +596,9 @@ fn hoverSymbol(id: types.RequestId, arena: *std.heap.ArenaAllocator, decl_handle
             };
 
             break :ast_node if (hover_kind == .Markdown)
-                try std.fmt.allocPrint(&arena.allocator, "```zig\n{}\n```\n{}", .{ signature_str, doc_str })
+                try std.fmt.allocPrint(&arena.allocator, "```zig\n{s}\n```\n{s}", .{ signature_str, doc_str })
             else
-                try std.fmt.allocPrint(&arena.allocator, "{}\n{}", .{ signature_str, doc_str });
+                try std.fmt.allocPrint(&arena.allocator, "{s}\n{s}", .{ signature_str, doc_str });
         },
         .param_decl => |param| param_decl: {
             const doc_str = if (param.doc_comments) |doc_comments|
@@ -608,28 +608,28 @@ fn hoverSymbol(id: types.RequestId, arena: *std.heap.ArenaAllocator, decl_handle
 
             const signature_str = handle.tree.source[handle.tree.token_locs[param.firstToken()].start..handle.tree.token_locs[param.lastToken()].end];
             break :param_decl if (hover_kind == .Markdown)
-                try std.fmt.allocPrint(&arena.allocator, "```zig\n{}\n```\n{}", .{ signature_str, doc_str })
+                try std.fmt.allocPrint(&arena.allocator, "```zig\n{s}\n```\n{s}", .{ signature_str, doc_str })
             else
-                try std.fmt.allocPrint(&arena.allocator, "{}\n{}", .{ signature_str, doc_str });
+                try std.fmt.allocPrint(&arena.allocator, "{s}\n{s}", .{ signature_str, doc_str });
         },
         .pointer_payload => |payload| if (hover_kind == .Markdown)
-            try std.fmt.allocPrint(&arena.allocator, "```zig\n{}\n```", .{handle.tree.tokenSlice(payload.node.value_symbol.firstToken())})
+            try std.fmt.allocPrint(&arena.allocator, "```zig\n{s}\n```", .{handle.tree.tokenSlice(payload.node.value_symbol.firstToken())})
         else
-            try std.fmt.allocPrint(&arena.allocator, "{}", .{handle.tree.tokenSlice(payload.node.value_symbol.firstToken())}),
+            try std.fmt.allocPrint(&arena.allocator, "{s}", .{handle.tree.tokenSlice(payload.node.value_symbol.firstToken())}),
         .array_payload => |payload| if (hover_kind == .Markdown)
-            try std.fmt.allocPrint(&arena.allocator, "```zig\n{}\n```", .{handle.tree.tokenSlice(payload.identifier.firstToken())})
+            try std.fmt.allocPrint(&arena.allocator, "```zig\n{s}\n```", .{handle.tree.tokenSlice(payload.identifier.firstToken())})
         else
-            try std.fmt.allocPrint(&arena.allocator, "{}", .{handle.tree.tokenSlice(payload.identifier.firstToken())}),
+            try std.fmt.allocPrint(&arena.allocator, "{s}", .{handle.tree.tokenSlice(payload.identifier.firstToken())}),
         .switch_payload => |payload| if (hover_kind == .Markdown)
-            try std.fmt.allocPrint(&arena.allocator, "```zig\n{}\n```", .{handle.tree.tokenSlice(payload.node.value_symbol.firstToken())})
+            try std.fmt.allocPrint(&arena.allocator, "```zig\n{s}\n```", .{handle.tree.tokenSlice(payload.node.value_symbol.firstToken())})
         else
-            try std.fmt.allocPrint(&arena.allocator, "{}", .{handle.tree.tokenSlice(payload.node.value_symbol.firstToken())}),
+            try std.fmt.allocPrint(&arena.allocator, "{s}", .{handle.tree.tokenSlice(payload.node.value_symbol.firstToken())}),
         .label_decl => |label_decl| block: {
             const source = handle.tree.source[handle.tree.token_locs[label_decl.firstToken()].start..handle.tree.token_locs[label_decl.lastToken()].end];
             break :block if (hover_kind == .Markdown)
-                try std.fmt.allocPrint(&arena.allocator, "```zig\n{}\n```", .{source})
+                try std.fmt.allocPrint(&arena.allocator, "```zig\n{s}\n```", .{source})
             else
-                try std.fmt.allocPrint(&arena.allocator, "```{}```", .{source});
+                try std.fmt.allocPrint(&arena.allocator, "```{s}```", .{source});
         },
     };
 
@@ -682,7 +682,7 @@ fn hoverDefinitionBuiltin(arena: *std.heap.ArenaAllocator, id: types.RequestId, 
                 .id = id,
                 .result = .{
                     .Hover = .{
-                        .contents = .{ .value = try std.fmt.allocPrint(&arena.allocator, "```zig\n{}\n```\n{}", .{ builtin.signature, builtin.documentation }) },
+                        .contents = .{ .value = try std.fmt.allocPrint(&arena.allocator, "```zig\n{s}\n```\n{s}", .{ builtin.signature, builtin.documentation }) },
                     },
                 },
             });
@@ -1155,7 +1155,7 @@ fn initializeHandler(arena: *std.heap.ArenaAllocator, id: types.RequestId, req: 
 
     logger.notice("zls initialized", .{});
     logger.info("{}", .{client_capabilities});
-    logger.notice("Using offset encoding: {}", .{std.meta.tagName(offset_encoding)});
+    logger.notice("Using offset encoding: {s}", .{std.meta.tagName(offset_encoding)});
 }
 
 var keep_running = true;
@@ -1176,7 +1176,7 @@ fn openDocumentHandler(arena: *std.heap.ArenaAllocator, id: types.RequestId, req
 
 fn changeDocumentHandler(arena: *std.heap.ArenaAllocator, id: types.RequestId, req: requests.ChangeDocument, config: Config) !void {
     const handle = document_store.getHandle(req.params.textDocument.uri) orelse {
-        logger.debug("Trying to change non existent document {}", .{req.params.textDocument.uri});
+        logger.debug("Trying to change non existent document {s}", .{req.params.textDocument.uri});
         return;
     };
 
@@ -1186,7 +1186,7 @@ fn changeDocumentHandler(arena: *std.heap.ArenaAllocator, id: types.RequestId, r
 
 fn saveDocumentHandler(arena: *std.heap.ArenaAllocator, id: types.RequestId, req: requests.SaveDocument, config: Config) error{OutOfMemory}!void {
     const handle = document_store.getHandle(req.params.textDocument.uri) orelse {
-        logger.warn("Trying to save non existent document {}", .{req.params.textDocument.uri});
+        logger.warn("Trying to save non existent document {s}", .{req.params.textDocument.uri});
         return;
     };
     try document_store.applySave(handle);
@@ -1199,7 +1199,7 @@ fn closeDocumentHandler(arena: *std.heap.ArenaAllocator, id: types.RequestId, re
 fn semanticTokensFullHandler(arena: *std.heap.ArenaAllocator, id: types.RequestId, req: requests.SemanticTokensFull, config: Config) (error{OutOfMemory} || std.fs.File.WriteError)!void {
     if (config.enable_semantic_tokens) {
         const handle = document_store.getHandle(req.params.textDocument.uri) orelse {
-            logger.warn("Trying to get semantic tokens of non existent document {}", .{req.params.textDocument.uri});
+            logger.warn("Trying to get semantic tokens of non existent document {s}", .{req.params.textDocument.uri});
             return try respondGeneric(id, no_semantic_tokens_response);
         };
 
@@ -1215,7 +1215,7 @@ fn semanticTokensFullHandler(arena: *std.heap.ArenaAllocator, id: types.RequestI
 
 fn completionHandler(arena: *std.heap.ArenaAllocator, id: types.RequestId, req: requests.Completion, config: Config) !void {
     const handle = document_store.getHandle(req.params.textDocument.uri) orelse {
-        logger.warn("Trying to complete in non existent document {}", .{req.params.textDocument.uri});
+        logger.warn("Trying to complete in non existent document {s}", .{req.params.textDocument.uri});
         return try respondGeneric(id, no_completions_response);
     };
 
@@ -1263,7 +1263,7 @@ fn signatureHelperHandler(arena: *std.heap.ArenaAllocator, id: types.RequestId, 
 
 fn gotoHandler(arena: *std.heap.ArenaAllocator, id: types.RequestId, req: requests.GotoDefinition, config: Config, resolve_alias: bool) !void {
     const handle = document_store.getHandle(req.params.textDocument.uri) orelse {
-        logger.warn("Trying to go to definition in non existent document {}", .{req.params.textDocument.uri});
+        logger.warn("Trying to go to definition in non existent document {s}", .{req.params.textDocument.uri});
         return try respondGeneric(id, null_result_response);
     };
 
@@ -1293,7 +1293,7 @@ fn gotoDeclarationHandler(arena: *std.heap.ArenaAllocator, id: types.RequestId, 
 
 fn hoverHandler(arena: *std.heap.ArenaAllocator, id: types.RequestId, req: requests.Hover, config: Config) !void {
     const handle = document_store.getHandle(req.params.textDocument.uri) orelse {
-        logger.warn("Trying to get hover in non existent document {}", .{req.params.textDocument.uri});
+        logger.warn("Trying to get hover in non existent document {s}", .{req.params.textDocument.uri});
         return try respondGeneric(id, null_result_response);
     };
 
@@ -1315,7 +1315,7 @@ fn hoverHandler(arena: *std.heap.ArenaAllocator, id: types.RequestId, req: reque
 
 fn documentSymbolsHandler(arena: *std.heap.ArenaAllocator, id: types.RequestId, req: requests.DocumentSymbols, config: Config) !void {
     const handle = document_store.getHandle(req.params.textDocument.uri) orelse {
-        logger.warn("Trying to get document symbols in non existent document {}", .{req.params.textDocument.uri});
+        logger.warn("Trying to get document symbols in non existent document {s}", .{req.params.textDocument.uri});
         return try respondGeneric(id, null_result_response);
     };
     try documentSymbol(arena, id, handle);
@@ -1324,7 +1324,7 @@ fn documentSymbolsHandler(arena: *std.heap.ArenaAllocator, id: types.RequestId, 
 fn formattingHandler(arena: *std.heap.ArenaAllocator, id: types.RequestId, req: requests.Formatting, config: Config) !void {
     if (config.zig_exe_path) |zig_exe_path| {
         const handle = document_store.getHandle(req.params.textDocument.uri) orelse {
-            logger.warn("Trying to got to definition in non existent document {}", .{req.params.textDocument.uri});
+            logger.warn("Trying to got to definition in non existent document {s}", .{req.params.textDocument.uri});
             return try respondGeneric(id, null_result_response);
         };
 
@@ -1366,7 +1366,7 @@ fn formattingHandler(arena: *std.heap.ArenaAllocator, id: types.RequestId, req: 
 
 fn renameHandler(arena: *std.heap.ArenaAllocator, id: types.RequestId, req: requests.Rename, config: Config) !void {
     const handle = document_store.getHandle(req.params.textDocument.uri) orelse {
-        logger.warn("Trying to rename in non existent document {}", .{req.params.textDocument.uri});
+        logger.warn("Trying to rename in non existent document {s}", .{req.params.textDocument.uri});
         return try respondGeneric(id, null_result_response);
     };
 
@@ -1387,7 +1387,7 @@ fn renameHandler(arena: *std.heap.ArenaAllocator, id: types.RequestId, req: requ
 
 fn referencesHandler(arena: *std.heap.ArenaAllocator, id: types.RequestId, req: requests.References, config: Config) !void {
     const handle = document_store.getHandle(req.params.textDocument.uri) orelse {
-        logger.warn("Trying to get references in non existent document {}", .{req.params.textDocument.uri});
+        logger.warn("Trying to get references in non existent document {s}", .{req.params.textDocument.uri});
         return try respondGeneric(id, null_result_response);
     };
 
@@ -1429,7 +1429,7 @@ fn processJsonRpc(arena: *std.heap.ArenaAllocator, parser: *std.json.Parser, jso
     const start_time = std.time.milliTimestamp();
     defer {
         const end_time = std.time.milliTimestamp();
-        logger.debug("Took {}ms to process method {}", .{ end_time - start_time, method });
+        logger.debug("Took {}ms to process method {s}", .{ end_time - start_time, method });
     }
 
     const method_map = .{
@@ -1469,7 +1469,7 @@ fn processJsonRpc(arena: *std.heap.ArenaAllocator, parser: *std.json.Parser, jso
                     done = extractErr(method_info[2](arena, id, request_obj, config));
                 } else |err| {
                     if (err == error.MalformedJson) {
-                        logger.warn("Could not create request type {} from JSON {}", .{ @typeName(ReqT), json });
+                        logger.warn("Could not create request type {s} from JSON {s}", .{ @typeName(ReqT), json });
                     }
                     done = err;
                 }
@@ -1508,7 +1508,7 @@ fn processJsonRpc(arena: *std.heap.ArenaAllocator, parser: *std.json.Parser, jso
     if (tree.root.Object.get("id")) |_| {
         return try respondGeneric(id, not_implemented_response);
     }
-    logger.debug("Method without return value not implemented: {}", .{method});
+    logger.debug("Method without return value not implemented: {s}", .{method});
 }
 
 var gpa_state = std.heap.GeneralPurposeAllocator(.{}){};
@@ -1528,7 +1528,7 @@ pub fn main() anyerror!void {
             actual_log_level = .debug;
             std.debug.print("Enabled debug logging", .{});
         } else {
-            std.debug.print("Unrecognized argument {}", .{arg});
+            std.debug.print("Unrecognized argument {s}", .{arg});
             std.os.exit(1);
         }
     }
@@ -1587,7 +1587,7 @@ pub fn main() anyerror!void {
                     break :find_zig;
             }
 
-            logger.debug("zig path `{}` is not absolute, will look in path", .{exe_path});
+            logger.debug("zig path `{s}` is not absolute, will look in path", .{exe_path});
         }
 
         const env_path = std.process.getEnvVarOwned(allocator, "PATH") catch |err| switch (err) {
@@ -1600,7 +1600,7 @@ pub fn main() anyerror!void {
         defer allocator.free(env_path);
 
         const exe_extension = @as(std.zig.CrossTarget, .{}).exeFileExt();
-        const zig_exe = try std.fmt.allocPrint(allocator, "zig{}", .{exe_extension});
+        const zig_exe = try std.fmt.allocPrint(allocator, "zig{s}", .{exe_extension});
         defer allocator.free(zig_exe);
 
         var it = std.mem.tokenize(env_path, &[_]u8{std.fs.path.delimiter});
@@ -1613,14 +1613,14 @@ pub fn main() anyerror!void {
 
             var buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
             zig_exe_path = try std.mem.dupe(allocator, u8, std.os.realpath(full_path, &buf) catch continue);
-            logger.info("Found zig in PATH: {}", .{zig_exe_path});
+            logger.info("Found zig in PATH: {s}", .{zig_exe_path});
             break :find_zig;
         }
     }
 
     if (zig_exe_path) |exe_path| {
         config.zig_exe_path = exe_path;
-        logger.info("Using zig executable {}", .{exe_path});
+        logger.info("Using zig executable {s}", .{exe_path});
         if (config.zig_lib_path == null) find_lib_path: {
             // Use `zig env` to find the lib path
             const zig_env_result = try std.ChildProcess.exec(.{
@@ -1656,7 +1656,7 @@ pub fn main() anyerror!void {
                         // We know this is allocated with `allocator`, we just steal it!
                         config.zig_lib_path = json_env.lib_dir.?;
                         json_env.lib_dir = null;
-                        logger.notice("Using zig lib path '{}'", .{config.zig_lib_path});
+                        logger.notice("Using zig lib path '{s}'", .{config.zig_lib_path});
                     }
                 },
                 else => logger.alert("zig env invocation failed", .{}),
@@ -1691,7 +1691,7 @@ pub fn main() anyerror!void {
 
     while (keep_running) {
         const headers = readRequestHeader(&arena.allocator, reader) catch |err| {
-            logger.crit("{}; exiting!", .{@errorName(err)});
+            logger.crit("{s}; exiting!", .{@errorName(err)});
             return;
         };
         const buf = try arena.allocator.alloc(u8, headers.content_length);

--- a/src/special/build_runner.zig
+++ b/src/special/build_runner.zig
@@ -51,7 +51,7 @@ fn processStep(stdout_stream: anytype, step: *std.build.Step) anyerror!void {
 }
 
 fn processPackage(out_stream: anytype, pkg: Pkg) anyerror!void {
-    try out_stream.print("{}\x00{}\n", .{ pkg.name, pkg.path });
+    try out_stream.print("{s}\x00{s}\n", .{ pkg.name, pkg.path });
     if (pkg.dependencies) |dependencies| {
         for (dependencies) |dep| {
             try processPackage(out_stream, dep);

--- a/tests/sessions.zig
+++ b/tests/sessions.zig
@@ -39,13 +39,13 @@ fn readResponses(process: *std.ChildProcess, expected_responses: anytype) !void 
                 seen[idx] = true;
             }
         }
-        std.debug.print("GOT MESSAGE: {}\n", .{stdout_bytes});
+        std.debug.print("GOT MESSAGE: {s}\n", .{stdout_bytes});
     }
 
     comptime var idx = 0;
     inline while (idx < expected_responses.len) : (idx += 1) {
         if (!seen[idx]) {
-            std.debug.print("Response `{}` not received.", .{expected_responses[idx]});
+            std.debug.print("Response `{s}` not received.", .{expected_responses[idx]});
             return error.ExpectedResponse;
         }
     }

--- a/tests/unit_tests.zig
+++ b/tests/unit_tests.zig
@@ -43,7 +43,7 @@ fn testContext(comptime line: []const u8, comptime tag: anytype, comptime range:
 
     if (ctx.range()) |ctx_range| {
         if (range == null) {
-            std.debug.warn("Expected null range, got `{}`\n", .{
+            std.debug.warn("Expected null range, got `{s}`\n", .{
                 doc.text[ctx_range.start..ctx_range.end],
             });
         } else {
@@ -51,7 +51,7 @@ fn testContext(comptime line: []const u8, comptime tag: anytype, comptime range:
             const range_end = range_start + range.?.len;
 
             if (range_start != ctx_range.start or range_end != ctx_range.end) {
-                std.debug.warn("Expected range `{}` ({}..{}), got `{}` ({}..{})\n", .{
+                std.debug.warn("Expected range `{s}` ({}..{}), got `{s}` ({}..{})\n", .{
                     doc.text[range_start..range_end],         range_start,     range_end,
                     doc.text[ctx_range.start..ctx_range.end], ctx_range.start, ctx_range.end,
                 });


### PR DESCRIPTION
Fixed string printing with `{s}` format specifier.

This fixes #213 and also before this change tooltips show the raw byte output instead of string formatting.