### PR TITLE
Fix errors that are caused by using deprecated functions

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -98,7 +98,7 @@ pub fn getFunctionSnippet(allocator: *std.mem.Allocator, tree: Ast, func: Ast.fu
     const name_index = func.name_token.?;
 
     var buffer = std.ArrayList(u8).init(allocator);
-    try buffer.ensureCapacity(128);
+    try buffer.ensureTotalCapacity(128);
 
     try buffer.appendSlice(tree.tokenSlice(name_index));
     try buffer.append('(');

--- a/src/header.zig
+++ b/src/header.zig
@@ -32,7 +32,7 @@ pub fn readRequestHeader(allocator: *std.mem.Allocator, instream: anytype) !Requ
             r.content_length = std.fmt.parseInt(usize, header_value, 10) catch return error.InvalidContentLength;
             has_content_length = true;
         } else if (std.mem.eql(u8, header_name, "Content-Type")) {
-            r.content_type = try std.mem.dupe(allocator, u8, header_value);
+            r.content_type = try allocator.dupe(u8, header_value);
         } else {
             return error.UnknownHeader;
         }

--- a/src/main.zig
+++ b/src/main.zig
@@ -209,7 +209,7 @@ fn publishDiagnostics(arena: *std.heap.ArenaAllocator, handle: DocumentStore.Han
             .severity = .Error,
             .code = @tagName(err.tag),
             .source = "zls",
-            .message = try std.mem.dupe(&arena.allocator, u8, fbs.getWritten()),
+            .message = try arena.allocator.dupe(u8, fbs.getWritten()),
             // .relatedInformation = undefined
         });
     }
@@ -1769,7 +1769,7 @@ pub fn main() anyerror!void {
                             &std.json.TokenStream.init(zig_env_result.stdout),
                             .{ .allocator = allocator },
                         ) catch {
-                            logger.alert("Failed to parse zig env JSON result", .{});
+                            logger.err("Failed to parse zig env JSON result", .{});
                             break :find_lib_path;
                         };
                         defer std.json.parseFree(Env, json_env, .{ .allocator = allocator });
@@ -1779,7 +1779,7 @@ pub fn main() anyerror!void {
                         logger.info("Using zig lib path '{s}'", .{config.zig_lib_path});
                     }
                 },
-                else => logger.alert("zig env invocation failed", .{}),
+                else => logger.err("zig env invocation failed", .{}),
             }
         }
     } else {
@@ -1828,7 +1828,7 @@ pub fn main() anyerror!void {
 
     while (keep_running) {
         const headers = readRequestHeader(&arena.allocator, reader) catch |err| {
-            logger.crit("{s}; exiting!", .{@errorName(err)});
+            logger.err("{s}; exiting!", .{@errorName(err)});
             return;
         };
         const buf = try arena.allocator.alloc(u8, headers.content_length);

--- a/src/setup.zig
+++ b/src/setup.zig
@@ -96,7 +96,7 @@ pub fn wizard(allocator: *std.mem.Allocator) !void {
         else => 1024 * 1024,
     };
 
-    std.debug.warn("Writing config to {s}/zls.json ... ", .{config_path});
+    std.debug.print("Writing config to {s}/zls.json ... \n", .{config_path});
 
     try std.json.stringify(.{
         .zig_exe_path = zig_exe_path,

--- a/src/setup.zig
+++ b/src/setup.zig
@@ -96,7 +96,7 @@ pub fn wizard(allocator: *std.mem.Allocator) !void {
         else => 1024 * 1024,
     };
 
-    std.debug.print("Writing config to {s}/zls.json ... \n", .{config_path});
+    std.debug.print("Writing config to {s}/zls.json ... ", .{config_path});
 
     try std.json.stringify(.{
         .zig_exe_path = zig_exe_path,

--- a/src/unit_tests.zig
+++ b/src/unit_tests.zig
@@ -39,13 +39,13 @@ fn testContext(comptime line: []const u8, comptime tag: anytype, comptime range:
     const ctx = try analysis.documentPositionContext(&arena, doc, p);
 
     if (std.meta.activeTag(ctx) != tag) {
-        std.debug.warn("Expected tag {}, got {}\n", .{ tag, std.meta.activeTag(ctx) });
+        std.debug.print("Expected tag {}, got {}\n", .{ tag, std.meta.activeTag(ctx) });
         return error.DifferentTag;
     }
 
     if (ctx.range()) |ctx_range| {
         if (range == null) {
-            std.debug.warn("Expected null range, got `{s}`\n", .{
+            std.debug.print("Expected null range, got `{s}`\n", .{
                 doc.text[ctx_range.start..ctx_range.end],
             });
         } else {
@@ -53,7 +53,7 @@ fn testContext(comptime line: []const u8, comptime tag: anytype, comptime range:
             const range_end = range_start + range.?.len;
 
             if (range_start != ctx_range.start or range_end != ctx_range.end) {
-                std.debug.warn("Expected range `{s}` ({}..{}), got `{s}` ({}..{})\n", .{
+                std.debug.print("Expected range `{s}` ({}..{}), got `{s}` ({}..{})\n", .{
                     doc.text[range_start..range_end],         range_start,     range_end,
                     doc.text[ctx_range.start..ctx_range.end], ctx_range.start, ctx_range.end,
                 });
@@ -61,7 +61,7 @@ fn testContext(comptime line: []const u8, comptime tag: anytype, comptime range:
             }
         }
     } else if (range != null) {
-        std.debug.warn("Unexpected null range\n", .{});
+        std.debug.print("Unexpected null range\n", .{});
         return error.DifferentRange;
     }
 }


### PR DESCRIPTION
Just renamed some stuff to make the code compile when using the master branch of Zig.
#426 