### PR TITLE
Added build option log_level to allow the user to set the default log level for release builds

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -16,6 +16,12 @@ pub fn build(b: *std.build.Builder) !void {
         b.option(shared.ZigVersion, "data_version", "The Zig version your compiler is.") orelse .master,
     );
 
+    exe_options.addOption(
+        std.log.Level,
+        "log_level",
+        b.option(std.log.Level, "log_level", "The Log Level to be used.") orelse .warn,
+    );
+
     exe.addPackage(.{ .name = "known-folders", .path = .{ .path = "src/known-folders/known-folders.zig" } });
     exe.addPackage(.{ .name = "zinput", .path = .{ .path = "src/zinput/src/main.zig" } });
 

--- a/build.zig
+++ b/build.zig
@@ -19,7 +19,7 @@ pub fn build(b: *std.build.Builder) !void {
     exe_options.addOption(
         std.log.Level,
         "log_level",
-        b.option(std.log.Level, "log_level", "The Log Level to be used.") orelse .warn,
+        b.option(std.log.Level, "log_level", "The Log Level to be used.") orelse .info,
     );
 
     exe.addPackage(.{ .name = "known-folders", .path = .{ .path = "src/known-folders/known-folders.zig" } });

--- a/src/main.zig
+++ b/src/main.zig
@@ -33,7 +33,7 @@ pub const log_level = .debug;
 
 var actual_log_level: std.log.Level = switch (zig_builtin.mode) {
     .Debug => .debug,
-    else => .info,
+    else => build_options.log_level,
 };
 
 pub fn log(comptime message_level: std.log.Level, comptime scope: @Type(.EnumLiteral), comptime format: []const u8, args: anytype) void {


### PR DESCRIPTION
By default on release builds the log level is set to `.info`; However, it would be nice if it was possible to override the default value. So I added the build option `log_level`. 

note: Setting log level to `.warn` also removes the constant notifications on VSCode.