### PR TITLE
build_runner: Require some paths to be given

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1815,6 +1815,13 @@ pub fn main() anyerror!void {
         build_runner_path,
         build_runner_cache_path,
         config.zig_lib_path,
+        // TODO make this configurable
+        // We can't figure it out ourselves since we don't know what arguments
+        // the user will use to run "zig build"
+        "zig-cache",
+        // Since we don't compile anything and no packages should put their
+        // files there this path can be ignored
+        "ZLS_DONT_CARE",
     );
     defer document_store.deinit();
 


### PR DESCRIPTION
For the build runner we now require the following to ge given in the cli args:
- zig_exe
- build_root
- cache_root
- global_cache_root

This fixes the path for packages that use one or more from the above to place
their files.

Some examples are `vulkan-zig` and `zig-wayland` that both place their files in the `zig-cache` directory.

For symmetry with the original `build_runner.zig` I just copied over the code from it. We don't actually need `global_cache_root` so we might consider removing it.

Probably closes #367 