### PR TITLE
Fix off-by-one deinit on DocumentStore

### DIFF
--- a/src/DocumentStore.zig
+++ b/src/DocumentStore.zig
@@ -190,7 +190,8 @@ fn newDocument(self: *DocumentStore, uri: []const u8, text: [:0]u8) anyerror!*Ha
         .document = .{
             .uri = uri,
             .text = text,
-            .mem = text,
+            // Extra +1 to include the null terminator
+            .mem = text.ptr[0 .. text.len + 1],
         },
         .tree = tree,
         .document_scope = document_scope,


### PR DESCRIPTION
This value is [allocated as `[:0]u8`](https://github.com/zigtools/zls/blob/088dc570de3870ababd35a94ac67b0f60c61361b/src/DocumentStore.zig#L299) but the sentinel is being erased, so deinitting later is triggering off-by-one error.

Identified by [functional tests in `analysis-buddy`](https://github.com/fengb/analysis-buddy/blob/64b25498788742744c90cdfa386432fe46c9f3bc/src/main.zig#L308-L323) but I'm not sure the best way to port them in.