### PR TITLE
c_void -> anyopaque

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -608,7 +608,7 @@ pub fn isTypeIdent(tree: Ast, token_idx: Ast.TokenIndex) bool {
         .{"c_int"},          .{"c_uint"},
         .{"c_long"},         .{"c_ulong"},
         .{"c_longlong"},     .{"c_ulonglong"},
-        .{"c_longdouble"},   .{"c_void"},
+        .{"c_longdouble"},   .{"anyopaque"},
         .{"f16"},            .{"f32"},
         .{"f64"},            .{"f128"},
         .{"bool"},           .{"void"},


### PR DESCRIPTION
Replaces occurrences of `c_void` to `anyopaque` as per ziglang/zig@9f9f215305389c08a21730859982b68bf2681932. The only occurrence I could find was in `src/analysis.zig`.

Edit: To compile on zig master `known-folders` will need to be updated after ziglibs/known-folders#26 gets merged.