### PR TITLE
Update prebuilt release URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You can install the latest release into `$HOME/zls` using e.g.:
 
 ```sh
 brew install xz
-mkdir $HOME/zls && cd $HOME/zls && curl -L https://github.com/zigtools/zls/releases/download/0.1.0/x86_64-macos.tar.xz | tar -xJ --strip-components=1 -C .
+mkdir $HOME/zls && cd $HOME/zls && curl -L https://github.com/zigtools/zls/releases/download/0.9.0/x86_64-macos.tar.xz | tar -xJ --strip-components=1 -C .
 ```
 
 #### Linux
@@ -45,7 +45,7 @@ You can install the latest release into `$HOME/zls` using e.g.:
 
 ```
 sudo apt install xz-utils
-mkdir $HOME/zls && cd $HOME/zls && curl -L https://github.com/zigtools/zls/releases/download/0.1.0/x86_64-linux.tar.xz | tar -xJ --strip-components=1 -C .
+mkdir $HOME/zls && cd $HOME/zls && curl -L https://github.com/zigtools/zls/releases/download/0.9.0/x86_64-linux.tar.xz | tar -xJ --strip-components=1 -C .
 ```
 
 ### From Source


### PR DESCRIPTION
The current URLs in the prebuilt release instructions are very out of date — I initially downloaded a super old `zls` as I assumed I could just copy and paste the command.

This PR updates the URLs for the 0.9.0 release.