### PR TITLE
Change notification method in log

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -61,9 +61,9 @@ pub fn log(comptime message_level: std.log.Level, comptime scope: @Type(.EnumLit
         .err => .Error,
     };
     send(&arena, types.Notification{
-        .method = "window/showMessage",
+        .method = "window/logMessage",
         .params = types.Notification.Params{
-            .ShowMessage = .{
+            .LogMessage = .{
                 .type = message_type,
                 .message = message,
             },


### PR DESCRIPTION
Currently in the log function in main, the notification method used to send logs to the client is "window/showMessage". This creates an a notification on the UI on VSCode that can cause slow downs. I propose a change to use the  "window/logMessage" method instead, which is intended to be used for logging.