### PR TITLE
Fix FnProto field name

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -243,7 +243,7 @@ fn publishDiagnostics(arena: *std.heap.ArenaAllocator, handle: DocumentStore.Han
                 => blk: {
                     var buf: [1]std.zig.ast.Node.Index = undefined;
                     const func = analysis.fnProto(tree, decl_idx, &buf).?;
-                    if (func.extern_export_token != null) break :blk;
+                    if (func.extern_export_inline_token != null) break :blk;
 
                     if (config.warn_style) {
                         if (func.name_token) |name_token| {

--- a/src/semantic_tokens.zig
+++ b/src/semantic_tokens.zig
@@ -455,7 +455,7 @@ fn writeNodeTokens(
                 try writeDocComments(builder, tree, docs);
 
             try writeToken(builder, fn_proto.visib_token, .keyword);
-            try writeToken(builder, fn_proto.extern_export_token, .keyword);
+            try writeToken(builder, fn_proto.extern_export_inline_token, .keyword);
             try writeToken(builder, fn_proto.lib_name, .string);
             try writeToken(builder, fn_proto.ast.fn_token, .keyword);
 


### PR DESCRIPTION
The name of this field was changed on zig master branch a few days ago in this commit: https://github.com/ziglang/zig/commit/3fd8ac092e88ac4bc604afcdd3fcb33249dba967

This is an attempt to make zls build form master HEAD again.