### PR TITLE
Update Sublime LSP settings for Sublime Text 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,20 +118,36 @@ You can install `zls` using the instuctions for your text editor below:
 
 Install the `zls-vscode` extension from [here](https://github.com/zigtools/zls-vscode/releases) and provide a path to the build `zls` executable.
 
-### Sublime Text 3
+### Sublime Text
 
 - Install the `LSP` package from [here](https://github.com/sublimelsp/LSP/releases) or via Package Control.
 - Add this snippet to `LSP's` user settings:
 
+#### For Sublime Text 3:
+
 ```json
 {
     "clients": {
-        "zig":{
+        "zig": {
             "command": ["zls"],
             "enabled": true,
             "languageId": "zig",
             "scopes": ["source.zig"],
             "syntaxes": ["Packages/Zig Language/Syntaxes/Zig.tmLanguage"]
+        }
+    }
+}
+```
+
+#### For Sublime Text 4:
+
+```json
+{
+    "clients": {
+        "zig": {
+            "command": ["zls"],
+            "enabled": true,
+            "selector": "source.zig"
         }
     }
 }

--- a/src/setup.zig
+++ b/src/setup.zig
@@ -127,6 +127,8 @@ pub fn wizard(allocator: *std.mem.Allocator) !void {
                 \\https://github.com/sublimelsp/LSP/releases or via Package Control.
                 \\Then, add the following snippet to LSP's user settings:
                 \\
+                \\For Sublime Text 3:
+                \\
                 \\{
                 \\  "clients": {
                 \\    "zig": {
@@ -134,7 +136,19 @@ pub fn wizard(allocator: *std.mem.Allocator) !void {
                 \\      "enabled": true,
                 \\      "languageId": "zig",
                 \\      "scopes": ["source.zig"],
-                \\      "syntaxes": ["Packages/Zig/Syntaxes/Zig.tmLanguage"]
+                \\      "syntaxes": ["Packages/Zig Language/Syntaxes/Zig.tmLanguage"]
+                \\    }
+                \\  }
+                \\}
+                \\
+                \\For Sublime Text 4:
+                \\
+                \\{
+                \\  "clients": {
+                \\    "zig": {
+                \\      "command": ["zls"],
+                \\      "enabled": true,
+                \\      "selector": "source.zig"
                 \\    }
                 \\  }
                 \\}


### PR DESCRIPTION
"selector" is now the preferred method of configuration, everything else was deprecated in SublimeLSP 4070-1.1.0: https://github.com/sublimelsp/LSP/releases/tag/4070-1.1.0

Also syncs setup.zig with the readme for the Sublime Text 3 settings (the Zig Language package name was wrong in setup.zig)