### PR TITLE
Add `insertText` field for enum completions

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -2672,6 +2672,8 @@ fn makeScopeInternal(
                     try enum_completions.put(allocator, .{
                         .label = name,
                         .kind = .Constant,
+                        .insertText = name,
+                        .insertTextFormat = .PlainText,
                         .documentation = if (try getDocComments(allocator, tree, decl, .Markdown)) |docs| .{
                             .kind = .Markdown,
                             .value = docs,

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -2602,8 +2602,8 @@ fn makeScopeInternal(
                     try error_completions.put(allocator, .{
                         .label = tree.tokenSlice(i),
                         .kind = .Constant,
-                        .insertTextFormat = .PlainText,
                         .insertText = tree.tokenSlice(i),
+                        .insertTextFormat = .PlainText,
                     }, {});
                 }
             }


### PR DESCRIPTION
Another bug with the older version of lsp-mode on Emacs prevents the label from being inserted when there is an empty `insertText`. This commit adds an `insertText` property to enum completions for consistency with the rest of the completion items.

