### PR TITLE
Update to Zig std's new AST format

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The following options are currently available.
 | `build_runner_cache_path` | `?[]const u8` | `null` | Path to a directroy that will be used as zig's cache when running `zig run build_runner.zig ...`. `null` is equivalent to `${KnownFloders.Cache}/zls` |
 | `enable_semantic_tokens` | `bool` | `true` | Enables semantic token support when the client also supports it. |
 | `operator_completions` | `bool` | `true` | Enables `*` and `?` operators in completion lists. |
+| `skip_std_references` | `bool` | `false` | When true, skips searching for references in std. Improves lookup speed for functions in user's code. Renaming and go-to-definition will continue to work as is.
 
 ## Features
 

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -1785,8 +1785,19 @@ fn getDocumentSymbolsInternal(allocator: *std.mem.Allocator, tree: ast.Tree, nod
     if (name.len == 0)
         return;
 
-    const start_loc = context.prev_loc.add(try offsets.tokenRelativeLocation(tree, context.prev_loc.offset, tree.firstToken(node), context.encoding));
-    const end_loc = start_loc.add(try offsets.tokenRelativeLocation(tree, start_loc.offset, tree.lastToken(node), context.encoding));
+    const starts = tree.tokens.items(.start);
+    const start_loc = context.prev_loc.add(try offsets.tokenRelativeLocation(
+        tree,
+        context.prev_loc.offset,
+        starts[tree.firstToken(node)],
+        context.encoding,
+    ));
+    const end_loc = start_loc.add(try offsets.tokenRelativeLocation(
+        tree,
+        start_loc.offset,
+        starts[tree.lastToken(node)],
+        context.encoding,
+    ));
     context.prev_loc = end_loc;
     const range = types.Range{
         .start = .{
@@ -1908,7 +1919,7 @@ pub const DeclWithHandle = struct {
 
     pub fn location(self: DeclWithHandle, encoding: offsets.Encoding) !offsets.TokenLocation {
         const tree = self.handle.tree;
-        return try offsets.tokenRelativeLocation(tree, 0, self.nameToken(), encoding);
+        return try offsets.tokenRelativeLocation(tree, 0, tree.tokens.items(.start)[self.nameToken()], encoding);
     }
 
     fn isPublic(self: DeclWithHandle) bool {

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -1285,9 +1285,13 @@ pub fn getFieldAccessType(
             .period => {
                 const after_period = tokenizer.next();
                 switch (after_period.tag) {
-                    .eof => return FieldAccessReturn{
-                        .original = current_type,
-                        .unwrapped = try resolveDerefType(store, arena, current_type, &bound_type_params),
+                    .eof => {
+                        // function labels cannot be dot accessed
+                        if (current_type.isFunc()) return null;
+                        return FieldAccessReturn{
+                            .original = current_type,
+                            .unwrapped = try resolveDerefType(store, arena, current_type, &bound_type_params),
+                        };
                     },
                     .identifier => {
                         if (after_period.loc.end == tokenizer.buffer.len) {

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -2802,7 +2802,7 @@ fn makeScopeInternal(
                 scope.* = .{
                     .range = .{
                         .start = offsets.tokenLocation(tree, payload).start,
-                        .end = offsets.tokenLocation(tree, tree.lastToken(if_node.ast.then_expr)).end,
+                        .end = offsets.tokenLocation(tree, tree.lastToken(if_node.ast.then_expr)).end + 1,
                     },
                     .decls = std.StringHashMap(Declaration).init(allocator),
                     .uses = &.{},
@@ -2887,7 +2887,7 @@ fn makeScopeInternal(
                 scope.* = .{
                     .range = .{
                         .start = offsets.tokenLocation(tree, payload).start,
-                        .end = offsets.tokenLocation(tree, tree.lastToken(while_node.ast.then_expr)).end,
+                        .end = offsets.tokenLocation(tree, tree.lastToken(while_node.ast.then_expr)).end + 1,
                     },
                     .decls = std.StringHashMap(Declaration).init(allocator),
                     .uses = &.{},

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -118,8 +118,8 @@ pub fn getFunctionSnippet(allocator: *std.mem.Allocator, tree: ast.Tree, func: a
 
     var it = func.iterate(tree);
     while (it.next()) |param| {
-        if (skip_self_param and it.param_i -1 == 0) continue;
-        if (it.param_i -1 != @boolToInt(skip_self_param)) try buffer.appendSlice(", ${") else try buffer.appendSlice("${");
+        if (skip_self_param and it.param_i - 1 == 0) continue;
+        if (it.param_i - 1 != @boolToInt(skip_self_param)) try buffer.appendSlice(", ${") else try buffer.appendSlice("${");
 
         try buf_stream.print("{d}:", .{it.param_i});
 
@@ -186,7 +186,7 @@ pub fn isTypeFunction(tree: ast.Tree, func: ast.full.FnProto) bool {
     return typeIsType(tree, func.ast.return_type);
 }
 
-pub fn isGenericFunction(tree: ast.Tree, func: *ast.full.FnProto) bool {
+pub fn isGenericFunction(tree: ast.Tree, func: ast.full.FnProto) bool {
     var it = func.iterate();
     while (it.next()) |param| {
         if (param.anytype_ellipsis3 != null or param.comptime_noalias != null) {
@@ -699,15 +699,15 @@ pub fn resolveTypeOfNodeInternal(
                 const has_self_param = token_tags[call.ast.lparen - 2] == .period;
                 var it = fn_decl.iterate(decl.handle.tree);
 
-                // Bind type params to the expressions passed in the calls.
+                // Bind type params to the expressions passed in txhe calls.
                 const param_len = std.math.min(call.ast.params.len + @boolToInt(has_self_param), fn_decl.ast.params.len);
                 while (it.next()) |decl_param| {
-                    if (it.param_i == 0 and has_self_param) continue;
-                    if (it.param_i >= param_len) break;
+                    if (it.param_i - 1 == 0 and has_self_param) continue;
+                    if (it.param_i - 1 >= param_len) break;
                     if (!typeIsType(decl.handle.tree, decl_param.type_expr)) continue;
 
                     const call_param_type = (try resolveTypeOfNodeInternal(store, arena, .{
-                        .node = call.ast.params[it.param_i - @boolToInt(has_self_param)],
+                        .node = call.ast.params[it.param_i - 1 - @boolToInt(has_self_param)],
                         .handle = decl.handle,
                     }, bound_type_params)) orelse continue;
                     if (!call_param_type.type.is_type_val) continue;

--- a/src/config.zig
+++ b/src/config.zig
@@ -25,3 +25,7 @@ enable_semantic_tokens: bool = true,
 
 /// Whether to enable `*` and `?` operators in completion lists
 operator_completions: bool = true,
+
+/// Skips references to std. This will improve lookup speeds.
+/// Going to definition however will continue to work
+skip_std_references: bool = true,

--- a/src/config.zig
+++ b/src/config.zig
@@ -28,4 +28,4 @@ operator_completions: bool = true,
 
 /// Skips references to std. This will improve lookup speeds.
 /// Going to definition however will continue to work
-skip_std_references: bool = true,
+skip_std_references: bool = false,

--- a/src/main.zig
+++ b/src/main.zig
@@ -622,8 +622,8 @@ fn hoverSymbol(
             const first_token = param.first_doc_comment orelse
                 param.comptime_noalias orelse
                 param.name_token orelse
-                tree.firstToken(param.type_expr);
-            const last_token = tree.lastToken(param.anytype_ellipsis3 orelse param.type_expr);
+                tree.firstToken(param.type_expr); // extern fn
+            const last_token = param.anytype_ellipsis3 orelse tree.lastToken(param.type_expr);
 
             const start = offsets.tokenLocation(tree, first_token).start;
             const end = offsets.tokenLocation(tree, last_token).end;

--- a/src/main.zig
+++ b/src/main.zig
@@ -650,6 +650,7 @@ fn getLabelGlobal(pos_index: usize, handle: *DocumentStore.Handle) !?analysis.De
 
 fn getSymbolGlobal(arena: *std.heap.ArenaAllocator, pos_index: usize, handle: *DocumentStore.Handle) !?analysis.DeclWithHandle {
     const name = identifierFromPosition(pos_index, handle.*);
+    logger.debug("Name: {s}", .{name});
     if (name.len == 0) return null;
 
     return try analysis.lookupSymbolGlobal(&document_store, arena, handle, name, pos_index);
@@ -1314,7 +1315,6 @@ fn hoverHandler(arena: *std.heap.ArenaAllocator, id: types.RequestId, req: reque
     if (req.params.position.character >= 0) {
         const doc_position = try offsets.documentPosition(handle.document, req.params.position, offset_encoding);
         const pos_context = try analysis.documentPositionContext(arena, handle.document, doc_position);
-
         switch (pos_context) {
             .builtin => try hoverDefinitionBuiltin(arena, id, doc_position.absolute_index, handle),
             .var_access => try hoverDefinitionGlobal(arena, id, doc_position.absolute_index, handle, config),

--- a/src/main.zig
+++ b/src/main.zig
@@ -554,7 +554,7 @@ fn gotoDefinitionSymbol(id: types.RequestId, arena: *std.heap.ArenaAllocator, de
 
             const name_token = analysis.getDeclNameToken(handle.tree, node) orelse
                 return try respondGeneric(id, null_result_response);
-            break :block offsets.tokenRelativeLocation(handle.tree, 0, name_token, offset_encoding) catch return;
+            break :block offsets.tokenRelativeLocation(handle.tree, 0, handle.tree.tokens.items(.start)[name_token], offset_encoding) catch return;
         },
         else => decl_handle.location(offset_encoding) catch return,
     };

--- a/src/main.zig
+++ b/src/main.zig
@@ -959,7 +959,7 @@ fn declToCompletion(context: DeclToCompletionContext, decl_handle: analysis.Decl
         },
         .switch_payload => |payload| {
             try context.completions.append(.{
-                .label = tree.tokenSlice(tree.firstToken(payload.node)),
+                .label = tree.tokenSlice(payload.node),
                 .kind = .Variable,
             });
         },

--- a/src/main.zig
+++ b/src/main.zig
@@ -366,7 +366,6 @@ fn nodeToCompletion(
             .arena = arena,
             .orig_handle = orig_handle,
         };
-        logger.debug("eklafgaef", .{});
         try analysis.iterateSymbolsContainer(&document_store, arena, node_handle, orig_handle, declToCompletion, context, !is_type_val);
     }
 
@@ -623,9 +622,8 @@ fn hoverSymbol(
             const first_token = param.first_doc_comment orelse
                 param.comptime_noalias orelse
                 param.name_token orelse
-                param.anytype_ellipsis3 orelse
                 tree.firstToken(param.type_expr);
-            const last_token = tree.lastToken(param.type_expr);
+            const last_token = tree.lastToken(param.anytype_ellipsis3 orelse param.type_expr);
 
             const start = offsets.tokenLocation(tree, first_token).start;
             const end = offsets.tokenLocation(tree, last_token).end;

--- a/src/main.zig
+++ b/src/main.zig
@@ -482,13 +482,17 @@ fn nodeToCompletion(
             const ptr_type = analysis.ptrType(tree, node).?;
 
             switch (ptr_type.size) {
-                .One, .C => if (config.operator_completions) {
+                .One, .C, .Many => if (config.operator_completions) {
                     try list.append(.{
                         .label = "*",
                         .kind = .Operator,
                     });
                 },
-                .Many, .Slice => return list.append(.{ .label = "len", .kind = .Field }),
+                .Slice => {
+                    try list.append(.{ .label = "ptr", .kind = .Field });
+                    try list.append(.{ .label = "len", .kind = .Field });
+                    return;
+                },
             }
 
             if (unwrapped) |actual_type| {

--- a/src/main.zig
+++ b/src/main.zig
@@ -650,7 +650,6 @@ fn getLabelGlobal(pos_index: usize, handle: *DocumentStore.Handle) !?analysis.De
 
 fn getSymbolGlobal(arena: *std.heap.ArenaAllocator, pos_index: usize, handle: *DocumentStore.Handle) !?analysis.DeclWithHandle {
     const name = identifierFromPosition(pos_index, handle.*);
-    logger.debug("Name: {s}", .{name});
     if (name.len == 0) return null;
 
     return try analysis.lookupSymbolGlobal(&document_store, arena, handle, name, pos_index);

--- a/src/main.zig
+++ b/src/main.zig
@@ -368,7 +368,7 @@ fn nodeToCompletion(
     if (is_type_val) return;
 
     switch (node_tags[node]) {
-        .fn_proto, .fn_proto_multi, .fn_proto_one, .fn_proto_multi, .fn_decl => {
+        .fn_proto, .fn_proto_multi, .fn_proto_one, .fn_decl => {
             var buf: [1]std.zig.ast.Node.Index = undefined;
             const func = analysis.fnProto(tree, node, &buf).?;
             if (func.name_token) |name_token| {

--- a/src/main.zig
+++ b/src/main.zig
@@ -637,10 +637,10 @@ fn hoverSymbol(
             try std.fmt.allocPrint(&arena.allocator, "```zig\n{s}\n```", .{tree.tokenSlice(payload.name)})
         else
             try std.fmt.allocPrint(&arena.allocator, "{s}", .{tree.tokenSlice(payload.name)}),
-        // .array_payload => |payload| if (hover_kind == .Markdown)
-        //     try std.fmt.allocPrint(&arena.allocator, "```zig\n{s}\n```", .{handle.tree.tokenSlice(payload.identifier.firstToken())})
-        // else
-        //     try std.fmt.allocPrint(&arena.allocator, "{s}", .{handle.tree.tokenSlice(payload.identifier.firstToken())}),
+        .array_payload => |payload| if (hover_kind == .Markdown)
+            try std.fmt.allocPrint(&arena.allocator, "```zig\n{s}\n```", .{handle.tree.tokenSlice(payload.identifier)})
+        else
+            try std.fmt.allocPrint(&arena.allocator, "{s}", .{handle.tree.tokenSlice(payload.identifier)}),
         .switch_payload => |payload| if (hover_kind == .Markdown)
             try std.fmt.allocPrint(&arena.allocator, "```zig\n{s}\n```", .{tree.tokenSlice(payload.node)})
         else
@@ -935,9 +935,8 @@ fn declToCompletion(context: DeclToCompletionContext, decl_handle: analysis.Decl
             const first_token = param.first_doc_comment orelse
                 param.comptime_noalias orelse
                 param.name_token orelse
-                param.anytype_ellipsis3 orelse
                 tree.firstToken(param.type_expr);
-            const last_token = tree.lastToken(param.type_expr);
+            const last_token = param.anytype_ellipsis3 orelse tree.lastToken(param.type_expr);
 
             try context.completions.append(.{
                 .label = tree.tokenSlice(param.name_token.?),
@@ -952,12 +951,12 @@ fn declToCompletion(context: DeclToCompletionContext, decl_handle: analysis.Decl
                 .kind = .Variable,
             });
         },
-        // .array_payload => |payload| {
-        //     try context.completions.append(.{
-        //         .label = tree.tokenSlice(payload.identifier.firstToken()),
-        //         .kind = .Variable,
-        //     });
-        // },
+        .array_payload => |payload| {
+            try context.completions.append(.{
+                .label = tree.tokenSlice(payload.identifier),
+                .kind = .Variable,
+            });
+        },
         .switch_payload => |payload| {
             try context.completions.append(.{
                 .label = tree.tokenSlice(tree.firstToken(payload.node)),

--- a/src/main.zig
+++ b/src/main.zig
@@ -391,6 +391,8 @@ fn nodeToCompletion(
                         var it = func.iterate(tree);
                         const param = it.next().?;
 
+                        if (param.type_expr == 0) break :param_check false;
+
                         if (try analysis.resolveTypeOfNode(&document_store, arena, .{
                             .node = param.type_expr,
                             .handle = handle,
@@ -641,6 +643,10 @@ fn hoverSymbol(
             try std.fmt.allocPrint(&arena.allocator, "```zig\n{s}\n```", .{handle.tree.tokenSlice(payload.identifier)})
         else
             try std.fmt.allocPrint(&arena.allocator, "{s}", .{handle.tree.tokenSlice(payload.identifier)}),
+        .array_index => |payload| if (hover_kind == .Markdown)
+            try std.fmt.allocPrint(&arena.allocator, "```zig\n{s}\n```", .{handle.tree.tokenSlice(payload)})
+        else
+            try std.fmt.allocPrint(&arena.allocator, "{s}", .{handle.tree.tokenSlice(payload)}),
         .switch_payload => |payload| if (hover_kind == .Markdown)
             try std.fmt.allocPrint(&arena.allocator, "```zig\n{s}\n```", .{tree.tokenSlice(payload.node)})
         else
@@ -954,6 +960,12 @@ fn declToCompletion(context: DeclToCompletionContext, decl_handle: analysis.Decl
         .array_payload => |payload| {
             try context.completions.append(.{
                 .label = tree.tokenSlice(payload.identifier),
+                .kind = .Variable,
+            });
+        },
+        .array_index => |payload| {
+            try context.completions.append(.{
+                .label = tree.tokenSlice(payload),
                 .kind = .Variable,
             });
         },

--- a/src/main.zig
+++ b/src/main.zig
@@ -361,7 +361,7 @@ fn nodeToCompletion(
             .arena = arena,
             .orig_handle = orig_handle,
         };
-        try analysis.iterateSymbolsContainer(&document_store, arena, node_handle, orig_handle, declToCompletion, context, is_type_val);
+        try analysis.iterateSymbolsContainer(&document_store, arena, node_handle, orig_handle, declToCompletion, context, !is_type_val);
     }
 
     if (is_type_val) return;

--- a/src/offsets.zig
+++ b/src/offsets.zig
@@ -113,9 +113,9 @@ pub fn tokenLength(tree: std.zig.ast.Tree, token: std.zig.ast.TokenIndex, encodi
     if (encoding == .utf8)
         return token_loc.line_end - token_loc.line_start;
 
-    var i: usize = token_loc.start;
+    var i: usize = token_loc.line_start;
     var utf16_len: usize = 0;
-    while (i < token_loc.end) {
+    while (i < token_loc.line_end) {
         const n = std.unicode.utf8ByteSequenceLength(tree.source[i]) catch unreachable;
         const codepoint = std.unicode.utf8Decode(tree.source[i .. i + n]) catch unreachable;
         if (codepoint < 0x10000) {

--- a/src/offsets.zig
+++ b/src/offsets.zig
@@ -71,8 +71,8 @@ pub const TokenLocation = struct {
     }
 };
 
-pub fn tokenRelativeLocation(tree: ast.Tree, start_index: usize, token: ast.TokenIndex, encoding: Encoding) !TokenLocation {
-    const start = tree.tokens.items(.start)[token];
+pub fn tokenRelativeLocation(tree: ast.Tree, start_index: usize, next_token_index: usize, encoding: Encoding) !TokenLocation {
+    const start = next_token_index;
 
     var loc = TokenLocation{
         .line = 0,

--- a/src/offsets.zig
+++ b/src/offsets.zig
@@ -71,14 +71,14 @@ pub const TokenLocation = struct {
 };
 
 pub fn tokenRelativeLocation(tree: std.zig.ast.Tree, start_index: usize, token: std.zig.ast.TokenIndex, encoding: Encoding) !TokenLocation {
-    const token_loc = tree.tokenLocation(@truncate(u32, start_index), token);
+    const start = tree.tokens.items(.start)[token];
 
     var loc = TokenLocation{
         .line = 0,
         .column = 0,
         .offset = 0,
     };
-    const token_start = token_loc.line_start;
+    const token_start = start;
     const source = tree.source[start_index..];
     var i: usize = 0;
     while (i + start_index < token_start) {

--- a/src/offsets.zig
+++ b/src/offsets.zig
@@ -70,15 +70,15 @@ pub const TokenLocation = struct {
     }
 };
 
-pub fn tokenRelativeLocation(tree: *std.zig.ast.Tree, start_index: usize, token: std.zig.ast.TokenIndex, encoding: Encoding) !TokenLocation {
-    const token_loc = tree.token_locs[token];
+pub fn tokenRelativeLocation(tree: std.zig.ast.Tree, start_index: usize, token: std.zig.ast.TokenIndex, encoding: Encoding) !TokenLocation {
+    const token_loc = tree.tokenLocation(@truncate(u32, start_index), token);
 
     var loc = TokenLocation{
         .line = 0,
         .column = 0,
         .offset = 0,
     };
-    const token_start = token_loc.start;
+    const token_start = token_loc.line_start;
     const source = tree.source[start_index..];
     var i: usize = 0;
     while (i + start_index < token_start) {
@@ -108,10 +108,10 @@ pub fn tokenRelativeLocation(tree: *std.zig.ast.Tree, start_index: usize, token:
 }
 
 /// Asserts the token is comprised of valid utf8
-pub fn tokenLength(tree: *std.zig.ast.Tree, token: std.zig.ast.TokenIndex, encoding: Encoding) usize {
-    const token_loc = tree.token_locs[token];
+pub fn tokenLength(tree: std.zig.ast.Tree, token: std.zig.ast.TokenIndex, encoding: Encoding) usize {
+    const token_loc = tree.tokenLocation(0, token);
     if (encoding == .utf8)
-        return token_loc.end - token_loc.start;
+        return token_loc.line_end - token_loc.line_start;
 
     var i: usize = token_loc.start;
     var utf16_len: usize = 0;

--- a/src/references.zig
+++ b/src/references.zig
@@ -78,7 +78,7 @@ fn symbolReferencesInternal(
     const node = node_handle.node;
     const handle = node_handle.handle;
 
-    switch (node.tag) {
+    switch (handle.tree.nodes.items(.tag)[node]) {
         .ContainerDecl, .Root, .Block => {
             var idx: usize = 0;
             while (node.iterate(idx)) |child| : (idx += 1) {

--- a/src/references.zig
+++ b/src/references.zig
@@ -14,7 +14,7 @@ fn tokenReference(
     context: anytype,
     comptime handler: anytype,
 ) !void {
-    const loc = offsets.tokenRelativeLocation(handle.tree, 0, tok, encoding) catch return;
+    const loc = offsets.tokenRelativeLocation(handle.tree, 0, handle.tree.tokens.items(.start)[tok], encoding) catch return;
     try handler(context, types.Location{
         .uri = handle.uri(),
         .range = .{

--- a/src/references.zig
+++ b/src/references.zig
@@ -199,11 +199,15 @@ fn symbolReferencesInternal(
         },
         .switch_case_one => {
             const case_one = tree.switchCaseOne(node);
+            if (case_one.ast.target_expr != 0)
+                try symbolReferencesInternal(arena, store, .{ .node = case_one.ast.target_expr, .handle = handle }, decl, encoding, context, handler);
             for (case_one.ast.values) |val|
                 try symbolReferencesInternal(arena, store, .{ .node = val, .handle = handle }, decl, encoding, context, handler);
         },
         .switch_case => {
             const case = tree.switchCase(node);
+            if (case.ast.target_expr != 0)
+                try symbolReferencesInternal(arena, store, .{ .node = case.ast.target_expr, .handle = handle }, decl, encoding, context, handler);
             for (case.ast.values) |val|
                 try symbolReferencesInternal(arena, store, .{ .node = val, .handle = handle }, decl, encoding, context, handler);
         },
@@ -401,7 +405,7 @@ fn symbolReferencesInternal(
         .field_access => {
             try symbolReferencesInternal(arena, store, .{ .node = datas[node].lhs, .handle = handle }, decl, encoding, context, handler);
 
-            const rhs_str = analysis.nodeToString(handle.tree, datas[node].rhs) orelse return;
+            const rhs_str = analysis.nodeToString(handle.tree, node) orelse return;
             var bound_type_params = analysis.BoundTypeParams.init(&arena.allocator);
             const left_type = try analysis.resolveFieldAccessLhsType(
                 store,
@@ -426,7 +430,7 @@ fn symbolReferencesInternal(
                 !left_type.type.is_type_val,
             )) |child| {
                 if (std.meta.eql(child, decl)) {
-                    try tokenReference(handle, tree.firstToken(datas[node].rhs), encoding, context, handler);
+                    try tokenReference(handle, datas[node].rhs, encoding, context, handler);
                 }
             }
         },

--- a/src/references.zig
+++ b/src/references.zig
@@ -585,7 +585,7 @@ pub fn symbolReferences(
                 return;
             };
         },
-        .pointer_payload, .switch_payload, .array_payload => {
+        .pointer_payload, .switch_payload, .array_payload, .array_index => {
             if (include_decl) {
                 try tokenReference(curr_handle, decl_handle.nameToken(), encoding, context, handler);
             }

--- a/src/references.zig
+++ b/src/references.zig
@@ -585,7 +585,7 @@ pub fn symbolReferences(
                 return;
             };
         },
-        .pointer_payload, .switch_payload => {
+        .pointer_payload, .switch_payload, .array_payload => {
             if (include_decl) {
                 try tokenReference(curr_handle, decl_handle.nameToken(), encoding, context, handler);
             }

--- a/src/rename.zig
+++ b/src/rename.zig
@@ -40,7 +40,7 @@ pub fn renameSymbol(
         .edits = edits,
         .allocator = &arena.allocator,
         .new_name = new_name,
-    }, refHandler);
+    }, refHandler, true);
 }
 
 pub fn renameLabel(

--- a/src/semantic_tokens.zig
+++ b/src/semantic_tokens.zig
@@ -199,23 +199,23 @@ fn colorIdentifierBasedOnType(builder: *Builder, type_node: analysis.TypeWithHan
     const tree = builder.handle.tree;
     if (type_node.type.is_type_val) {
         var new_tok_mod = tok_mod;
-        if (type_node.isNamespace(tree))
+        if (type_node.isNamespace())
             new_tok_mod.set("namespace")
-        else if (type_node.isStructType(tree))
+        else if (type_node.isStructType())
             new_tok_mod.set("struct")
-        else if (type_node.isEnumType(tree))
+        else if (type_node.isEnumType())
             new_tok_mod.set("enum")
-        else if (type_node.isUnionType(tree))
+        else if (type_node.isUnionType())
             new_tok_mod.set("union")
-        else if (type_node.isOpaqueType(tree))
+        else if (type_node.isOpaqueType())
             new_tok_mod.set("opaque");
 
         try writeTokenMod(builder, target_tok, .type, new_tok_mod);
-    } else if (type_node.isTypeFunc(tree)) {
+    } else if (type_node.isTypeFunc()) {
         try writeTokenMod(builder, target_tok, .type, tok_mod);
-    } else if (type_node.isFunc(tree)) {
+    } else if (type_node.isFunc()) {
         var new_tok_mod = tok_mod;
-        if (type_node.isGenericFunc(tree)) {
+        if (type_node.isGenericFunc()) {
             new_tok_mod.set("generic");
         }
         try writeTokenMod(builder, target_tok, .function, new_tok_mod);
@@ -277,6 +277,7 @@ fn writeNodeTokens(
     const main_tokens = tree.nodes.items(.main_token);
 
     const node = maybe_node.?;
+    if (node > node_tags.len) return;
     const tag = node_tags[node];
     const main_token = main_tokens[node];
 

--- a/src/semantic_tokens.zig
+++ b/src/semantic_tokens.zig
@@ -598,6 +598,7 @@ fn writeNodeTokens(
 
             try writeToken(builder, while_node.label_token, .label);
             try writeToken(builder, while_node.inline_token, .keyword);
+            try writeToken(builder, while_node.ast.while_token, .keyword);
             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, while_node.ast.cond_expr });
             try writeToken(builder, while_node.payload_token, .variable);
             if (while_node.ast.cont_expr != 0)
@@ -607,8 +608,10 @@ fn writeNodeTokens(
 
             try writeToken(builder, while_node.error_token, .variable);
 
-            if (while_node.ast.else_expr != 0)
+            if (while_node.ast.else_expr != 0) {
+                try writeToken(builder, while_node.else_token, .keyword);
                 try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, while_node.ast.else_expr });
+            }
         },
         .@"if",
         .if_simple,
@@ -622,8 +625,10 @@ fn writeNodeTokens(
             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, if_node.ast.then_expr });
 
             try writeToken(builder, if_node.error_token, .variable);
-            if (if_node.ast.else_expr != 0)
+            if (if_node.ast.else_expr != 0) {
+                try writeToken(builder, if_node.else_token, .keyword);
                 try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, if_node.ast.else_expr });
+            }
         },
         .array_init,
         .array_init_comma,

--- a/src/semantic_tokens.zig
+++ b/src/semantic_tokens.zig
@@ -65,11 +65,11 @@ const Builder = struct {
 
     fn add(self: *Builder, token: ast.TokenIndex, token_type: TokenType, token_modifiers: TokenModifiers) !void {
         const start_idx = if (self.current_token) |current_token|
-            self.handle.tree.token_locs[current_token].start
+            self.handle.tree.tokenLocation[current_token].line_start
         else
             0;
 
-        if (start_idx > self.handle.tree.token_locs[token].start)
+        if (start_idx > self.handle.tree.tokenLocation[token].line_start)
             return;
 
         const delta_loc = offsets.tokenRelativeLocation(self.handle.tree, start_idx, token, self.encoding) catch return;

--- a/src/semantic_tokens.zig
+++ b/src/semantic_tokens.zig
@@ -254,568 +254,582 @@ fn writeContainerField(
     }
 }
 
+// @TODO: Fix semantic tokens
 // TODO This is very slow and does a lot of extra work, improve in the future.
-fn writeNodeTokens(builder: *Builder, arena: *std.heap.ArenaAllocator, store: *DocumentStore, maybe_node: ?*ast.Node) error{OutOfMemory}!void {
-    if (maybe_node == null) return;
-    const node = maybe_node.?;
-    const handle = builder.handle;
+// fn writeNodeTokens(
+//     builder: *Builder,
+//     arena: *std.heap.ArenaAllocator,
+//     store: *DocumentStore,
+//     maybe_node: ?ast.Node.Index,
+//     tree: ast.Tree,
+// ) error{OutOfMemory}!void {
+//     if (maybe_node == null) return;
 
-    const FrameSize = @sizeOf(@Frame(writeNodeTokens));
-    var child_frame = try arena.child_allocator.alignedAlloc(u8, std.Target.stack_align, FrameSize);
-    defer arena.child_allocator.free(child_frame);
+//     const node_tags = tree.nodes.items(.tag);
+//     const token_tags = tree.tokens.items(.tag);
+//     const nodes_data = tree.nodes.items(.data);
+//     const main_tokens = tree.nodes.items(.main_token);
 
-    switch (node.tag) {
-        .Root, .Block, .LabeledBlock => {
-            const first_tok = if (node.castTag(.LabeledBlock)) |block_node| block: {
-                try writeToken(builder, block_node.label, .label);
-                break :block block_node.lbrace + 1;
-            } else if (node.castTag(.Block)) |block_node|
-                block_node.lbrace + 1
-            else
-                0;
+//     const node = maybe_node.?;
+//     const handle = builder.handle;
 
-            var gap_highlighter = GapHighlighter.init(builder, first_tok);
-            var child_idx: usize = 0;
-            while (node.iterate(child_idx)) |child| : (child_idx += 1) {
-                try gap_highlighter.next(child);
-                if (child.cast(ast.Node.ContainerField)) |container_field| {
-                    try writeContainerField(builder, arena, store, container_field, .field, child_frame);
-                } else {
-                    try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, child });
-                }
-            }
+//     const FrameSize = @sizeOf(@Frame(writeNodeTokens));
+//     var child_frame = try arena.child_allocator.alignedAlloc(u8, std.Target.stack_align, FrameSize);
+//     defer arena.child_allocator.free(child_frame);
 
-            if (node.tag == .Root) {
-                try gap_highlighter.end(handle.tree.token_ids.len - 1);
-            } else {
-                try gap_highlighter.end(node.lastToken());
-            }
-        },
-        .VarDecl => {
-            const var_decl = node.cast(ast.Node.VarDecl).?;
-            if (var_decl.getDocComments()) |doc| try writeDocComments(builder, handle.tree, doc);
-            try writeToken(builder, var_decl.getVisibToken(), .keyword);
-            try writeToken(builder, var_decl.getExternExportToken(), .keyword);
-            try writeToken(builder, var_decl.getThreadLocalToken(), .keyword);
-            try writeToken(builder, var_decl.getComptimeToken(), .keyword);
-            try writeToken(builder, var_decl.mut_token, .keyword);
-            if (try analysis.resolveTypeOfNode(store, arena, .{ .node = node, .handle = handle })) |decl_type| {
-                try colorIdentifierBasedOnType(builder, decl_type, var_decl.name_token, .{ .declaration = true });
-            } else {
-                try writeTokenMod(builder, var_decl.name_token, .variable, .{ .declaration = true });
-            }
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, var_decl.getTypeNode() });
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, var_decl.getAlignNode() });
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, var_decl.getSectionNode() });
-            try writeToken(builder, var_decl.getEqToken(), .operator);
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, var_decl.getInitNode() });
-        },
-        .Use => {
-            const use = node.cast(ast.Node.Use).?;
-            if (use.doc_comments) |docs| try writeDocComments(builder, builder.handle.tree, docs);
-            try writeToken(builder, use.visib_token, .keyword);
-            try writeToken(builder, use.use_token, .keyword);
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, use.expr });
-        },
-        .ErrorSetDecl => {
-            const error_set = node.cast(ast.Node.ErrorSetDecl).?;
-            try writeToken(builder, error_set.error_token, .keyword);
-            for (error_set.declsConst()) |decl|
-                try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, decl });
-        },
-        .ContainerDecl => {
-            const container_decl = node.cast(ast.Node.ContainerDecl).?;
-            try writeToken(builder, container_decl.layout_token, .keyword);
-            try writeToken(builder, container_decl.kind_token, .keyword);
-            switch (container_decl.init_arg_expr) {
-                .None => {},
-                .Enum => |enum_expr| if (enum_expr) |expr|
-                    try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, expr })
-                else
-                    try writeToken(builder, container_decl.kind_token + 2, .keyword),
-                .Type => |type_node| try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, type_node }),
-            }
+//     switch (node_tags[node]) {
+//         .root, .block, .block_semicolon => |tag| {
+//             const first_tok = if (tag != block_semicolon) block: {
+//                 const lbrace = main_tokens[node];
+//                 if (token_tags[lbrace - 1] == .colon and token_tags[lbrace - 2] == .identifier)
+//                     try writeToken(builder, lbrace - 2, .label);
 
-            var gap_highlighter = GapHighlighter.init(builder, container_decl.lbrace_token + 1);
-            const field_token_type = fieldTokenType(container_decl, handle);
-            for (container_decl.fieldsAndDeclsConst()) |child| {
-                try gap_highlighter.next(child);
-                if (child.cast(ast.Node.ContainerField)) |container_field| {
-                    try writeContainerField(builder, arena, store, container_field, field_token_type, child_frame);
-                } else {
-                    try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, child });
-                }
-            }
-            try gap_highlighter.end(node.lastToken());
-        },
-        .ErrorTag => {
-            const error_tag = node.cast(ast.Node.ErrorTag).?;
-            if (error_tag.doc_comments) |docs| try writeDocComments(builder, handle.tree, docs);
-            try writeToken(builder, error_tag.firstToken(), .errorTag);
-        },
-        .Identifier => {
-            if (analysis.isTypeIdent(handle.tree, node.firstToken())) {
-                return try writeToken(builder, node.firstToken(), .type);
-            }
+//                 break :block lbrace + 1;
+//             } else 0;
 
-            if (try analysis.lookupSymbolGlobal(store, arena, handle, handle.tree.getNodeSource(node), handle.tree.token_locs[node.firstToken()].start)) |child| {
-                if (child.decl.* == .param_decl) {
-                    return try writeToken(builder, node.firstToken(), .parameter);
-                }
-                var bound_type_params = analysis.BoundTypeParams.init(&arena.allocator);
-                if (try child.resolveType(store, arena, &bound_type_params)) |decl_type| {
-                    try colorIdentifierBasedOnType(builder, decl_type, node.firstToken(), .{});
-                } else {
-                    try writeTokenMod(builder, node.firstToken(), .variable, .{});
-                }
-            }
-        },
-        .FnProto => {
-            const fn_proto = node.cast(ast.Node.FnProto).?;
-            if (fn_proto.getDocComments()) |docs| try writeDocComments(builder, handle.tree, docs);
-            try writeToken(builder, fn_proto.getVisibToken(), .keyword);
-            try writeToken(builder, fn_proto.getExternExportInlineToken(), .keyword);
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, fn_proto.getLibName() });
-            try writeToken(builder, fn_proto.fn_token, .keyword);
+//             var gap_highlighter = GapHighlighter.init(builder, first_tok);
+//             var child_idx: usize = 0;
+//             while (node.iterate(child_idx)) |child| : (child_idx += 1) {
+//                 try gap_highlighter.next(child);
+//                 if (child.cast(ast.Node.ContainerField)) |container_field| {
+//                     try writeContainerField(builder, arena, store, container_field, .field, child_frame);
+//                 } else {
+//                     try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, child });
+//                 }
+//             }
 
-            const func_name_tok_type: TokenType = if (analysis.isTypeFunction(handle.tree, fn_proto))
-                .type
-            else
-                .function;
+//             if (node.tag == .Root) {
+//                 try gap_highlighter.end(handle.tree.token_ids.len - 1);
+//             } else {
+//                 try gap_highlighter.end(node.lastToken());
+//             }
+//         },
+//         .VarDecl => {
+//             const var_decl = node.cast(ast.Node.VarDecl).?;
+//             if (var_decl.getDocComments()) |doc| try writeDocComments(builder, handle.tree, doc);
+//             try writeToken(builder, var_decl.getVisibToken(), .keyword);
+//             try writeToken(builder, var_decl.getExternExportToken(), .keyword);
+//             try writeToken(builder, var_decl.getThreadLocalToken(), .keyword);
+//             try writeToken(builder, var_decl.getComptimeToken(), .keyword);
+//             try writeToken(builder, var_decl.mut_token, .keyword);
+//             if (try analysis.resolveTypeOfNode(store, arena, .{ .node = node, .handle = handle })) |decl_type| {
+//                 try colorIdentifierBasedOnType(builder, decl_type, var_decl.name_token, .{ .declaration = true });
+//             } else {
+//                 try writeTokenMod(builder, var_decl.name_token, .variable, .{ .declaration = true });
+//             }
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, var_decl.getTypeNode() });
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, var_decl.getAlignNode() });
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, var_decl.getSectionNode() });
+//             try writeToken(builder, var_decl.getEqToken(), .operator);
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, var_decl.getInitNode() });
+//         },
+//         .Use => {
+//             const use = node.cast(ast.Node.Use).?;
+//             if (use.doc_comments) |docs| try writeDocComments(builder, builder.handle.tree, docs);
+//             try writeToken(builder, use.visib_token, .keyword);
+//             try writeToken(builder, use.use_token, .keyword);
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, use.expr });
+//         },
+//         .ErrorSetDecl => {
+//             const error_set = node.cast(ast.Node.ErrorSetDecl).?;
+//             try writeToken(builder, error_set.error_token, .keyword);
+//             for (error_set.declsConst()) |decl|
+//                 try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, decl });
+//         },
+//         .ContainerDecl => {
+//             const container_decl = node.cast(ast.Node.ContainerDecl).?;
+//             try writeToken(builder, container_decl.layout_token, .keyword);
+//             try writeToken(builder, container_decl.kind_token, .keyword);
+//             switch (container_decl.init_arg_expr) {
+//                 .None => {},
+//                 .Enum => |enum_expr| if (enum_expr) |expr|
+//                     try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, expr })
+//                 else
+//                     try writeToken(builder, container_decl.kind_token + 2, .keyword),
+//                 .Type => |type_node| try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, type_node }),
+//             }
 
-            const tok_mod = if (analysis.isGenericFunction(handle.tree, fn_proto))
-                TokenModifiers{ .generic = true }
-            else
-                TokenModifiers{};
+//             var gap_highlighter = GapHighlighter.init(builder, container_decl.lbrace_token + 1);
+//             const field_token_type = fieldTokenType(container_decl, handle);
+//             for (container_decl.fieldsAndDeclsConst()) |child| {
+//                 try gap_highlighter.next(child);
+//                 if (child.cast(ast.Node.ContainerField)) |container_field| {
+//                     try writeContainerField(builder, arena, store, container_field, field_token_type, child_frame);
+//                 } else {
+//                     try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, child });
+//                 }
+//             }
+//             try gap_highlighter.end(node.lastToken());
+//         },
+//         .ErrorTag => {
+//             const error_tag = node.cast(ast.Node.ErrorTag).?;
+//             if (error_tag.doc_comments) |docs| try writeDocComments(builder, handle.tree, docs);
+//             try writeToken(builder, error_tag.firstToken(), .errorTag);
+//         },
+//         .Identifier => {
+//             if (analysis.isTypeIdent(handle.tree, node.firstToken())) {
+//                 return try writeToken(builder, node.firstToken(), .type);
+//             }
 
-            try writeTokenMod(builder, fn_proto.getNameToken(), func_name_tok_type, tok_mod);
+//             if (try analysis.lookupSymbolGlobal(store, arena, handle, handle.tree.getNodeSource(node), handle.tree.token_locs[node.firstToken()].start)) |child| {
+//                 if (child.decl.* == .param_decl) {
+//                     return try writeToken(builder, node.firstToken(), .parameter);
+//                 }
+//                 var bound_type_params = analysis.BoundTypeParams.init(&arena.allocator);
+//                 if (try child.resolveType(store, arena, &bound_type_params)) |decl_type| {
+//                     try colorIdentifierBasedOnType(builder, decl_type, node.firstToken(), .{});
+//                 } else {
+//                     try writeTokenMod(builder, node.firstToken(), .variable, .{});
+//                 }
+//             }
+//         },
+//         .FnProto => {
+//             const fn_proto = node.cast(ast.Node.FnProto).?;
+//             if (fn_proto.getDocComments()) |docs| try writeDocComments(builder, handle.tree, docs);
+//             try writeToken(builder, fn_proto.getVisibToken(), .keyword);
+//             try writeToken(builder, fn_proto.getExternExportInlineToken(), .keyword);
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, fn_proto.getLibName() });
+//             try writeToken(builder, fn_proto.fn_token, .keyword);
 
-            for (fn_proto.paramsConst()) |param_decl| {
-                if (param_decl.doc_comments) |docs| try writeDocComments(builder, handle.tree, docs);
-                try writeToken(builder, param_decl.noalias_token, .keyword);
-                try writeToken(builder, param_decl.comptime_token, .keyword);
-                try writeTokenMod(builder, param_decl.name_token, .parameter, .{ .declaration = true });
-                switch (param_decl.param_type) {
-                    .any_type => |var_node| try writeToken(builder, var_node.firstToken(), .type),
-                    .type_expr => |type_expr| try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, type_expr }),
-                }
-            }
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, fn_proto.getAlignExpr() });
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, fn_proto.getSectionExpr() });
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, fn_proto.getCallconvExpr() });
+//             const func_name_tok_type: TokenType = if (analysis.isTypeFunction(handle.tree, fn_proto))
+//                 .type
+//             else
+//                 .function;
 
-            switch (fn_proto.return_type) {
-                .Explicit => |type_expr| try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, type_expr }),
-                .InferErrorSet => |type_expr| {
-                    try writeToken(builder, type_expr.firstToken() - 1, .operator);
-                    try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, type_expr });
-                },
-                .Invalid => {},
-            }
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, fn_proto.getBodyNode() });
-        },
-        .AnyFrameType => {
-            const any_frame_type = node.cast(ast.Node.AnyFrameType).?;
-            try writeToken(builder, any_frame_type.anyframe_token, .type);
-            if (any_frame_type.result) |any_frame_result| {
-                try writeToken(builder, any_frame_result.arrow_token, .type);
-                try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, any_frame_result.return_type });
-            }
-        },
-        .Defer => {
-            const defer_node = node.cast(ast.Node.Defer).?;
-            try writeToken(builder, defer_node.defer_token, .keyword);
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, defer_node.payload });
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, defer_node.expr });
-        },
-        .Comptime => {
-            const comptime_node = node.cast(ast.Node.Comptime).?;
-            if (comptime_node.doc_comments) |docs| try writeDocComments(builder, handle.tree, docs);
-            try writeToken(builder, comptime_node.comptime_token, .keyword);
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, comptime_node.expr });
-        },
-        .Nosuspend => {
-            const nosuspend_node = node.cast(ast.Node.Nosuspend).?;
-            try writeToken(builder, nosuspend_node.nosuspend_token, .keyword);
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, nosuspend_node.expr });
-        },
-        .Payload => {
-            const payload = node.cast(ast.Node.Payload).?;
-            try writeToken(builder, payload.lpipe, .operator);
-            try writeToken(builder, payload.error_symbol.firstToken(), .variable);
-            try writeToken(builder, payload.rpipe, .operator);
-        },
-        .PointerPayload => {
-            const payload = node.cast(ast.Node.PointerPayload).?;
-            try writeToken(builder, payload.lpipe, .operator);
-            try writeToken(builder, payload.ptr_token, .operator);
-            try writeToken(builder, payload.value_symbol.firstToken(), .variable);
-            try writeToken(builder, payload.rpipe, .operator);
-        },
-        .PointerIndexPayload => {
-            const payload = node.cast(ast.Node.PointerIndexPayload).?;
-            try writeToken(builder, payload.lpipe, .operator);
-            try writeToken(builder, payload.ptr_token, .operator);
-            try writeToken(builder, payload.value_symbol.firstToken(), .variable);
-            if (payload.index_symbol) |index_symbol| try writeToken(builder, index_symbol.firstToken(), .variable);
-            try writeToken(builder, payload.rpipe, .operator);
-        },
-        .Else => {
-            const else_node = node.cast(ast.Node.Else).?;
-            try writeToken(builder, else_node.else_token, .keyword);
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, else_node.payload });
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, else_node.body });
-        },
-        .Switch => {
-            const switch_node = node.cast(ast.Node.Switch).?;
-            try writeToken(builder, switch_node.switch_token, .keyword);
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, switch_node.expr });
+//             const tok_mod = if (analysis.isGenericFunction(handle.tree, fn_proto))
+//                 TokenModifiers{ .generic = true }
+//             else
+//                 TokenModifiers{};
 
-            var gap_highlighter = GapHighlighter.init(builder, switch_node.expr.lastToken() + 3);
-            for (switch_node.casesConst()) |case_node| {
-                try gap_highlighter.next(case_node);
-                try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, case_node });
-            }
-            try gap_highlighter.end(node.lastToken());
-        },
-        .SwitchCase => {
-            const switch_case = node.cast(ast.Node.SwitchCase).?;
-            for (switch_case.itemsConst()) |item_node| try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, item_node });
-            try writeToken(builder, switch_case.arrow_token, .operator);
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, switch_case.payload });
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, switch_case.expr });
-        },
-        .SwitchElse => {
-            const switch_else = node.cast(ast.Node.SwitchElse).?;
-            try writeToken(builder, switch_else.token, .keyword);
-        },
-        .While => {
-            const while_node = node.cast(ast.Node.While).?;
-            try writeToken(builder, while_node.label, .label);
-            try writeToken(builder, while_node.inline_token, .keyword);
-            try writeToken(builder, while_node.while_token, .keyword);
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, while_node.condition });
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, while_node.payload });
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, while_node.continue_expr });
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, while_node.body });
-            if (while_node.@"else") |else_node|
-                try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, &else_node.base });
-        },
-        .For => {
-            const for_node = node.cast(ast.Node.For).?;
-            try writeToken(builder, for_node.label, .label);
-            try writeToken(builder, for_node.inline_token, .keyword);
-            try writeToken(builder, for_node.for_token, .keyword);
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, for_node.array_expr });
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, for_node.payload });
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, for_node.body });
-            if (for_node.@"else") |else_node|
-                try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, &else_node.base });
-        },
-        .If => {
-            const if_node = node.cast(ast.Node.If).?;
-            try writeToken(builder, if_node.if_token, .keyword);
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, if_node.condition });
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, if_node.payload });
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, if_node.body });
-            if (if_node.@"else") |else_node|
-                try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, &else_node.base });
-        },
-        .ArrayInitializer => {
-            const array_initializer = node.cast(ast.Node.ArrayInitializer).?;
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, array_initializer.lhs });
-            for (array_initializer.listConst()) |elem| try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, elem });
-        },
-        .ArrayInitializerDot => {
-            const array_initializer = node.cast(ast.Node.ArrayInitializerDot).?;
-            for (array_initializer.listConst()) |elem| try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, elem });
-        },
-        .StructInitializer => {
-            const struct_initializer = node.cast(ast.Node.StructInitializer).?;
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, struct_initializer.lhs });
-            const field_token_type = if (try analysis.resolveTypeOfNode(store, arena, .{ .node = struct_initializer.lhs, .handle = handle })) |struct_type| switch (struct_type.type.data) {
-                .other => |type_node| if (type_node.cast(ast.Node.ContainerDecl)) |container_decl|
-                    fieldTokenType(container_decl, handle)
-                else
-                    null,
-                else => null,
-            } else null;
+//             try writeTokenMod(builder, fn_proto.getNameToken(), func_name_tok_type, tok_mod);
 
-            var gap_highlighter = GapHighlighter.init(builder, struct_initializer.lhs.lastToken() + 1);
-            for (struct_initializer.listConst()) |field_init_node| {
-                try gap_highlighter.next(field_init_node);
-                std.debug.assert(field_init_node.tag == .FieldInitializer);
-                const field_init = field_init_node.cast(ast.Node.FieldInitializer).?;
-                if (field_token_type) |tok_type| {
-                    try writeToken(builder, field_init.period_token, tok_type);
-                    try writeToken(builder, field_init.name_token, tok_type);
-                }
-                try writeToken(builder, field_init.name_token + 1, .operator);
-                try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, field_init.expr });
-            }
-            try gap_highlighter.end(struct_initializer.rtoken);
-        },
-        .StructInitializerDot => {
-            const struct_initializer = node.castTag(.StructInitializerDot).?;
+//             for (fn_proto.paramsConst()) |param_decl| {
+//                 if (param_decl.doc_comments) |docs| try writeDocComments(builder, handle.tree, docs);
+//                 try writeToken(builder, param_decl.noalias_token, .keyword);
+//                 try writeToken(builder, param_decl.comptime_token, .keyword);
+//                 try writeTokenMod(builder, param_decl.name_token, .parameter, .{ .declaration = true });
+//                 switch (param_decl.param_type) {
+//                     .any_type => |var_node| try writeToken(builder, var_node.firstToken(), .type),
+//                     .type_expr => |type_expr| try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, type_expr }),
+//                 }
+//             }
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, fn_proto.getAlignExpr() });
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, fn_proto.getSectionExpr() });
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, fn_proto.getCallconvExpr() });
 
-            var gap_highlighter = GapHighlighter.init(builder, struct_initializer.dot + 1);
-            for (struct_initializer.listConst()) |field_init_node| {
-                try gap_highlighter.next(field_init_node);
-                std.debug.assert(field_init_node.tag == .FieldInitializer);
-                const field_init = field_init_node.castTag(.FieldInitializer).?;
-                try writeToken(builder, field_init.period_token, .field);
-                try writeToken(builder, field_init.name_token, .field);
-                try writeToken(builder, field_init.name_token + 1, .operator);
-                try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, field_init.expr });
-            }
-            try gap_highlighter.end(struct_initializer.rtoken);
-        },
-        .Call => {
-            const call = node.cast(ast.Node.Call).?;
-            try writeToken(builder, call.async_token, .keyword);
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, call.lhs });
-            if (builder.current_token) |curr_tok| {
-                if (curr_tok != call.lhs.lastToken() and handle.tree.token_ids[call.lhs.lastToken()] == .Identifier) {
-                    try writeToken(builder, call.lhs.lastToken(), .function);
-                }
-            }
-            for (call.paramsConst()) |param| try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, param });
-        },
-        .Slice => {
-            const slice = node.castTag(.Slice).?;
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, slice.lhs });
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, slice.start });
-            try writeToken(builder, slice.start.lastToken() + 1, .operator);
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, slice.end });
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, slice.sentinel });
-        },
-        .ArrayAccess => {
-            const arr_acc = node.castTag(.ArrayAccess).?;
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, arr_acc.lhs });
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, arr_acc.index_expr });
-        },
-        .Deref, .UnwrapOptional => {
-            const suffix = node.cast(ast.Node.SimpleSuffixOp).?;
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, suffix.lhs });
-            try writeToken(builder, suffix.rtoken, .operator);
-        },
-        .GroupedExpression => {
-            const grouped_expr = node.cast(ast.Node.GroupedExpression).?;
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, grouped_expr.expr });
-        },
-        .Return, .Break, .Continue => {
-            const cfe = node.cast(ast.Node.ControlFlowExpression).?;
-            try writeToken(builder, cfe.ltoken, .keyword);
-            switch (node.tag) {
-                .Break => if (cfe.getLabel()) |n| try writeToken(builder, n, .label),
-                .Continue => if (cfe.getLabel()) |n| try writeToken(builder, n, .label),
-                else => {},
-            }
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, cfe.getRHS() });
-        },
-        .Suspend => {
-            const suspend_node = node.cast(ast.Node.Suspend).?;
-            try writeToken(builder, suspend_node.suspend_token, .keyword);
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, suspend_node.body });
-        },
-        .IntegerLiteral => {
-            try writeToken(builder, node.firstToken(), .number);
-        },
-        .EnumLiteral => {
-            const enum_literal = node.cast(ast.Node.EnumLiteral).?;
-            try writeToken(builder, enum_literal.dot, .enumMember);
-            try writeToken(builder, enum_literal.name, .enumMember);
-        },
-        .FloatLiteral => {
-            try writeToken(builder, node.firstToken(), .number);
-        },
-        .BuiltinCall => {
-            const builtin_call = node.cast(ast.Node.BuiltinCall).?;
-            try writeToken(builder, builtin_call.builtin_token, .builtin);
-            for (builtin_call.paramsConst()) |param|
-                try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, param });
-        },
-        .StringLiteral, .CharLiteral => {
-            try writeToken(builder, node.firstToken(), .string);
-        },
-        .MultilineStringLiteral => {
-            const multi_line = node.cast(ast.Node.MultilineStringLiteral).?;
-            for (multi_line.linesConst()) |line| try writeToken(builder, line, .string);
-        },
-        .BoolLiteral, .NullLiteral, .UndefinedLiteral, .Unreachable => {
-            try writeToken(builder, node.firstToken(), .keywordLiteral);
-        },
-        .ErrorType => {
-            try writeToken(builder, node.firstToken(), .keyword);
-        },
-        .Asm => {
-            const asm_expr = node.cast(ast.Node.Asm).?;
-            try writeToken(builder, asm_expr.asm_token, .keyword);
-            try writeToken(builder, asm_expr.volatile_token, .keyword);
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, asm_expr.template });
-            // TODO Inputs, outputs.
-        },
-        .AnyType => {
-            try writeToken(builder, node.firstToken(), .type);
-        },
-        .TestDecl => {
-            const test_decl = node.cast(ast.Node.TestDecl).?;
-            if (test_decl.doc_comments) |doc| try writeDocComments(builder, handle.tree, doc);
-            try writeToken(builder, test_decl.test_token, .keyword);
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, test_decl.name });
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, test_decl.body_node });
-        },
-        .Catch => {
-            const catch_expr = node.cast(ast.Node.Catch).?;
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, catch_expr.lhs });
-            try writeToken(builder, catch_expr.op_token, .keyword);
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, catch_expr.rhs });
-        },
-        .Add, .AddWrap, .ArrayCat, .ArrayMult, .Assign, .AssignBitAnd, .AssignBitOr, .AssignBitShiftLeft, .AssignBitShiftRight, .AssignBitXor, .AssignDiv, .AssignSub, .AssignSubWrap, .AssignMod, .AssignAdd, .AssignAddWrap, .AssignMul, .AssignMulWrap, .BangEqual, .BitAnd, .BitOr, .BitShiftLeft, .BitShiftRight, .BitXor, .BoolAnd, .BoolOr, .Div, .EqualEqual, .ErrorUnion, .GreaterOrEqual, .GreaterThan, .LessOrEqual, .LessThan, .MergeErrorSets, .Mod, .Mul, .MulWrap, .Period, .Range, .Sub, .SubWrap, .OrElse => {
-            const infix_op = node.cast(ast.Node.SimpleInfixOp).?;
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, infix_op.lhs });
-            if (node.tag != .Period) {
-                const token_type: TokenType = switch (node.tag) {
-                    .BoolAnd, .BoolOr, .OrElse => .keyword,
-                    else => .operator,
-                };
+//             switch (fn_proto.return_type) {
+//                 .Explicit => |type_expr| try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, type_expr }),
+//                 .InferErrorSet => |type_expr| {
+//                     try writeToken(builder, type_expr.firstToken() - 1, .operator);
+//                     try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, type_expr });
+//                 },
+//                 .Invalid => {},
+//             }
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, fn_proto.getBodyNode() });
+//         },
+//         .AnyFrameType => {
+//             const any_frame_type = node.cast(ast.Node.AnyFrameType).?;
+//             try writeToken(builder, any_frame_type.anyframe_token, .type);
+//             if (any_frame_type.result) |any_frame_result| {
+//                 try writeToken(builder, any_frame_result.arrow_token, .type);
+//                 try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, any_frame_result.return_type });
+//             }
+//         },
+//         .Defer => {
+//             const defer_node = node.cast(ast.Node.Defer).?;
+//             try writeToken(builder, defer_node.defer_token, .keyword);
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, defer_node.payload });
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, defer_node.expr });
+//         },
+//         .Comptime => {
+//             const comptime_node = node.cast(ast.Node.Comptime).?;
+//             if (comptime_node.doc_comments) |docs| try writeDocComments(builder, handle.tree, docs);
+//             try writeToken(builder, comptime_node.comptime_token, .keyword);
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, comptime_node.expr });
+//         },
+//         .Nosuspend => {
+//             const nosuspend_node = node.cast(ast.Node.Nosuspend).?;
+//             try writeToken(builder, nosuspend_node.nosuspend_token, .keyword);
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, nosuspend_node.expr });
+//         },
+//         .Payload => {
+//             const payload = node.cast(ast.Node.Payload).?;
+//             try writeToken(builder, payload.lpipe, .operator);
+//             try writeToken(builder, payload.error_symbol.firstToken(), .variable);
+//             try writeToken(builder, payload.rpipe, .operator);
+//         },
+//         .PointerPayload => {
+//             const payload = node.cast(ast.Node.PointerPayload).?;
+//             try writeToken(builder, payload.lpipe, .operator);
+//             try writeToken(builder, payload.ptr_token, .operator);
+//             try writeToken(builder, payload.value_symbol.firstToken(), .variable);
+//             try writeToken(builder, payload.rpipe, .operator);
+//         },
+//         .PointerIndexPayload => {
+//             const payload = node.cast(ast.Node.PointerIndexPayload).?;
+//             try writeToken(builder, payload.lpipe, .operator);
+//             try writeToken(builder, payload.ptr_token, .operator);
+//             try writeToken(builder, payload.value_symbol.firstToken(), .variable);
+//             if (payload.index_symbol) |index_symbol| try writeToken(builder, index_symbol.firstToken(), .variable);
+//             try writeToken(builder, payload.rpipe, .operator);
+//         },
+//         .Else => {
+//             const else_node = node.cast(ast.Node.Else).?;
+//             try writeToken(builder, else_node.else_token, .keyword);
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, else_node.payload });
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, else_node.body });
+//         },
+//         .Switch => {
+//             const switch_node = node.cast(ast.Node.Switch).?;
+//             try writeToken(builder, switch_node.switch_token, .keyword);
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, switch_node.expr });
 
-                try writeToken(builder, infix_op.op_token, token_type);
-                try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, infix_op.rhs });
-            }
-            switch (node.tag) {
-                .Period => {
-                    const rhs_str = handle.tree.tokenSlice(infix_op.rhs.firstToken());
+//             var gap_highlighter = GapHighlighter.init(builder, switch_node.expr.lastToken() + 3);
+//             for (switch_node.casesConst()) |case_node| {
+//                 try gap_highlighter.next(case_node);
+//                 try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, case_node });
+//             }
+//             try gap_highlighter.end(node.lastToken());
+//         },
+//         .SwitchCase => {
+//             const switch_case = node.cast(ast.Node.SwitchCase).?;
+//             for (switch_case.itemsConst()) |item_node| try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, item_node });
+//             try writeToken(builder, switch_case.arrow_token, .operator);
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, switch_case.payload });
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, switch_case.expr });
+//         },
+//         .SwitchElse => {
+//             const switch_else = node.cast(ast.Node.SwitchElse).?;
+//             try writeToken(builder, switch_else.token, .keyword);
+//         },
+//         .While => {
+//             const while_node = node.cast(ast.Node.While).?;
+//             try writeToken(builder, while_node.label, .label);
+//             try writeToken(builder, while_node.inline_token, .keyword);
+//             try writeToken(builder, while_node.while_token, .keyword);
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, while_node.condition });
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, while_node.payload });
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, while_node.continue_expr });
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, while_node.body });
+//             if (while_node.@"else") |else_node|
+//                 try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, &else_node.base });
+//         },
+//         .For => {
+//             const for_node = node.cast(ast.Node.For).?;
+//             try writeToken(builder, for_node.label, .label);
+//             try writeToken(builder, for_node.inline_token, .keyword);
+//             try writeToken(builder, for_node.for_token, .keyword);
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, for_node.array_expr });
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, for_node.payload });
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, for_node.body });
+//             if (for_node.@"else") |else_node|
+//                 try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, &else_node.base });
+//         },
+//         .If => {
+//             const if_node = node.cast(ast.Node.If).?;
+//             try writeToken(builder, if_node.if_token, .keyword);
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, if_node.condition });
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, if_node.payload });
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, if_node.body });
+//             if (if_node.@"else") |else_node|
+//                 try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, &else_node.base });
+//         },
+//         .ArrayInitializer => {
+//             const array_initializer = node.cast(ast.Node.ArrayInitializer).?;
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, array_initializer.lhs });
+//             for (array_initializer.listConst()) |elem| try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, elem });
+//         },
+//         .ArrayInitializerDot => {
+//             const array_initializer = node.cast(ast.Node.ArrayInitializerDot).?;
+//             for (array_initializer.listConst()) |elem| try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, elem });
+//         },
+//         .StructInitializer => {
+//             const struct_initializer = node.cast(ast.Node.StructInitializer).?;
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, struct_initializer.lhs });
+//             const field_token_type = if (try analysis.resolveTypeOfNode(store, arena, .{ .node = struct_initializer.lhs, .handle = handle })) |struct_type| switch (struct_type.type.data) {
+//                 .other => |type_node| if (type_node.cast(ast.Node.ContainerDecl)) |container_decl|
+//                     fieldTokenType(container_decl, handle)
+//                 else
+//                     null,
+//                 else => null,
+//             } else null;
 
-                    // TODO This is basically exactly the same as what is done in analysis.resolveTypeOfNode, with the added
-                    //      writeToken code.
-                    // Maybe we can hook into it insead? Also applies to Identifier and VarDecl
-                    var bound_type_params = analysis.BoundTypeParams.init(&arena.allocator);
-                    const lhs_type = try analysis.resolveFieldAccessLhsType(
-                        store,
-                        arena,
-                        (try analysis.resolveTypeOfNodeInternal(store, arena, .{
-                            .node = infix_op.lhs,
-                            .handle = handle,
-                        }, &bound_type_params)) orelse return,
-                        &bound_type_params,
-                    );
-                    const left_type_node = switch (lhs_type.type.data) {
-                        .other => |n| n,
-                        else => return,
-                    };
-                    if (try analysis.lookupSymbolContainer(store, arena, .{ .node = left_type_node, .handle = lhs_type.handle }, rhs_str, !lhs_type.type.is_type_val)) |decl_type| {
-                        switch (decl_type.decl.*) {
-                            .ast_node => |decl_node| {
-                                if (decl_node.tag == .ContainerField) {
-                                    const tok_type: ?TokenType = if (left_type_node.cast(ast.Node.ContainerDecl)) |container_decl|
-                                        fieldTokenType(container_decl, lhs_type.handle)
-                                    else if (left_type_node.tag == .Root)
-                                        TokenType.field
-                                    else
-                                        null;
+//             var gap_highlighter = GapHighlighter.init(builder, struct_initializer.lhs.lastToken() + 1);
+//             for (struct_initializer.listConst()) |field_init_node| {
+//                 try gap_highlighter.next(field_init_node);
+//                 std.debug.assert(field_init_node.tag == .FieldInitializer);
+//                 const field_init = field_init_node.cast(ast.Node.FieldInitializer).?;
+//                 if (field_token_type) |tok_type| {
+//                     try writeToken(builder, field_init.period_token, tok_type);
+//                     try writeToken(builder, field_init.name_token, tok_type);
+//                 }
+//                 try writeToken(builder, field_init.name_token + 1, .operator);
+//                 try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, field_init.expr });
+//             }
+//             try gap_highlighter.end(struct_initializer.rtoken);
+//         },
+//         .StructInitializerDot => {
+//             const struct_initializer = node.castTag(.StructInitializerDot).?;
 
-                                    if (tok_type) |tt| try writeToken(builder, infix_op.rhs.firstToken(), tt);
-                                    return;
-                                } else if (decl_node.tag == .ErrorTag) {
-                                    try writeToken(builder, infix_op.rhs.firstToken(), .errorTag);
-                                }
-                            },
-                            else => {},
-                        }
+//             var gap_highlighter = GapHighlighter.init(builder, struct_initializer.dot + 1);
+//             for (struct_initializer.listConst()) |field_init_node| {
+//                 try gap_highlighter.next(field_init_node);
+//                 std.debug.assert(field_init_node.tag == .FieldInitializer);
+//                 const field_init = field_init_node.castTag(.FieldInitializer).?;
+//                 try writeToken(builder, field_init.period_token, .field);
+//                 try writeToken(builder, field_init.name_token, .field);
+//                 try writeToken(builder, field_init.name_token + 1, .operator);
+//                 try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, field_init.expr });
+//             }
+//             try gap_highlighter.end(struct_initializer.rtoken);
+//         },
+//         .Call => {
+//             const call = node.cast(ast.Node.Call).?;
+//             try writeToken(builder, call.async_token, .keyword);
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, call.lhs });
+//             if (builder.current_token) |curr_tok| {
+//                 if (curr_tok != call.lhs.lastToken() and handle.tree.token_ids[call.lhs.lastToken()] == .Identifier) {
+//                     try writeToken(builder, call.lhs.lastToken(), .function);
+//                 }
+//             }
+//             for (call.paramsConst()) |param| try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, param });
+//         },
+//         .Slice => {
+//             const slice = node.castTag(.Slice).?;
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, slice.lhs });
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, slice.start });
+//             try writeToken(builder, slice.start.lastToken() + 1, .operator);
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, slice.end });
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, slice.sentinel });
+//         },
+//         .ArrayAccess => {
+//             const arr_acc = node.castTag(.ArrayAccess).?;
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, arr_acc.lhs });
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, arr_acc.index_expr });
+//         },
+//         .Deref, .UnwrapOptional => {
+//             const suffix = node.cast(ast.Node.SimpleSuffixOp).?;
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, suffix.lhs });
+//             try writeToken(builder, suffix.rtoken, .operator);
+//         },
+//         .GroupedExpression => {
+//             const grouped_expr = node.cast(ast.Node.GroupedExpression).?;
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, grouped_expr.expr });
+//         },
+//         .Return, .Break, .Continue => {
+//             const cfe = node.cast(ast.Node.ControlFlowExpression).?;
+//             try writeToken(builder, cfe.ltoken, .keyword);
+//             switch (node.tag) {
+//                 .Break => if (cfe.getLabel()) |n| try writeToken(builder, n, .label),
+//                 .Continue => if (cfe.getLabel()) |n| try writeToken(builder, n, .label),
+//                 else => {},
+//             }
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, cfe.getRHS() });
+//         },
+//         .Suspend => {
+//             const suspend_node = node.cast(ast.Node.Suspend).?;
+//             try writeToken(builder, suspend_node.suspend_token, .keyword);
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, suspend_node.body });
+//         },
+//         .IntegerLiteral => {
+//             try writeToken(builder, node.firstToken(), .number);
+//         },
+//         .EnumLiteral => {
+//             const enum_literal = node.cast(ast.Node.EnumLiteral).?;
+//             try writeToken(builder, enum_literal.dot, .enumMember);
+//             try writeToken(builder, enum_literal.name, .enumMember);
+//         },
+//         .FloatLiteral => {
+//             try writeToken(builder, node.firstToken(), .number);
+//         },
+//         .BuiltinCall => {
+//             const builtin_call = node.cast(ast.Node.BuiltinCall).?;
+//             try writeToken(builder, builtin_call.builtin_token, .builtin);
+//             for (builtin_call.paramsConst()) |param|
+//                 try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, param });
+//         },
+//         .StringLiteral, .CharLiteral => {
+//             try writeToken(builder, node.firstToken(), .string);
+//         },
+//         .MultilineStringLiteral => {
+//             const multi_line = node.cast(ast.Node.MultilineStringLiteral).?;
+//             for (multi_line.linesConst()) |line| try writeToken(builder, line, .string);
+//         },
+//         .BoolLiteral, .NullLiteral, .UndefinedLiteral, .Unreachable => {
+//             try writeToken(builder, node.firstToken(), .keywordLiteral);
+//         },
+//         .ErrorType => {
+//             try writeToken(builder, node.firstToken(), .keyword);
+//         },
+//         .Asm => {
+//             const asm_expr = node.cast(ast.Node.Asm).?;
+//             try writeToken(builder, asm_expr.asm_token, .keyword);
+//             try writeToken(builder, asm_expr.volatile_token, .keyword);
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, asm_expr.template });
+//             // TODO Inputs, outputs.
+//         },
+//         .AnyType => {
+//             try writeToken(builder, node.firstToken(), .type);
+//         },
+//         .TestDecl => {
+//             const test_decl = node.cast(ast.Node.TestDecl).?;
+//             if (test_decl.doc_comments) |doc| try writeDocComments(builder, handle.tree, doc);
+//             try writeToken(builder, test_decl.test_token, .keyword);
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, test_decl.name });
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, test_decl.body_node });
+//         },
+//         .Catch => {
+//             const catch_expr = node.cast(ast.Node.Catch).?;
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, catch_expr.lhs });
+//             try writeToken(builder, catch_expr.op_token, .keyword);
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, catch_expr.rhs });
+//         },
+//         .Add, .AddWrap, .ArrayCat, .ArrayMult, .Assign, .AssignBitAnd, .AssignBitOr, .AssignBitShiftLeft, .AssignBitShiftRight, .AssignBitXor, .AssignDiv, .AssignSub, .AssignSubWrap, .AssignMod, .AssignAdd, .AssignAddWrap, .AssignMul, .AssignMulWrap, .BangEqual, .BitAnd, .BitOr, .BitShiftLeft, .BitShiftRight, .BitXor, .BoolAnd, .BoolOr, .Div, .EqualEqual, .ErrorUnion, .GreaterOrEqual, .GreaterThan, .LessOrEqual, .LessThan, .MergeErrorSets, .Mod, .Mul, .MulWrap, .Period, .Range, .Sub, .SubWrap, .OrElse => {
+//             const infix_op = node.cast(ast.Node.SimpleInfixOp).?;
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, infix_op.lhs });
+//             if (node.tag != .Period) {
+//                 const token_type: TokenType = switch (node.tag) {
+//                     .BoolAnd, .BoolOr, .OrElse => .keyword,
+//                     else => .operator,
+//                 };
 
-                        if (try decl_type.resolveType(store, arena, &bound_type_params)) |resolved_type| {
-                            try colorIdentifierBasedOnType(builder, resolved_type, infix_op.rhs.firstToken(), .{});
-                        }
-                    }
-                },
-                else => {},
-            }
-        },
-        .SliceType => {
-            const slice_type = node.castTag(.SliceType).?;
-            const ptr_info = slice_type.ptr_info;
-            if (ptr_info.align_info) |align_info| {
-                try writeToken(builder, slice_type.op_token + 2, .keyword);
-                try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, align_info.node });
-            }
-            try writeToken(builder, ptr_info.const_token, .keyword);
-            try writeToken(builder, ptr_info.volatile_token, .keyword);
-            try writeToken(builder, ptr_info.allowzero_token, .keyword);
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, slice_type.rhs });
-        },
-        .PtrType => {
-            const pointer_type = node.castTag(.PtrType).?;
-            const tok_ids = builder.handle.tree.token_ids;
+//                 try writeToken(builder, infix_op.op_token, token_type);
+//                 try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, infix_op.rhs });
+//             }
+//             switch (node.tag) {
+//                 .Period => {
+//                     const rhs_str = handle.tree.tokenSlice(infix_op.rhs.firstToken());
 
-            const ptr_info = switch (tok_ids[pointer_type.op_token]) {
-                .AsteriskAsterisk => pointer_type.rhs.castTag(.PtrType).?.ptr_info,
-                else => pointer_type.ptr_info,
-            };
-            const rhs = switch (tok_ids[pointer_type.op_token]) {
-                .AsteriskAsterisk => pointer_type.rhs.castTag(.PtrType).?.rhs,
-                else => pointer_type.rhs,
-            };
+//                     // TODO This is basically exactly the same as what is done in analysis.resolveTypeOfNode, with the added
+//                     //      writeToken code.
+//                     // Maybe we can hook into it insead? Also applies to Identifier and VarDecl
+//                     var bound_type_params = analysis.BoundTypeParams.init(&arena.allocator);
+//                     const lhs_type = try analysis.resolveFieldAccessLhsType(
+//                         store,
+//                         arena,
+//                         (try analysis.resolveTypeOfNodeInternal(store, arena, .{
+//                             .node = infix_op.lhs,
+//                             .handle = handle,
+//                         }, &bound_type_params)) orelse return,
+//                         &bound_type_params,
+//                     );
+//                     const left_type_node = switch (lhs_type.type.data) {
+//                         .other => |n| n,
+//                         else => return,
+//                     };
+//                     if (try analysis.lookupSymbolContainer(store, arena, .{ .node = left_type_node, .handle = lhs_type.handle }, rhs_str, !lhs_type.type.is_type_val)) |decl_type| {
+//                         switch (decl_type.decl.*) {
+//                             .ast_node => |decl_node| {
+//                                 if (decl_node.tag == .ContainerField) {
+//                                     const tok_type: ?TokenType = if (left_type_node.cast(ast.Node.ContainerDecl)) |container_decl|
+//                                         fieldTokenType(container_decl, lhs_type.handle)
+//                                     else if (left_type_node.tag == .Root)
+//                                         TokenType.field
+//                                     else
+//                                         null;
 
-            const off = switch (tok_ids[pointer_type.op_token]) {
-                .Asterisk, .AsteriskAsterisk => blk: {
-                    try writeToken(builder, pointer_type.op_token, .operator);
-                    break :blk pointer_type.op_token + 1;
-                },
-                .LBracket => blk: {
-                    try writeToken(builder, pointer_type.op_token + 1, .operator);
-                    const is_c_ptr = tok_ids[pointer_type.op_token + 2] == .Identifier;
+//                                     if (tok_type) |tt| try writeToken(builder, infix_op.rhs.firstToken(), tt);
+//                                     return;
+//                                 } else if (decl_node.tag == .ErrorTag) {
+//                                     try writeToken(builder, infix_op.rhs.firstToken(), .errorTag);
+//                                 }
+//                             },
+//                             else => {},
+//                         }
 
-                    if (is_c_ptr) {
-                        try writeToken(builder, pointer_type.op_token + 2, .operator);
-                    }
+//                         if (try decl_type.resolveType(store, arena, &bound_type_params)) |resolved_type| {
+//                             try colorIdentifierBasedOnType(builder, resolved_type, infix_op.rhs.firstToken(), .{});
+//                         }
+//                     }
+//                 },
+//                 else => {},
+//             }
+//         },
+//         .SliceType => {
+//             const slice_type = node.castTag(.SliceType).?;
+//             const ptr_info = slice_type.ptr_info;
+//             if (ptr_info.align_info) |align_info| {
+//                 try writeToken(builder, slice_type.op_token + 2, .keyword);
+//                 try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, align_info.node });
+//             }
+//             try writeToken(builder, ptr_info.const_token, .keyword);
+//             try writeToken(builder, ptr_info.volatile_token, .keyword);
+//             try writeToken(builder, ptr_info.allowzero_token, .keyword);
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, slice_type.rhs });
+//         },
+//         .PtrType => {
+//             const pointer_type = node.castTag(.PtrType).?;
+//             const tok_ids = builder.handle.tree.token_ids;
 
-                    if (ptr_info.sentinel) |sentinel| {
-                        try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, sentinel });
-                        break :blk sentinel.lastToken() + 2;
-                    }
+//             const ptr_info = switch (tok_ids[pointer_type.op_token]) {
+//                 .AsteriskAsterisk => pointer_type.rhs.castTag(.PtrType).?.ptr_info,
+//                 else => pointer_type.ptr_info,
+//             };
+//             const rhs = switch (tok_ids[pointer_type.op_token]) {
+//                 .AsteriskAsterisk => pointer_type.rhs.castTag(.PtrType).?.rhs,
+//                 else => pointer_type.rhs,
+//             };
 
-                    break :blk pointer_type.op_token + 3 + @boolToInt(is_c_ptr);
-                },
-                else => 0,
-            };
+//             const off = switch (tok_ids[pointer_type.op_token]) {
+//                 .Asterisk, .AsteriskAsterisk => blk: {
+//                     try writeToken(builder, pointer_type.op_token, .operator);
+//                     break :blk pointer_type.op_token + 1;
+//                 },
+//                 .LBracket => blk: {
+//                     try writeToken(builder, pointer_type.op_token + 1, .operator);
+//                     const is_c_ptr = tok_ids[pointer_type.op_token + 2] == .Identifier;
 
-            if (ptr_info.align_info) |align_info| {
-                try writeToken(builder, off, .keyword);
-                try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, align_info.node });
-            }
-            try writeToken(builder, ptr_info.const_token, .keyword);
-            try writeToken(builder, ptr_info.volatile_token, .keyword);
-            try writeToken(builder, ptr_info.allowzero_token, .keyword);
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, rhs });
-        },
-        .ArrayType => {
-            const array_type = node.castTag(.ArrayType).?;
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, array_type.len_expr });
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, array_type.rhs });
-        },
-        .ArrayTypeSentinel => {
-            const array_type = node.castTag(.ArrayTypeSentinel).?;
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, array_type.len_expr });
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, array_type.sentinel });
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, array_type.rhs });
-        },
-        .AddressOf, .Await, .BitNot, .BoolNot, .OptionalType, .Negation, .NegationWrap, .Resume, .Try => {
-            const prefix_op = node.cast(ast.Node.SimplePrefixOp).?;
-            const tok_type: TokenType = switch (node.tag) {
-                .Try, .Await, .Resume => .keyword,
-                else => .operator,
-            };
-            try writeToken(builder, prefix_op.op_token, tok_type);
-            try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, prefix_op.rhs });
-        },
-        else => {},
-    }
-}
+//                     if (is_c_ptr) {
+//                         try writeToken(builder, pointer_type.op_token + 2, .operator);
+//                     }
+
+//                     if (ptr_info.sentinel) |sentinel| {
+//                         try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, sentinel });
+//                         break :blk sentinel.lastToken() + 2;
+//                     }
+
+//                     break :blk pointer_type.op_token + 3 + @boolToInt(is_c_ptr);
+//                 },
+//                 else => 0,
+//             };
+
+//             if (ptr_info.align_info) |align_info| {
+//                 try writeToken(builder, off, .keyword);
+//                 try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, align_info.node });
+//             }
+//             try writeToken(builder, ptr_info.const_token, .keyword);
+//             try writeToken(builder, ptr_info.volatile_token, .keyword);
+//             try writeToken(builder, ptr_info.allowzero_token, .keyword);
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, rhs });
+//         },
+//         .ArrayType => {
+//             const array_type = node.castTag(.ArrayType).?;
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, array_type.len_expr });
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, array_type.rhs });
+//         },
+//         .ArrayTypeSentinel => {
+//             const array_type = node.castTag(.ArrayTypeSentinel).?;
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, array_type.len_expr });
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, array_type.sentinel });
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, array_type.rhs });
+//         },
+//         .AddressOf, .Await, .BitNot, .BoolNot, .OptionalType, .Negation, .NegationWrap, .Resume, .Try => {
+//             const prefix_op = node.cast(ast.Node.SimplePrefixOp).?;
+//             const tok_type: TokenType = switch (node.tag) {
+//                 .Try, .Await, .Resume => .keyword,
+//                 else => .operator,
+//             };
+//             try writeToken(builder, prefix_op.op_token, tok_type);
+//             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, prefix_op.rhs });
+//         },
+//         else => {},
+//     }
+// }
 
 // TODO Range version, edit version.
 pub fn writeAllSemanticTokens(arena: *std.heap.ArenaAllocator, store: *DocumentStore, handle: *DocumentStore.Handle, encoding: offsets.Encoding) ![]u32 {
     var builder = Builder.init(arena.child_allocator, handle, encoding);
-    try writeNodeTokens(&builder, arena, store, &handle.tree.root_node.base);
+    // pass root node, which always has index '0'
+    // try writeNodeTokens(&builder, arena, store, 0, handle.tree);
     return builder.toOwnedSlice();
 }

--- a/tests/sessions.zig
+++ b/tests/sessions.zig
@@ -4,13 +4,16 @@ const headerPkg = @import("header");
 const suffix = if (std.builtin.os.tag == .windows) ".exe" else "";
 const allocator = std.heap.page_allocator;
 
-const initialize_message = \\{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"processId":6896,"clientInfo":{"name":"vscode","version":"1.46.1"},"rootPath":null,"rootUri":null,"capabilities":{"workspace":{"applyEdit":true,"workspaceEdit":{"documentChanges":true,"resourceOperations":["create","rename","delete"],"failureHandling":"textOnlyTransactional"},"didChangeConfiguration":{"dynamicRegistration":true},"didChangeWatchedFiles":{"dynamicRegistration":true},"symbol":{"dynamicRegistration":true,"symbolKind":{"valueSet":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26]},"tagSupport":{"valueSet":[1]}},"executeCommand":{"dynamicRegistration":true},"configuration":true,"workspaceFolders":true},"textDocument":{"publishDiagnostics":{"relatedInformation":true,"versionSupport":false,"tagSupport":{"valueSet":[1,2]},"complexDiagnosticCodeSupport":true},"synchronization":{"dynamicRegistration":true,"willSave":true,"willSaveWaitUntil":true,"didSave":true},"completion":{"dynamicRegistration":true,"contextSupport":true,"completionItem":{"snippetSupport":true,"commitCharactersSupport":true,"documentationFormat":["markdown","plaintext"],"deprecatedSupport":true,"preselectSupport":true,"tagSupport":{"valueSet":[1]},"insertReplaceSupport":true},"completionItemKind":{"valueSet":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25]}},"hover":{"dynamicRegistration":true,"contentFormat":["markdown","plaintext"]},"signatureHelp":{"dynamicRegistration":true,"signatureInformation":{"documentationFormat":["markdown","plaintext"],"parameterInformation":{"labelOffsetSupport":true}},"contextSupport":true},"definition":{"dynamicRegistration":true,"linkSupport":true},"references":{"dynamicRegistration":true},"documentHighlight":{"dynamicRegistration":true},"documentSymbol":{"dynamicRegistration":true,"symbolKind":{"valueSet":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26]},"hierarchicalDocumentSymbolSupport":true,"tagSupport":{"valueSet":[1]}},"codeAction":{"dynamicRegistration":true,"isPreferredSupport":true,"codeActionLiteralSupport":{"codeActionKind":{"valueSet":["","quickfix","refactor","refactor.extract","refactor.inline","refactor.rewrite","source","source.organizeImports"]}}},"codeLens":{"dynamicRegistration":true},"formatting":{"dynamicRegistration":true},"rangeFormatting":{"dynamicRegistration":true},"onTypeFormatting":{"dynamicRegistration":true},"rename":{"dynamicRegistration":true,"prepareSupport":true},"documentLink":{"dynamicRegistration":true,"tooltipSupport":true},"typeDefinition":{"dynamicRegistration":true,"linkSupport":true},"implementation":{"dynamicRegistration":true,"linkSupport":true},"colorProvider":{"dynamicRegistration":true},"foldingRange":{"dynamicRegistration":true,"rangeLimit":5000,"lineFoldingOnly":true},"declaration":{"dynamicRegistration":true,"linkSupport":true},"selectionRange":{"dynamicRegistration":true},"semanticTokens":{"dynamicRegistration":true,"tokenTypes":["comment","keyword","number","regexp","operator","namespace","type","struct","class","interface","enum","typeParameter","function","member","macro","variable","parameter","property","label"],"tokenModifiers":["declaration","documentation","static","abstract","deprecated","readonly"]}},"window":{"workDoneProgress":true}},"trace":"off","workspaceFolders":[{"uri":"file://./tests", "name":"root"}]}}
+const initialize_message =
+    \\{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"processId":6896,"clientInfo":{"name":"vscode","version":"1.46.1"},"rootPath":null,"rootUri":null,"capabilities":{"workspace":{"applyEdit":true,"workspaceEdit":{"documentChanges":true,"resourceOperations":["create","rename","delete"],"failureHandling":"textOnlyTransactional"},"didChangeConfiguration":{"dynamicRegistration":true},"didChangeWatchedFiles":{"dynamicRegistration":true},"symbol":{"dynamicRegistration":true,"symbolKind":{"valueSet":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26]},"tagSupport":{"valueSet":[1]}},"executeCommand":{"dynamicRegistration":true},"configuration":true,"workspaceFolders":true},"textDocument":{"publishDiagnostics":{"relatedInformation":true,"versionSupport":false,"tagSupport":{"valueSet":[1,2]},"complexDiagnosticCodeSupport":true},"synchronization":{"dynamicRegistration":true,"willSave":true,"willSaveWaitUntil":true,"didSave":true},"completion":{"dynamicRegistration":true,"contextSupport":true,"completionItem":{"snippetSupport":true,"commitCharactersSupport":true,"documentationFormat":["markdown","plaintext"],"deprecatedSupport":true,"preselectSupport":true,"tagSupport":{"valueSet":[1]},"insertReplaceSupport":true},"completionItemKind":{"valueSet":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25]}},"hover":{"dynamicRegistration":true,"contentFormat":["markdown","plaintext"]},"signatureHelp":{"dynamicRegistration":true,"signatureInformation":{"documentationFormat":["markdown","plaintext"],"parameterInformation":{"labelOffsetSupport":true}},"contextSupport":true},"definition":{"dynamicRegistration":true,"linkSupport":true},"references":{"dynamicRegistration":true},"documentHighlight":{"dynamicRegistration":true},"documentSymbol":{"dynamicRegistration":true,"symbolKind":{"valueSet":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26]},"hierarchicalDocumentSymbolSupport":true,"tagSupport":{"valueSet":[1]}},"codeAction":{"dynamicRegistration":true,"isPreferredSupport":true,"codeActionLiteralSupport":{"codeActionKind":{"valueSet":["","quickfix","refactor","refactor.extract","refactor.inline","refactor.rewrite","source","source.organizeImports"]}}},"codeLens":{"dynamicRegistration":true},"formatting":{"dynamicRegistration":true},"rangeFormatting":{"dynamicRegistration":true},"onTypeFormatting":{"dynamicRegistration":true},"rename":{"dynamicRegistration":true,"prepareSupport":true},"documentLink":{"dynamicRegistration":true,"tooltipSupport":true},"typeDefinition":{"dynamicRegistration":true,"linkSupport":true},"implementation":{"dynamicRegistration":true,"linkSupport":true},"colorProvider":{"dynamicRegistration":true},"foldingRange":{"dynamicRegistration":true,"rangeLimit":5000,"lineFoldingOnly":true},"declaration":{"dynamicRegistration":true,"linkSupport":true},"selectionRange":{"dynamicRegistration":true},"semanticTokens":{"dynamicRegistration":true,"tokenTypes":["comment","keyword","number","regexp","operator","namespace","type","struct","class","interface","enum","typeParameter","function","member","macro","variable","parameter","property","label"],"tokenModifiers":["declaration","documentation","static","abstract","deprecated","readonly"]}},"window":{"workDoneProgress":true}},"trace":"off","workspaceFolders":[{"uri":"file://./tests", "name":"root"}]}}
 ;
 
-const initialized_message = \\{"jsonrpc":"2.0","method":"initialized","params":{}}
+const initialized_message =
+    \\{"jsonrpc":"2.0","method":"initialized","params":{}}
 ;
 
-const shutdown_message = \\{"jsonrpc":"2.0", "id":"STDWN", "method":"shutdown","params":{}}
+const shutdown_message =
+    \\{"jsonrpc":"2.0", "id":"STDWN", "method":"shutdown","params":{}}
 ;
 
 fn sendRequest(req: []const u8, process: *std.ChildProcess) !void {
@@ -22,7 +25,7 @@ fn readResponses(process: *std.ChildProcess, expected_responses: anytype) !void 
     var seen = std.mem.zeroes([expected_responses.len]bool);
     while (true) {
         const header = headerPkg.readRequestHeader(allocator, process.stdout.?.reader()) catch |err| {
-            switch(err) {
+            switch (err) {
                 error.EndOfStream => break,
                 else => return err,
             }
@@ -52,7 +55,7 @@ fn readResponses(process: *std.ChildProcess, expected_responses: anytype) !void 
 }
 
 fn startZls() !*std.ChildProcess {
-    var process = try std.ChildProcess.init(&[_][]const u8{ "zig-cache/bin/zls" ++ suffix }, allocator);
+    var process = try std.ChildProcess.init(&[_][]const u8{"zig-cache/bin/zls" ++ suffix}, allocator);
     process.stdin_behavior = .Pipe;
     process.stdout_behavior = .Pipe;
     process.stderr_behavior = std.ChildProcess.StdIo.Inherit;
@@ -89,10 +92,12 @@ test "Open file, ask for semantic tokens" {
     try sendRequest(initialize_message, process);
     try sendRequest(initialized_message, process);
 
-    const new_file_req = \\{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"file://./tests/test.zig","languageId":"zig","version":420,"text":"const std = @import(\"std\");"}}}
+    const new_file_req =
+        \\{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"file://./tests/test.zig","languageId":"zig","version":420,"text":"const std = @import(\"std\");"}}}
     ;
     try sendRequest(new_file_req, process);
-    const sem_toks_req = \\{"jsonrpc":"2.0","id":2,"method":"textDocument/semanticTokens/full","params":{"textDocument":{"uri":"file://./tests/test.zig"}}}
+    const sem_toks_req =
+        \\{"jsonrpc":"2.0","id":2,"method":"textDocument/semanticTokens/full","params":{"textDocument":{"uri":"file://./tests/test.zig"}}}
     ;
     try sendRequest(sem_toks_req, process);
     try sendRequest(shutdown_message, process);
@@ -106,10 +111,12 @@ test "Requesting a completion in an empty file" {
     try sendRequest(initialize_message, process);
     try sendRequest(initialized_message, process);
 
-    const new_file_req = \\{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"file:///test.zig","languageId":"zig","version":420,"text":""}}}
+    const new_file_req =
+        \\{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"file:///test.zig","languageId":"zig","version":420,"text":""}}}
     ;
     try sendRequest(new_file_req, process);
-    const completion_req = \\{"jsonrpc":"2.0","id":2,"method":"textDocument/completion","params":{"textDocument":{"uri":"file:///test.zig"}, "position":{"line":0,"character":0}}}
+    const completion_req =
+        \\{"jsonrpc":"2.0","id":2,"method":"textDocument/completion","params":{"textDocument":{"uri":"file:///test.zig"}, "position":{"line":0,"character":0}}}
     ;
     try sendRequest(completion_req, process);
     try sendRequest(shutdown_message, process);
@@ -121,19 +128,22 @@ test "Requesting a completion with no trailing whitespace" {
     try sendRequest(initialize_message, process);
     try sendRequest(initialized_message, process);
 
-    const new_file_req = \\{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"file:///test.zig","languageId":"zig","version":420,"text":"const std = @import(\"std\");\nc"}}}
+    const new_file_req =
+        \\{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"file:///test.zig","languageId":"zig","version":420,"text":"const std = @import(\"std\");\nc"}}}
     ;
     try sendRequest(new_file_req, process);
-    const completion_req = \\{"jsonrpc":"2.0","id":2,"method":"textDocument/completion","params":{"textDocument":{"uri":"file:///test.zig"}, "position":{"line":1,"character":1}}}
+    const completion_req =
+        \\{"jsonrpc":"2.0","id":2,"method":"textDocument/completion","params":{"textDocument":{"uri":"file:///test.zig"}, "position":{"line":1,"character":1}}}
     ;
     try sendRequest(completion_req, process);
     try sendRequest(shutdown_message, process);
     try consumeOutputAndWait(process, .{
-        \\{"jsonrpc":"2.0","id":2,"result":{"isIncomplete":false,"items":[]}}
+        \\{"jsonrpc":"2.0","id":2,"result":{"isIncomplete":false,"items":[{"label":"std","kind":21,"textEdit":null,"filterText":null,"insertText":null,"insertTextFormat":1,"detail":"const std = @import(\"std\")","documentation":null}]}}
     });
 }
 
-const initialize_message_offs = \\{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"processId":6896,"clientInfo":{"name":"vscode","version":"1.46.1"},"rootPath":null,"rootUri":null,"capabilities":{"offsetEncoding":["utf-16", "utf-8"],"workspace":{"applyEdit":true,"workspaceEdit":{"documentChanges":true,"resourceOperations":["create","rename","delete"],"failureHandling":"textOnlyTransactional"},"didChangeConfiguration":{"dynamicRegistration":true},"didChangeWatchedFiles":{"dynamicRegistration":true},"symbol":{"dynamicRegistration":true,"symbolKind":{"valueSet":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26]},"tagSupport":{"valueSet":[1]}},"executeCommand":{"dynamicRegistration":true},"configuration":true,"workspaceFolders":true},"textDocument":{"publishDiagnostics":{"relatedInformation":true,"versionSupport":false,"tagSupport":{"valueSet":[1,2]},"complexDiagnosticCodeSupport":true},"synchronization":{"dynamicRegistration":true,"willSave":true,"willSaveWaitUntil":true,"didSave":true},"completion":{"dynamicRegistration":true,"contextSupport":true,"completionItem":{"snippetSupport":true,"commitCharactersSupport":true,"documentationFormat":["markdown","plaintext"],"deprecatedSupport":true,"preselectSupport":true,"tagSupport":{"valueSet":[1]},"insertReplaceSupport":true},"completionItemKind":{"valueSet":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25]}},"hover":{"dynamicRegistration":true,"contentFormat":["markdown","plaintext"]},"signatureHelp":{"dynamicRegistration":true,"signatureInformation":{"documentationFormat":["markdown","plaintext"],"parameterInformation":{"labelOffsetSupport":true}},"contextSupport":true},"definition":{"dynamicRegistration":true,"linkSupport":true},"references":{"dynamicRegistration":true},"documentHighlight":{"dynamicRegistration":true},"documentSymbol":{"dynamicRegistration":true,"symbolKind":{"valueSet":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26]},"hierarchicalDocumentSymbolSupport":true,"tagSupport":{"valueSet":[1]}},"codeAction":{"dynamicRegistration":true,"isPreferredSupport":true,"codeActionLiteralSupport":{"codeActionKind":{"valueSet":["","quickfix","refactor","refactor.extract","refactor.inline","refactor.rewrite","source","source.organizeImports"]}}},"codeLens":{"dynamicRegistration":true},"formatting":{"dynamicRegistration":true},"rangeFormatting":{"dynamicRegistration":true},"onTypeFormatting":{"dynamicRegistration":true},"rename":{"dynamicRegistration":true,"prepareSupport":true},"documentLink":{"dynamicRegistration":true,"tooltipSupport":true},"typeDefinition":{"dynamicRegistration":true,"linkSupport":true},"implementation":{"dynamicRegistration":true,"linkSupport":true},"colorProvider":{"dynamicRegistration":true},"foldingRange":{"dynamicRegistration":true,"rangeLimit":5000,"lineFoldingOnly":true},"declaration":{"dynamicRegistration":true,"linkSupport":true},"selectionRange":{"dynamicRegistration":true},"semanticTokens":{"dynamicRegistration":true,"tokenTypes":["comment","keyword","number","regexp","operator","namespace","type","struct","class","interface","enum","typeParameter","function","member","macro","variable","parameter","property","label"],"tokenModifiers":["declaration","documentation","static","abstract","deprecated","readonly"]}},"window":{"workDoneProgress":true}},"trace":"off","workspaceFolders":null}}
+const initialize_message_offs =
+    \\{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"processId":6896,"clientInfo":{"name":"vscode","version":"1.46.1"},"rootPath":null,"rootUri":null,"capabilities":{"offsetEncoding":["utf-16", "utf-8"],"workspace":{"applyEdit":true,"workspaceEdit":{"documentChanges":true,"resourceOperations":["create","rename","delete"],"failureHandling":"textOnlyTransactional"},"didChangeConfiguration":{"dynamicRegistration":true},"didChangeWatchedFiles":{"dynamicRegistration":true},"symbol":{"dynamicRegistration":true,"symbolKind":{"valueSet":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26]},"tagSupport":{"valueSet":[1]}},"executeCommand":{"dynamicRegistration":true},"configuration":true,"workspaceFolders":true},"textDocument":{"publishDiagnostics":{"relatedInformation":true,"versionSupport":false,"tagSupport":{"valueSet":[1,2]},"complexDiagnosticCodeSupport":true},"synchronization":{"dynamicRegistration":true,"willSave":true,"willSaveWaitUntil":true,"didSave":true},"completion":{"dynamicRegistration":true,"contextSupport":true,"completionItem":{"snippetSupport":true,"commitCharactersSupport":true,"documentationFormat":["markdown","plaintext"],"deprecatedSupport":true,"preselectSupport":true,"tagSupport":{"valueSet":[1]},"insertReplaceSupport":true},"completionItemKind":{"valueSet":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25]}},"hover":{"dynamicRegistration":true,"contentFormat":["markdown","plaintext"]},"signatureHelp":{"dynamicRegistration":true,"signatureInformation":{"documentationFormat":["markdown","plaintext"],"parameterInformation":{"labelOffsetSupport":true}},"contextSupport":true},"definition":{"dynamicRegistration":true,"linkSupport":true},"references":{"dynamicRegistration":true},"documentHighlight":{"dynamicRegistration":true},"documentSymbol":{"dynamicRegistration":true,"symbolKind":{"valueSet":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26]},"hierarchicalDocumentSymbolSupport":true,"tagSupport":{"valueSet":[1]}},"codeAction":{"dynamicRegistration":true,"isPreferredSupport":true,"codeActionLiteralSupport":{"codeActionKind":{"valueSet":["","quickfix","refactor","refactor.extract","refactor.inline","refactor.rewrite","source","source.organizeImports"]}}},"codeLens":{"dynamicRegistration":true},"formatting":{"dynamicRegistration":true},"rangeFormatting":{"dynamicRegistration":true},"onTypeFormatting":{"dynamicRegistration":true},"rename":{"dynamicRegistration":true,"prepareSupport":true},"documentLink":{"dynamicRegistration":true,"tooltipSupport":true},"typeDefinition":{"dynamicRegistration":true,"linkSupport":true},"implementation":{"dynamicRegistration":true,"linkSupport":true},"colorProvider":{"dynamicRegistration":true},"foldingRange":{"dynamicRegistration":true,"rangeLimit":5000,"lineFoldingOnly":true},"declaration":{"dynamicRegistration":true,"linkSupport":true},"selectionRange":{"dynamicRegistration":true},"semanticTokens":{"dynamicRegistration":true,"tokenTypes":["comment","keyword","number","regexp","operator","namespace","type","struct","class","interface","enum","typeParameter","function","member","macro","variable","parameter","property","label"],"tokenModifiers":["declaration","documentation","static","abstract","deprecated","readonly"]}},"window":{"workDoneProgress":true}},"trace":"off","workspaceFolders":null}}
 ;
 
 test "Requesting utf-8 offset encoding" {


### PR DESCRIPTION
Started updating zls to use the new AST that was introduced in https://github.com/ziglang/zig/pull/7920
I hope to get this finished quickly so people can update to the latest master again.
Perhaps we should consider creating a new binary release after this as well.

Will fix : 
- fixes #237 
- fixes #152
- fixes #157
- fixes #153
- fixes #150
- fixes #242
- fixes #244

This also introduces a new option to `zls.json`, allowing the server to skip finding for references in std. 
This means that when searching for references of a user's function, it will skip searching through std to find a reference to it, allowing for a big speedup in lookups. This is only for references. Go to definition and renaming will continue to work as is.
The option can be enabled by setting the following field to `true`:
`skip_std_references`

TODO's:
- [x] Implement errors (completions/docs/etc)
- [x] Semantic tokens (currently commented out)
- [x] makeScopeInternal
- [x] resolveTypeOfNodeInternal
- [x] usingnamespace
- [x] Implement `test ""{}` support
- [x] Make it actually compile
- [x] Ensure no more `@TODO:` inserted by me are left
- [x] Goto definition on imports.
- [x] Completion for generic types that are imported.
- [x] Completion for `Try`
- [x] Incorrect completions. i.e. https://github.com/vrischmann/zig-sqlite/blob/master/sqlite.zig#L302
- [x] Slice/Array payload completion
- [x] Unwrapping optional in `if` causes crash