### PR TITLE
Usingnamespace semantics update

### DIFF
--- a/src/ast.zig
+++ b/src/ast.zig
@@ -3,13 +3,13 @@
 //! when there are parser errors.
 
 const std = @import("std");
-const ast = std.zig.ast;
-const Tree = ast.Tree;
+const ast = std.zig.Ast;
+pub const Tree = ast;
 const Node = ast.Node;
 const full = ast.full;
 const assert = std.debug.assert;
 
-fn fullPtrType(tree: Tree, info: full.PtrType.Ast) full.PtrType {
+fn fullPtrType(tree: Tree, info: full.PtrType.Components) full.PtrType {
     const token_tags = tree.tokens.items(.tag);
     // TODO: looks like stage1 isn't quite smart enough to handle enum
     // literals in some places here
@@ -112,7 +112,7 @@ pub fn ptrTypeBitRange(tree: Tree, node: Node.Index) full.PtrType {
     });
 }
 
-fn fullIf(tree: Tree, info: full.If.Ast) full.If {
+fn fullIf(tree: Tree, info: full.If.Components) full.If {
     const token_tags = tree.tokens.items(.tag);
     var result: full.If = .{
         .ast = info,
@@ -158,7 +158,7 @@ pub fn ifFull(tree: Tree, node: Node.Index) full.If {
     }
 }
 
-fn fullWhile(tree: Tree, info: full.While.Ast) full.While {
+fn fullWhile(tree: Tree, info: full.While.Components) full.While {
     const token_tags = tree.tokens.items(.tag);
     var result: full.While = .{
         .ast = info,
@@ -251,7 +251,7 @@ pub fn forFull(tree: Tree, node: Node.Index) full.While {
     });
 }
 
-pub fn lastToken(tree: ast.Tree, node: ast.Node.Index) ast.TokenIndex {
+pub fn lastToken(tree: Tree, node: ast.Node.Index) ast.TokenIndex {
     const TokenIndex = ast.TokenIndex;
     const tags = tree.nodes.items(.tag);
     const datas = tree.nodes.items(.data);
@@ -863,7 +863,7 @@ pub fn lastToken(tree: ast.Tree, node: ast.Node.Index) ast.TokenIndex {
     };
 }
 
-pub fn containerField(tree: ast.Tree, node: ast.Node.Index) ?ast.full.ContainerField {
+pub fn containerField(tree: Tree, node: ast.Node.Index) ?ast.full.ContainerField {
     return switch (tree.nodes.items(.tag)[node]) {
         .container_field => tree.containerField(node),
         .container_field_init => tree.containerFieldInit(node),
@@ -872,7 +872,7 @@ pub fn containerField(tree: ast.Tree, node: ast.Node.Index) ?ast.full.ContainerF
     };
 }
 
-pub fn ptrType(tree: ast.Tree, node: ast.Node.Index) ?ast.full.PtrType {
+pub fn ptrType(tree: Tree, node: ast.Node.Index) ?ast.full.PtrType {
     return switch (tree.nodes.items(.tag)[node]) {
         .ptr_type => ptrTypeSimple(tree, node),
         .ptr_type_aligned => ptrTypeAligned(tree, node),
@@ -882,7 +882,7 @@ pub fn ptrType(tree: ast.Tree, node: ast.Node.Index) ?ast.full.PtrType {
     };
 }
 
-pub fn whileAst(tree: ast.Tree, node: ast.Node.Index) ?ast.full.While {
+pub fn whileAst(tree: Tree, node: ast.Node.Index) ?ast.full.While {
     return switch (tree.nodes.items(.tag)[node]) {
         .@"while" => whileFull(tree, node),
         .while_simple => whileSimple(tree, node),
@@ -893,7 +893,7 @@ pub fn whileAst(tree: ast.Tree, node: ast.Node.Index) ?ast.full.While {
     };
 }
 
-pub fn isContainer(tree: ast.Tree, node: ast.Node.Index) bool {
+pub fn isContainer(tree: Tree, node: ast.Node.Index) bool {
     return switch (tree.nodes.items(.tag)[node]) {
         .container_decl,
         .container_decl_trailing,
@@ -916,7 +916,7 @@ pub fn isContainer(tree: ast.Tree, node: ast.Node.Index) bool {
 
 /// Returns the member indices of a given declaration container.
 /// Asserts given `tag` is a container node
-pub fn declMembers(tree: ast.Tree, node_idx: ast.Node.Index, buffer: *[2]ast.Node.Index) []const ast.Node.Index {
+pub fn declMembers(tree: Tree, node_idx: ast.Node.Index, buffer: *[2]ast.Node.Index) []const ast.Node.Index {
     std.debug.assert(isContainer(tree, node_idx));
     return switch (tree.nodes.items(.tag)[node_idx]) {
         .container_decl, .container_decl_trailing => tree.containerDecl(node_idx).ast.members,
@@ -933,7 +933,7 @@ pub fn declMembers(tree: ast.Tree, node_idx: ast.Node.Index, buffer: *[2]ast.Nod
 
 /// Returns an `ast.full.VarDecl` for a given node index.
 /// Returns null if the tag doesn't match
-pub fn varDecl(tree: ast.Tree, node_idx: ast.Node.Index) ?ast.full.VarDecl {
+pub fn varDecl(tree: Tree, node_idx: ast.Node.Index) ?ast.full.VarDecl {
     return switch (tree.nodes.items(.tag)[node_idx]) {
         .global_var_decl => tree.globalVarDecl(node_idx),
         .local_var_decl => tree.localVarDecl(node_idx),
@@ -943,7 +943,7 @@ pub fn varDecl(tree: ast.Tree, node_idx: ast.Node.Index) ?ast.full.VarDecl {
     };
 }
 
-pub fn isBuiltinCall(tree: ast.Tree, node: ast.Node.Index) bool {
+pub fn isBuiltinCall(tree: Tree, node: ast.Node.Index) bool {
     return switch (tree.nodes.items(.tag)[node]) {
         .builtin_call,
         .builtin_call_comma,
@@ -954,7 +954,7 @@ pub fn isBuiltinCall(tree: ast.Tree, node: ast.Node.Index) bool {
     };
 }
 
-pub fn isCall(tree: ast.Tree, node: ast.Node.Index) bool {
+pub fn isCall(tree: Tree, node: ast.Node.Index) bool {
     return switch (tree.nodes.items(.tag)[node]) {
         .call,
         .call_comma,
@@ -969,7 +969,7 @@ pub fn isCall(tree: ast.Tree, node: ast.Node.Index) bool {
     };
 }
 
-pub fn fnProto(tree: ast.Tree, node: ast.Node.Index, buf: *[1]ast.Node.Index) ?ast.full.FnProto {
+pub fn fnProto(tree: Tree, node: ast.Node.Index, buf: *[1]ast.Node.Index) ?ast.full.FnProto {
     return switch (tree.nodes.items(.tag)[node]) {
         .fn_proto => tree.fnProto(node),
         .fn_proto_multi => tree.fnProtoMulti(node),
@@ -980,7 +980,7 @@ pub fn fnProto(tree: ast.Tree, node: ast.Node.Index, buf: *[1]ast.Node.Index) ?a
     };
 }
 
-pub fn callFull(tree: ast.Tree, node: ast.Node.Index, buf: *[1]ast.Node.Index) ?ast.full.Call {
+pub fn callFull(tree: Tree, node: ast.Node.Index, buf: *[1]ast.Node.Index) ?ast.full.Call {
     return switch (tree.nodes.items(.tag)[node]) {
         .call,
         .call_comma,

--- a/src/document_store.zig
+++ b/src/document_store.zig
@@ -4,6 +4,7 @@ const URI = @import("uri.zig");
 const analysis = @import("analysis.zig");
 const offsets = @import("offsets.zig");
 const log = std.log.scoped(.doc_store);
+const Tree = std.zig.Ast;
 const BuildAssociatedConfig = @import("build_associated_config.zig");
 
 const DocumentStore = @This();
@@ -33,7 +34,7 @@ pub const Handle = struct {
     import_uris: []const []const u8,
     /// Items in this array list come from `import_uris`
     imports_used: std.ArrayListUnmanaged([]const u8),
-    tree: std.zig.ast.Tree,
+    tree: Tree,
     document_scope: analysis.DocumentScope,
 
     associated_build_file: ?*BuildFile,

--- a/src/main.zig
+++ b/src/main.zig
@@ -13,6 +13,7 @@ const rename = @import("rename.zig");
 const offsets = @import("offsets.zig");
 const setup = @import("setup.zig");
 const semantic_tokens = @import("semantic_tokens.zig");
+const ast = std.zig.Ast;
 const known_folders = @import("known-folders");
 const data = blk: {
     if (std.mem.eql(u8, build_options.data_version, "0.7.0")) break :blk @import("data/0.7.0.zig");
@@ -200,7 +201,7 @@ fn showMessage(message_type: types.MessageType, message: []const u8) !void {
 }
 
 // TODO: Is this correct or can we get a better end?
-fn astLocationToRange(loc: std.zig.ast.Tree.Location) types.Range {
+fn astLocationToRange(loc: ast.Location) types.Range {
     return .{
         .start = .{
             .line = @intCast(i64, loc.line),
@@ -246,7 +247,7 @@ fn publishDiagnostics(arena: *std.heap.ArenaAllocator, handle: DocumentStore.Han
                 .fn_proto_simple,
                 .fn_decl,
                 => blk: {
-                    var buf: [1]std.zig.ast.Node.Index = undefined;
+                    var buf: [1]ast.Node.Index = undefined;
                     const func = analysis.fnProto(tree, decl_idx, &buf).?;
                     if (func.extern_export_inline_token != null) break :blk;
 
@@ -415,7 +416,7 @@ fn nodeToCompletion(
         .fn_proto_simple,
         .fn_decl,
         => {
-            var buf: [1]std.zig.ast.Node.Index = undefined;
+            var buf: [1]ast.Node.Index = undefined;
             const func = analysis.fnProto(tree, node, &buf).?;
             if (func.name_token) |name_token| {
                 const use_snippets = config.enable_snippets and client_capabilities.supports_snippets;
@@ -637,7 +638,7 @@ fn hoverSymbol(
             }
             doc_str = try analysis.getDocComments(&arena.allocator, tree, node, hover_kind);
 
-            var buf: [1]std.zig.ast.Node.Index = undefined;
+            var buf: [1]ast.Node.Index = undefined;
 
             if (analysis.varDecl(tree, node)) |var_decl| {
                 break :def analysis.getVariableSignature(tree, var_decl);

--- a/src/offsets.zig
+++ b/src/offsets.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const types = @import("types.zig");
-const ast = std.zig.ast;
+const ast = std.zig.Ast;
+const Tree = ast;
 
 pub const Encoding = enum {
     utf8,
@@ -62,7 +63,7 @@ pub fn documentPosition(doc: types.TextDocument, position: types.Position, encod
     }
 }
 
-pub fn lineSectionLength(tree: ast.Tree, start_index: usize, end_index: usize, encoding: Encoding) !usize {
+pub fn lineSectionLength(tree: Tree, start_index: usize, end_index: usize, encoding: Encoding) !usize {
     const source = tree.source[start_index..];
     std.debug.assert(end_index >= start_index and source.len >= end_index - start_index);
     if (encoding == .utf8) {
@@ -103,7 +104,7 @@ pub const TokenLocation = struct {
     }
 };
 
-pub fn tokenRelativeLocation(tree: ast.Tree, start_index: usize, token_start: usize, encoding: Encoding) !TokenLocation {
+pub fn tokenRelativeLocation(tree: Tree, start_index: usize, token_start: usize, encoding: Encoding) !TokenLocation {
     std.debug.assert(token_start >= start_index);
     var loc = TokenLocation{
         .line = 0,
@@ -139,7 +140,7 @@ pub fn tokenRelativeLocation(tree: ast.Tree, start_index: usize, token_start: us
 }
 
 /// Asserts the token is comprised of valid utf8
-pub fn tokenLength(tree: ast.Tree, token: ast.TokenIndex, encoding: Encoding) usize {
+pub fn tokenLength(tree: Tree, token: ast.TokenIndex, encoding: Encoding) usize {
     const token_loc = tokenLocation(tree, token);
     if (encoding == .utf8)
         return token_loc.end - token_loc.start;
@@ -165,7 +166,7 @@ pub const Loc = struct {
     end: usize,
 };
 
-pub fn tokenLocation(tree: ast.Tree, token_index: ast.TokenIndex) Loc {
+pub fn tokenLocation(tree: Tree, token_index: ast.TokenIndex) Loc {
     const start = tree.tokens.items(.start)[token_index];
     const tag = tree.tokens.items(.tag)[token_index];
 

--- a/src/signature_help.zig
+++ b/src/signature_help.zig
@@ -3,9 +3,10 @@ const analysis = @import("analysis.zig");
 const offsets = @import("offsets.zig");
 const DocumentStore = @import("document_store.zig");
 const types = @import("types.zig");
-const ast = std.zig.ast;
+const ast = std.zig.Ast;
 const Token = std.zig.Token;
 const identifierFromPosition = @import("main.zig").identifierFromPosition;
+const SignatureHelp = @This();
 usingnamespace @import("ast.zig");
 
 fn fnProtoToSignatureInfo(
@@ -58,7 +59,7 @@ fn fnProtoToSignatureInfo(
             if (param_label_start == 0)
                 param_label_start = token_starts[tree.firstToken(param.type_expr)];
 
-            const last_param_tok = lastToken(tree, param.type_expr);
+            const last_param_tok = SignatureHelp.lastToken(tree, param.type_expr);
             param_label_end = token_starts[last_param_tok] + tree.tokenSlice(last_param_tok).len;
         }
         const param_label = tree.source[param_label_start..param_label_end];
@@ -287,7 +288,7 @@ pub fn getSignatureInfo(
                     };
 
                     var buf: [1]ast.Node.Index = undefined;
-                    if (fnProto(type_handle.handle.tree, node, &buf)) |proto| {
+                    if (SignatureHelp.fnProto(type_handle.handle.tree, node, &buf)) |proto| {
                         return try fnProtoToSignatureInfo(
                             document_store,
                             arena,
@@ -339,7 +340,7 @@ pub fn getSignatureInfo(
                         }
                     }
 
-                    if (fnProto(res_handle.tree, node, &buf)) |proto| {
+                    if (SignatureHelp.fnProto(res_handle.tree, node, &buf)) |proto| {
                         return try fnProtoToSignatureInfo(
                             document_store,
                             arena,


### PR DESCRIPTION
* Adds `pub const Tree = ast` in ast.zig
* Adds `const [FileName] = @This()` to all files that were using `usingnamespace @import('ast.zig')`
  - analysis.zig
  - references.zig 
  - semantic_tokens.zig 
  - signature_help.zig
* Fixes std.zig.Ast.Tree references
  - by referencing Tree from ast.zig in files with usingnamespace
  - by adding `const Tree = std.zig.Ast` in other files
* Fixes rename of full.PtrType.Ast to full.PtrType.Components