### PR TITLE
Add instructions for LanguageClient-neovim

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,16 @@ set completeopt=menuone,noinsert,noselect
 let g:completion_enable_auto_popup = 1
 ```
 
+#### LanguageClient-neovim
+
+- Install the LanguageClient-neovim from [here](https://github.com/autozimu/LanguageClient-neovim)
+- Edit your neovim configuration and add `zls` for zig filetypes:
+
+```vim
+let g:LanguageClient_serverCommands = {
+       \ 'zig': ['~/code/zls/zig-cache/bin/zls'],
+       \ }
+```
 
 ### Emacs
 


### PR DESCRIPTION
# Description
[LanguageClient-neovim](https://github.com/autozimu/LanguageClient-neovim) is a popular language client for neovim, it is stable and works well.

I added instructions for how to configure `zls` on LanguageClient-neovim.

Working locally:
<img width="1690" alt="Screen Shot 2021-01-30 at 14 42 58" src="https://user-images.githubusercontent.com/8126891/106363795-72fd7200-6309-11eb-86a1-17537289556b.png">
 