### PR TITLE
Actions- run all tests even if one fails

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
this is achieved by adding `fail-fast: false` to the strategy.

so now if the build fails on windows for example, it won't interrupt the tests running on linux or macOS