### PR TITLE
only send format editings when necessary

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1650,6 +1650,8 @@ fn formattingHandler(arena: *std.heap.ArenaAllocator, id: types.RequestId, req: 
 
         switch (try process.wait()) {
             .Exited => |code| if (code == 0) {
+                if (std.mem.eql(u8, handle.document.text, stdout_bytes)) return try respondGeneric(id, null_result_response);
+
                 return try send(arena, types.Response{
                     .id = id,
                     .result = .{


### PR DESCRIPTION
If the original document is same as the formatted one, there's no need to send the unchanged
document's content back which will make the client confused.