### PR TITLE
Updates to run on Zig 0.9.0-dev.796+fcf2ce0ff

### DIFF
--- a/src/document_store.zig
+++ b/src/document_store.zig
@@ -148,7 +148,7 @@ fn loadPackages(context: LoadPackagesContext) !void {
                 }
 
                 build_file.packages.shrinkAndFree(allocator, 0);
-                var line_it = std.mem.split(zig_run_result.stdout, "\n");
+                var line_it = std.mem.split(u8, zig_run_result.stdout, "\n");
                 while (line_it.next()) |line| {
                     if (std.mem.indexOfScalar(u8, line, '\x00')) |zero_byte_idx| {
                         const name = line[0..zero_byte_idx];

--- a/src/offsets.zig
+++ b/src/offsets.zig
@@ -14,7 +14,7 @@ pub const DocumentPosition = struct {
 };
 
 pub fn documentPosition(doc: types.TextDocument, position: types.Position, encoding: Encoding) !DocumentPosition {
-    var split_iterator = std.mem.split(doc.text, "\n");
+    var split_iterator = std.mem.split(u8, doc.text, "\n");
 
     var line_idx: i64 = 0;
     var line: []const u8 = "";
@@ -185,7 +185,7 @@ pub fn documentRange(doc: types.TextDocument, encoding: Encoding) !types.Range {
     var line_idx: i64 = 0;
     var curr_line: []const u8 = doc.text;
 
-    var split_iterator = std.mem.split(doc.text, "\n");
+    var split_iterator = std.mem.split(u8, doc.text, "\n");
     while (split_iterator.next()) |line| : (line_idx += 1) {
         curr_line = line;
     }

--- a/src/setup.zig
+++ b/src/setup.zig
@@ -225,7 +225,7 @@ pub fn findZig(allocator: *std.mem.Allocator) !?[]const u8 {
     const zig_exe = try std.fmt.allocPrint(allocator, "zig{s}", .{exe_extension});
     defer allocator.free(zig_exe);
 
-    var it = std.mem.tokenize(env_path, &[_]u8{std.fs.path.delimiter});
+    var it = std.mem.tokenize(u8, env_path, &[_]u8{std.fs.path.delimiter});
     while (it.next()) |path| {
         if (std.builtin.os.tag == .windows) {
             if (std.mem.indexOfScalar(u8, path, '/') != null) continue;

--- a/src/uri.zig
+++ b/src/uri.zig
@@ -57,7 +57,7 @@ pub fn pathRelative(allocator: *mem.Allocator, base: []const u8, rel: []const u8
     mem.copy(u8, result, base);
     var result_index: usize = base.len;
 
-    var it = mem.tokenize(rel, "/");
+    var it = mem.tokenize(u8, rel, "/");
     while (it.next()) |component| {
         if (mem.eql(u8, component, ".")) {
             continue;


### PR DESCRIPTION
This PR fixes a few invocations of `std.mem.*` functions that have recently been changed to take an additional type parameter.