### PR TITLE
Fix namespaces

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -1,10 +1,22 @@
 const std = @import("std");
 const DocumentStore = @import("document_store.zig");
 const ast = std.zig.ast;
+const fnProto = ast.Tree.fnProto;
+const lastToken = ast.Tree.lastToken;
 const types = @import("types.zig");
 const offsets = @import("offsets.zig");
+const isContainer = std.meta.trait.isContainer;
 const log = std.log.scoped(.analysis);
-usingnamespace @import("ast.zig");
+
+const callFull = @import("ast.zig").callFull;
+const containerField = @import("ast.zig").containerField;
+const declMembers = @import("ast.zig").declMembers;
+const ifFull = @import("ast.zig").ifFull;
+const isBuiltinCall = @import("ast.zig").isBuiltinCall;
+const isCall = @import("ast.zig").isCall;
+const ptrType = @import("ast.zig").ptrType;
+const varDecl = @import("ast.zig").varDecl;
+const whileAst = @import("ast.zig").whileAst;
 
 var using_trail: std.ArrayList([*]const u8) = undefined;
 var resolve_trail: std.ArrayList(NodeWithHandle) = undefined;
@@ -2460,7 +2472,7 @@ pub const DocumentScope = struct {
             while (decl_it.next()) |_| : (idx += 1) {
                 if (idx != 0) log.debug(", ", .{});
             }
-            log.debug("{s}", .{name_decl.key});
+            //log.debug("{s}", .{name_decl.key});
             log.debug("\n--------------------------\n", .{});
         }
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,6 +1,8 @@
 const std = @import("std");
 const build_options = @import("build_options");
 
+const ast = std.zig.ast;
+
 const Config = @import("config.zig");
 const DocumentStore = @import("document_store.zig");
 const readRequestHeader = @import("header.zig").readRequestHeader;
@@ -200,7 +202,7 @@ fn showMessage(message_type: types.MessageType, message: []const u8) !void {
 }
 
 // TODO: Is this correct or can we get a better end?
-fn astLocationToRange(loc: std.zig.ast.Tree.Location) types.Range {
+fn astLocationToRange(loc: ast.Tree.Location) types.Range {
     return .{
         .start = .{
             .line = @intCast(i64, loc.line),
@@ -246,7 +248,7 @@ fn publishDiagnostics(arena: *std.heap.ArenaAllocator, handle: DocumentStore.Han
                 .fn_proto_simple,
                 .fn_decl,
                 => blk: {
-                    var buf: [1]std.zig.ast.Node.Index = undefined;
+                    var buf: [1]ast.Node.Index = undefined;
                     const func = analysis.fnProto(tree, decl_idx, &buf).?;
                     if (func.extern_export_inline_token != null) break :blk;
 
@@ -415,7 +417,7 @@ fn nodeToCompletion(
         .fn_proto_simple,
         .fn_decl,
         => {
-            var buf: [1]std.zig.ast.Node.Index = undefined;
+            var buf: [1]ast.Node.Index = undefined;
             const func = analysis.fnProto(tree, node, &buf).?;
             if (func.name_token) |name_token| {
                 const use_snippets = config.enable_snippets and client_capabilities.supports_snippets;
@@ -637,7 +639,7 @@ fn hoverSymbol(
             }
             doc_str = try analysis.getDocComments(&arena.allocator, tree, node, hover_kind);
 
-            var buf: [1]std.zig.ast.Node.Index = undefined;
+            var buf: [1]ast.Node.Index = undefined;
 
             if (analysis.varDecl(tree, node)) |var_decl| {
                 break :def analysis.getVariableSignature(tree, var_decl);

--- a/src/references.zig
+++ b/src/references.zig
@@ -3,10 +3,16 @@ const DocumentStore = @import("document_store.zig");
 const analysis = @import("analysis.zig");
 const types = @import("types.zig");
 const offsets = @import("offsets.zig");
-const log = std.log.scoped(.references);
-usingnamespace @import("ast.zig");
-
 const ast = std.zig.ast;
+const fnProto = ast.Tree.fnProto;
+const log = std.log.scoped(.references);
+
+const containerField = @import("ast.zig").containerField;
+const declMembers = @import("ast.zig").declMembers;
+const ifFull = @import("ast.zig").ifFull;
+const ptrType = @import("ast.zig").ptrType;
+const varDecl = @import("ast.zig").varDecl;
+const whileAst = @import("ast.zig").whileAst;
 
 fn tokenReference(
     handle: *DocumentStore.Handle,

--- a/src/semantic_tokens.zig
+++ b/src/semantic_tokens.zig
@@ -3,8 +3,17 @@ const offsets = @import("offsets.zig");
 const DocumentStore = @import("document_store.zig");
 const analysis = @import("analysis.zig");
 const ast = std.zig.ast;
+const fnProto = ast.Tree.fnProto;
+const lastToken = ast.Tree.lastToken;
+const isContainer = std.meta.trait.isContainer;
 const log = std.log.scoped(.semantic_tokens);
-usingnamespace @import("ast.zig");
+
+const containerField = @import("ast.zig").containerField;
+const declMembers = @import("ast.zig").declMembers;
+const ifFull = @import("ast.zig").ifFull;
+const ptrType = @import("ast.zig").ptrType;
+const varDecl = @import("ast.zig").varDecl;
+const whileAst = @import("ast.zig").whileAst;
 
 pub const TokenType = enum(u32) {
     type,

--- a/src/signature_help.zig
+++ b/src/signature_help.zig
@@ -4,9 +4,10 @@ const offsets = @import("offsets.zig");
 const DocumentStore = @import("document_store.zig");
 const types = @import("types.zig");
 const ast = std.zig.ast;
+const fnProto = ast.Tree.fnProto;
+const lastToken = ast.Tree.lastToken;
 const Token = std.zig.Token;
 const identifierFromPosition = @import("main.zig").identifierFromPosition;
-usingnamespace @import("ast.zig");
 
 fn fnProtoToSignatureInfo(
     document_store: *DocumentStore,


### PR DESCRIPTION
Addresses most of #387. There's still a compile error because zinput (one of the submodules) needs to be fixed too.

If somebody has a better idea than spamming `@import("ast.zig")`, feel free to suggest one.

I had no idea what `log.debug("{s}", .{name_decl.key});` did, so I commented it out.
Maybe it was supposed to be inside this loop?
https://github.com/zigtools/zls/blob/c2cbc05135aebb4a9fa24cd60a4a091db18605fb/src/analysis.zig#L2461-L2463