### PR TITLE
Update inline functions to use the new syntax

### DIFF
--- a/src/requests.zig
+++ b/src/requests.zig
@@ -23,7 +23,7 @@ fn Transform(comptime Original: type, comptime transform_fn: anytype) type {
     };
 }
 
-inline fn fromDynamicTreeInternal(arena: *std.heap.ArenaAllocator, value: std.json.Value, out: anytype) error{ MalformedJson, OutOfMemory }!void {
+fn fromDynamicTreeInternal(arena: *std.heap.ArenaAllocator, value: std.json.Value, out: anytype) callconv(.Inline) error{ MalformedJson, OutOfMemory }!void {
     const T = comptime std.meta.Child(@TypeOf(out));
 
     if (comptime std.meta.trait.is(.Struct)(T)) {

--- a/src/semantic_tokens.zig
+++ b/src/semantic_tokens.zig
@@ -43,7 +43,7 @@ pub const TokenModifiers = packed struct {
         return res;
     }
 
-    inline fn set(self: *TokenModifiers, comptime field: []const u8) void {
+    fn set(self: *TokenModifiers, comptime field: []const u8) callconv(.Inline) void {
         @field(self, field) = true;
     }
 };
@@ -88,11 +88,11 @@ const Builder = struct {
     }
 };
 
-inline fn writeToken(builder: *Builder, token_idx: ?ast.TokenIndex, tok_type: TokenType) !void {
+fn writeToken(builder: *Builder, token_idx: ?ast.TokenIndex, tok_type: TokenType) callconv(.Inline) !void {
     return try writeTokenMod(builder, token_idx, tok_type, .{});
 }
 
-inline fn writeTokenMod(builder: *Builder, token_idx: ?ast.TokenIndex, tok_type: TokenType, tok_mod: TokenModifiers) !void {
+fn writeTokenMod(builder: *Builder, token_idx: ?ast.TokenIndex, tok_type: TokenType, tok_mod: TokenModifiers) callconv(.Inline) !void {
     if (token_idx) |ti| {
         try builder.add(ti, tok_type, tok_mod);
     }


### PR DESCRIPTION
inline fn() void -> fn () callconv(.Inline) void