### PR TITLE
[WIP] Fix Nix build

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,5 @@
-{ pkgs ? import <nixpkgs> {} }:
+{ pkgs ? import <nixpkgs> {},
+  system ? builtins.currentSystem }:
 
 let
   zig-overlay = pkgs.fetchFromGitHub {
@@ -14,7 +15,7 @@ let
     sha256 = "1npnx0h6bd0d7ql93ka7azhj40zgjp815fw2r6smg8ch9p7mzdlx";
   };
   inherit (import gitignoreSrc { inherit (pkgs) lib; }) gitignoreSource;
-  zig = (import zig-overlay { inherit pkgs; }).master.latest;
+  zig = (import zig-overlay { inherit pkgs system; }).master.latest;
 in
 pkgs.stdenvNoCC.mkDerivation {
   name = "zls";

--- a/default.nix
+++ b/default.nix
@@ -1,10 +1,11 @@
+{ pkgs ? import <nixpkgs> {} }:
+
 let
-  pkgs = import <nixpkgs> {};
   zig-overlay = pkgs.fetchFromGitHub {
     owner = "arqv";
     repo = "zig-overlay";
     rev = "5b9504b8bff072553051d6e130727f7f5c0715c3";
-    sha256 = "sha256-NDm5qT6/qr789IhI2dsQxrR5/Mr7cXVj17x/+tl3pDE=";
+    sha256 = "NDm5qT6/qr789IhI2dsQxrR5/Mr7cXVj17x/+tl3pDE=";
   };
   gitignoreSrc = pkgs.fetchFromGitHub {
     owner = "hercules-ci";
@@ -13,8 +14,8 @@ let
     sha256 = "1npnx0h6bd0d7ql93ka7azhj40zgjp815fw2r6smg8ch9p7mzdlx";
   };
   inherit (import gitignoreSrc { inherit (pkgs) lib; }) gitignoreSource;
-  zig-default = (import zig-overlay { inherit pkgs; }).master.latest;
-in { zig ? zig-default, extraConfig ? { } }:
+  zig = (import zig-overlay {}).master.latest;
+in
 pkgs.stdenvNoCC.mkDerivation {
   name = "zls";
   version = "master";

--- a/default.nix
+++ b/default.nix
@@ -14,7 +14,7 @@ let
     sha256 = "1npnx0h6bd0d7ql93ka7azhj40zgjp815fw2r6smg8ch9p7mzdlx";
   };
   inherit (import gitignoreSrc { inherit (pkgs) lib; }) gitignoreSource;
-  zig = (import zig-overlay {}).master.latest;
+  zig = (import zig-overlay { inherit pkgs; }).master.latest;
 in
 pkgs.stdenvNoCC.mkDerivation {
   name = "zls";

--- a/default.nix
+++ b/default.nix
@@ -1,9 +1,11 @@
 let
-  zig-overlay = import (builtins.fetchGit {
-    url = "https://github.com/arqv/zig-overlay.git";
-    rev = "a56601116906a2f192702e0b97487b8e7f796fdc";
-  });
-  pkgs = import <nixpkgs> { overlays = [ zig-overlay ]; };
+  pkgs = import <nixpkgs> {};
+  zig-overlay = pkgs.fetchFromGitHub {
+    owner = "arqv";
+    repo = "zig-overlay";
+    rev = "5b9504b8bff072553051d6e130727f7f5c0715c3";
+    sha256 = "sha256-NDm5qT6/qr789IhI2dsQxrR5/Mr7cXVj17x/+tl3pDE=";
+  };
   gitignoreSrc = pkgs.fetchFromGitHub {
     owner = "hercules-ci";
     repo = "gitignore";
@@ -11,7 +13,7 @@ let
     sha256 = "1npnx0h6bd0d7ql93ka7azhj40zgjp815fw2r6smg8ch9p7mzdlx";
   };
   inherit (import gitignoreSrc { inherit (pkgs) lib; }) gitignoreSource;
-  zig-default = pkgs.zig.master;
+  zig-default = (import zig-overlay { inherit pkgs; }).master.latest;
 in { zig ? zig-default, extraConfig ? { } }:
 pkgs.stdenvNoCC.mkDerivation {
   name = "zls";
@@ -23,18 +25,6 @@ pkgs.stdenvNoCC.mkDerivation {
   buildPhase = ''
     mkdir -p $out
     zig build install -Drelease-safe=true -Ddata_version=master --prefix $out
-    cat << EOF > $out/bin/zls.json
-      ${
-        builtins.toJSON ({
-          zig_lib_path = "${zig}/lib/zig/";
-          zig_exe_path = "${zig}/bin/zig";
-          warn_style = false;
-          enable_snippets = false;
-          enable_semantic_tokens = false;
-          operator_completions = true;
-        } // extraConfig)
-      }
-    EOF
   '';
   XDG_CACHE_HOME = ".cache";
 }


### PR DESCRIPTION
The older version of `zig-overlay` used was unable to handle the newer directory layout of Zig tarballs, so `zig-overlay` has been updated and is currently using a `master` version of Zig.

Additionally, `zls.json` was removed since `zls` will now only look for it in local or global configuration folders.

Closes #330.