### PR TITLE
Fix index out of range

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -2296,7 +2296,11 @@ fn resolveUse(
     defer _ = using_trail.pop();
 
     for (uses) |use| {
-        const expr = .{ .node = handle.tree.nodes.items(.data)[use.*].lhs, .handle = handle };
+        const index = use.*;
+
+        if (handle.tree.nodes.items(.data).len <= index) continue;
+
+        const expr = .{ .node = handle.tree.nodes.items(.data)[index].lhs, .handle = handle };
         const expr_type_node = (try resolveTypeOfNode(store, arena, expr)) orelse
             continue;
 


### PR DESCRIPTION
This fixes a very intermittent index out of range i've been getting from here: `handle.tree.nodes.items(.data)[use.*]`