### PR TITLE
Update to zig master

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -1525,7 +1525,10 @@ pub fn documentPositionContext(
     _ = document;
 
     const line = doc_position.line;
-    var tokenizer = std.zig.Tokenizer.init(line[0..doc_position.line_index]);
+
+    var lineZ = try arena.allocator.dupeZ(u8, line[0..doc_position.line_index]);
+
+    var tokenizer = std.zig.Tokenizer.init(lineZ);
     var stack = try std.ArrayList(StackState).initCapacity(&arena.allocator, 8);
 
     while (true) {
@@ -1632,7 +1635,10 @@ pub fn documentPositionContext(
                 'a'...'z', 'A'...'Z', '_', '@' => {},
                 else => break :block .empty,
             }
-            tokenizer = std.zig.Tokenizer.init(line[doc_position.line_index..]);
+
+            lineZ = try arena.allocator.dupeZ(u8, line[doc_position.line_index..]);
+
+            tokenizer = std.zig.Tokenizer.init(lineZ);
             const tok = tokenizer.next();
             if (tok.tag == .identifier)
                 break :block PositionContext{ .var_access = tok.loc };

--- a/src/main.zig
+++ b/src/main.zig
@@ -774,7 +774,10 @@ fn getSymbolFieldAccess(
 
     const name = identifierFromPosition(position.absolute_index, handle.*);
     if (name.len == 0) return null;
-    var tokenizer = std.zig.Tokenizer.init(position.line[range.start..range.end]);
+
+    const spanZ = try arena.allocator.dupeZ(u8, position.line[range.start..range.end]);
+
+    var tokenizer = std.zig.Tokenizer.init(spanZ);
 
     if (try analysis.getFieldAccessType(&document_store, arena, handle, position.absolute_index, &tokenizer)) |result| {
         const container_handle = result.unwrapped orelse result.original;
@@ -1147,7 +1150,10 @@ fn completeFieldAccess(
     config: Config,
 ) !void {
     var completions = std.ArrayList(types.CompletionItem).init(&arena.allocator);
-    var tokenizer = std.zig.Tokenizer.init(position.line[range.start..range.end]);
+
+    const spanZ = try arena.allocator.dupeZ(u8, position.line[range.start..range.end]);
+
+    var tokenizer = std.zig.Tokenizer.init(spanZ);
     if (try analysis.getFieldAccessType(&document_store, arena, handle, position.absolute_index, &tokenizer)) |result| {
         try typeToCompletion(arena, &completions, result, handle, config);
         truncateCompletions(completions.items, config.max_detail_length);

--- a/src/signature_help.zig
+++ b/src/signature_help.zig
@@ -264,9 +264,11 @@ pub fn getSignatureInfo(
                 const expr_start = token_starts[expr_first_token];
                 const last_token_slice = tree.tokenSlice(expr_last_token);
                 const expr_end = token_starts[expr_last_token] + last_token_slice.len;
-                const expr_source = tree.source[expr_start..expr_end];
+
+                const expr_sourceZ = try arena.allocator.dupeZ(u8, tree.source[expr_start..expr_end]);
+
                 // Resolve the expression.
-                var tokenizer = std.zig.Tokenizer.init(expr_source);
+                var tokenizer = std.zig.Tokenizer.init(expr_sourceZ);
                 if (try analysis.getFieldAccessType(
                     document_store,
                     arena,

--- a/src/types.zig
+++ b/src/types.zig
@@ -114,9 +114,9 @@ pub const Diagnostic = struct {
 pub const TextDocument = struct {
     uri: []const u8,
     // This is a substring of mem starting at 0
-    text: []const u8,
+    text: [:0]const u8,
     // This holds the memory that we have actually allocated.
-    mem: []u8,
+    mem: [:0]u8,
 };
 
 pub const WorkspaceEdit = struct {

--- a/src/unit_tests.zig
+++ b/src/unit_tests.zig
@@ -8,7 +8,7 @@ const std = @import("std");
 const allocator = std.testing.allocator;
 
 fn makeDocument(uri: []const u8, text: []const u8) !types.TextDocument {
-    const mem = try allocator.alloc(u8, text.len);
+    const mem = try allocator.allocSentinel(u8, text.len, 0);
     std.mem.copy(u8, mem, text);
 
     return types.TextDocument{


### PR DESCRIPTION
Unfortunately this is a bad update for ZLS :(

Commit https://github.com/ziglang/zig/commit/3f680abbe2c4d2eeefd0eb73b8af25d1768e6ceb as part of https://github.com/ziglang/zig/pull/9219, means `std.zig.parse` and `std.zig.Tokenizer` take null terminated slices now.

This means allocations with `dupeZ` in places where slices were fine before.