### PR TITLE
Add option to truncate long completions

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -74,6 +74,12 @@ pub fn config(step: *std.build.Step) anyerror!void {
         else =>
             try zinput.askBool("Should the @ sign be included in completions of builtin functions?\nChange this later if `@inc` completes to `include` or `@@include`")
     };
+    const max_detail_length: usize = switch (editor) {
+        .Sublime =>
+            256,
+        else =>
+            1024 * 1024
+    };
     
     var dir = try std.fs.cwd().openDir(builder.exe_dir, .{});
     defer dir.close();
@@ -92,6 +98,7 @@ pub fn config(step: *std.build.Step) anyerror!void {
         .enable_semantic_tokens = semantic_tokens,
         .operator_completions = operator_completions,
         .include_at_in_builtins = include_at_in_builtins,
+        .max_detail_length = max_detail_length,
     }, std.json.StringifyOptions{}, out);
 
     std.debug.warn("Successfully saved configuration options!\n", .{});

--- a/src/config.zig
+++ b/src/config.zig
@@ -17,7 +17,7 @@ warn_style: bool = false,
 /// Path to the build_runner.zig file.
 build_runner_path: ?[]const u8 = null,
 
-/// Path to a directory that will be used as cache when `zig run`ing the build runner
+/// Path to a directory that will be used as cache when `zig run`ning the build runner
 build_runner_cache_path: ?[]const u8 = null,
 
 /// Semantic token support
@@ -28,6 +28,9 @@ operator_completions: bool = true,
 
 /// Whether the @ sign should be part of the completion of builtins
 include_at_in_builtins: bool = false,
+
+/// The detail field of completions is truncated to be no longer than this (in bytes).
+max_detail_length: usize = 1024 * 1024,
 
 /// Skips references to std. This will improve lookup speeds.
 /// Going to definition however will continue to work


### PR DESCRIPTION
The detail entries for big structs such as `std.zig.CrossTarget` were bricking the preview window in Sublime Text.

I needed to increase the EvalBranchQuota of the json parser to add this option even though it is just a single integer. Maybe we should evaluate the build time impact of adding config options and consider alternatives (TOML?)