### PR TITLE
Emacs: update setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,13 +216,12 @@ let g:LanguageClient_serverCommands = {
 - [zig mode](https://github.com/ziglang/zig-mode) is also useful
 
 ```elisp
-(require 'lsp)
-(add-to-list 'lsp-language-id-configuration '(zig-mode . "zig"))
-(lsp-register-client
-  (make-lsp-client
-    :new-connection (lsp-stdio-connection "<path to zls>")
-    :major-modes '(zig-mode)
-    :server-id 'zls))
+;; Setup lsp-mode as desired.
+;; See https://emacs-lsp.github.io/lsp-mode/page/installation/ for more information.
+(require 'lsp-mode)
+
+;; Either place zls in your PATH or add the following:
+(setq lsp-zig-zls-executable "<path to zls>")
 ```
 
 ### Doom Emacs
@@ -231,17 +230,17 @@ let g:LanguageClient_serverCommands = {
 - Install the [zig-mode](https://github.com/ziglang/zig-mode) package (add `(package! zig-mode)` to your `packages.el` file
 
 ```elisp
-(require 'lsp)
 (use-package! zig-mode
-  :hook ((zig-mode . lsp))
+  :hook ((zig-mode . lsp-deferred))
   :custom (zig-format-on-save nil)
-  :init
-  (add-to-list 'lsp-language-id-configuration '(zig-mode . "zig"))
-  (lsp-register-client
-   (make-lsp-client
-    :new-connection (lsp-stdio-connection "<path to zls>")
-    :major-modes '(zig-mode)
-    :server-id 'zls)))
+  :config
+  (after! lsp-mode
+    (add-to-list 'lsp-language-id-configuration '(zig-mode . "zig"))
+    (lsp-register-client
+      (make-lsp-client
+        :new-connection (lsp-stdio-connection "<path to zls>")
+        :major-modes '(zig-mode)
+        :server-id 'zls))))
 ```
 
 ## Related Projects

--- a/build.zig
+++ b/build.zig
@@ -146,31 +146,26 @@ pub fn config(step: *std.build.Step) anyerror!void {
                 \\Zig mode (https://github.com/ziglang/zig-mode) is also useful!
                 \\Then, add the following to your emacs config:
                 \\
-                \\(require 'lsp)
-                \\(add-to-list 'lsp-language-id-configuration '(zig-mode . "zig"))
-                \\(lsp-register-client
-                \\  (make-lsp-client
-                \\    :new-connection (lsp-stdio-connection "<path to zls>")
-                \\    :major-modes '(zig-mode)
-                \\    :server-id 'zls))
+                \\(require 'lsp-mode)
+                \\(setq lsp-zig-zls-executable "<path to zls>")
             , .{});
         },
         .Doom => {
             std.debug.warn(
                 \\To use ZLS in Doom Emacs, enable the lsp module
-                \\And install the zig mode (https://github.com/ziglang/zig-mode) package by adding `(package! zig-mode)` to your packages.el file.
+                \\And install the `zig-mode` (https://github.com/ziglang/zig-mode) package by adding `(package! zig-mode)` to your packages.el file.
                 \\
-                \\(require 'lsp)
                 \\(use-package! zig-mode
-                \\  :hook ((zig-mode . lsp))
+                \\  :hook ((zig-mode . lsp-deferred))
                 \\  :custom (zig-format-on-save nil)
-                \\  :init
-                \\  (add-to-list 'lsp-language-id-configuration '(zig-mode . "zig"))
-                \\  (lsp-register-client
-                \\   (make-lsp-client
-                \\    :new-connection (lsp-stdio-connection "<path to zls>")
-                \\    :major-modes '(zig-mode)
-                \\    :server-id 'zls)))
+                \\  :config
+                \\  (after! lsp-mode
+                \\    (add-to-list 'lsp-language-id-configuration '(zig-mode . "zig"))
+                \\    (lsp-register-client
+                \\      (make-lsp-client
+                \\        :new-connection (lsp-stdio-connection "<path to zls>")
+                \\        :major-modes '(zig-mode)
+                \\        :server-id 'zls))))
             , .{});
         },
         .Other => {


### PR DESCRIPTION
`lsp-mode` now has built-in configuration for zls, so the only configuration that might be required is setting the location of the zls
executable (or placing it in the PATH).

`doom-emacs` has not updated to use the latest version of `lsp-mode` yet, so its configuration cannot be simplified. However, I've updated the snippet for configuration to avoid loading `lsp-mode` on startup, which can cause significant slowdown to Emacs startup, and instead defer loading it until it is required.