### PR TITLE
Call `resolveInstallPrefix` in build runner

### DIFF
--- a/src/special/build_runner.zig
+++ b/src/special/build_runner.zig
@@ -20,6 +20,7 @@ pub fn main() !void {
     const builder = try Builder.create(allocator, "", "", "", "");
     defer builder.destroy();
 
+    builder.resolveInstallPrefix(null);
     try runBuild(builder);
 
     const stdout_stream = io.getStdOut().writer();


### PR DESCRIPTION
If the build runner doesn't call `builder.resolveInstallPrefix` then multiple fields on the `builder` are undefined.

I noticed this when one of my projects had no package completion but another did, the broken one calls `builder.getInstallPath` which would result in attempting to validate if an undefined slice is a valid path, triggering a segmentation fault in `std.fs.path.isAbsolutePosix`