### PR TITLE
Attempt at per build.zig config

### DIFF
--- a/src/build_associated_config.zig
+++ b/src/build_associated_config.zig
@@ -1,0 +1,8 @@
+// Configuration options related to a specific `BuildFile`.
+
+/// If provided this path is used when resolving `@import("builtin")`
+/// It is relative to the directory containing the `build.zig`
+///
+/// This file should contain the output of:
+/// `zig build-exe/build-lib/build-obj --show-builtin <options>`
+relative_builtin_path: ?[]const u8 = null,


### PR DESCRIPTION
This is a rough attempt at a per build.zig config file. 

If a file called `zls.build.json` is in the same directory as the `build.zig` it will be used to apply configuration changes to the `BuildFile` associated with that `build.zig`.

Then `Handle`'s can access this configuration on their `associated_build_file` field.

Currently the only option available is:
| Option | Type | Default value | What it Does |
| --- | --- | --- | --- |
| `relative_builtin_path` | `?[]const u8` | `null` | The path to resolve `@import("builtin")` to, it is relative to the directory containing the `build.zig`. This file should contain the output of `zig build-exe/build-lib/build-obj --show-builtin <options>` |