### PR TITLE
Use fs.path.resolve to find Zig binary during config

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -28,8 +28,10 @@ pub fn config(step: *std.build.Step) anyerror!void {
 
         var it = std.mem.tokenize(env_path, &[_]u8{std.fs.path.delimiter});
         while (it.next()) |path| {
+            const resolved_path = try std.fs.path.resolve(allocator, &[_][]const u8{path});
+            defer allocator.free(resolved_path);
             const full_path = try std.fs.path.join(allocator, &[_][]const u8{
-                path,
+                resolved_path,
                 zig_exe,
             });
             defer allocator.free(full_path);


### PR DESCRIPTION
I discovered an edge case on path resolution while building ZLS on Windows. One of my PATH values has ".." in it (I'm not exactly sure why, but I'm honestly too afraid to touch it). This path was being given to OpenFile, which causes a panic:
```
$ zig build config
Welcome to the ZLS configuration wizard! (insert mage emoji here)
Looking for 'zig' in PATH...
thread 10940 panic: reached unreachable code
D:\Other Things\Programs\Zig\lib\zig\std\os\windows.zig:118:37: 0x7ff7d7302219 in std.os.windows.OpenFile (build.obj)
            .OBJECT_NAME_INVALID => unreachable,
                                    ^
D:\Other Things\Programs\Zig\lib\zig\std\fs.zig:881:46: 0x7ff7d72db2e3 in std.fs.Dir::std.fs.Dir.openFileW (build.obj)
            .handle = try os.windows.OpenFile(sub_path_w, .{
                                             ^
D:\Other Things\Programs\Zig\lib\zig\std\fs.zig:765:34: 0x7ff7d72e35c4 in std.fs.Dir::std.fs.Dir.openFile (build.obj)
            return self.openFileW(path_w.span(), flags);
                                 ^
D:\Other Things\Programs\Zig\lib\zig\std\fs.zig:2047:26: 0x7ff7d73118f6 in std.fs.openFileAbsolute (build.obj)
    return cwd().openFile(absolute_path, flags);
                         ^
D:\Other Things\Code\Zig\zls\build.zig:39:49: 0x7ff7d730b7b4 in .@build.config (build.obj)
            const file = std.fs.openFileAbsolute(full_path, .{}) catch continue;
```