### PR TITLE
Handle tag moved backwards without logging

### DIFF
--- a/tests/sessions.zig
+++ b/tests/sessions.zig
@@ -100,7 +100,7 @@ const Server = struct {
 
     fn shutdown(self: *Server) void {
         self.request("shutdown", "{}", null) catch @panic("Could not send shutdown request");
-        waitNoError(self.process) catch |err| @panic("Server error");
+        waitNoError(self.process) catch @panic("Server error");
         self.process.deinit();
     }
 };


### PR DESCRIPTION
Sometimes zls gets into a state where every token it tries to add to `semantic_tokens.Builder` hits the `next_start < self.previous_position` error condition resulting in an extremely large number of log messages.

Unfortunately as these log messages are at `err` they cause a pop up in vscode which for a file like `std.build` which exhibits this problem (with a release-fast build) results in vscode locking up and sometimes even crashing, see video in #332.

Treating this as a termination condition in `semantic_tokens.writeAllSemanticTokens` prevents this log spam and as far as I can tell results in unchanged completion/semantic highlighting functionality.

Closes #332