### PR TITLE
add type function symbols to document symbol outline

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -1809,6 +1809,16 @@ fn getDocumentSymbolsInternal(allocator: std.mem.Allocator, tree: Ast, node: Ast
                 if (var_decl.ast.init_node != 0)
                     try addOutlineNodes(allocator, tree, var_decl.ast.init_node, &child_context);
             }
+            if (tags[node] == .fn_decl) fn_ch: {
+                const fn_decl = tree.nodes.items(.data)[node];
+                var params: [1]Ast.Node.Index = undefined;
+                const fn_proto = ast.fnProto(tree, fn_decl.lhs, &params) orelse break :fn_ch;
+                if (!isTypeFunction(tree, fn_proto)) break :fn_ch;
+                const ret_stmt = findReturnStatement(tree, fn_proto, fn_decl.rhs) orelse break :fn_ch;
+                const type_decl = tree.nodes.items(.data)[ret_stmt].lhs;
+                if (type_decl != 0)
+                    try addOutlineNodes(allocator, tree, type_decl, &child_context);
+            }
             break :ch children.items;
         },
     };


### PR DESCRIPTION
### Description
ZLS skips Type Functions when enumerating the document symbols. This leads to a lot of standard library files looking like this in the VSCode Document Outline:
![image](https://user-images.githubusercontent.com/505737/149112240-ca5af425-8a3d-47b6-b760-b4f7d07ee855.png)

With the PR, it looks like:
![image](https://user-images.githubusercontent.com/505737/149113557-b4359ddb-a311-4a45-b1a7-490199a01f21.png)
Go To Document Symbol also works: 
![image](https://user-images.githubusercontent.com/505737/149113758-ed1c85c0-0ce2-4ca1-b7a6-f4fc9d0440f2.png)

### Change
Recurse into functions if they are a type function

### Questions
I'm not too familiar with VSCode extensions or the ZLS codebase. I ran the tests and did some sanity manual testing but please review accordingly

- `getDocumentSymbolsInternal`: from looking at the code + cross referencing VSCode Api, looks like its just used to enumerate document symbols (call tree: `documentSymbol()->getDocumentSymbols()->getDocumentSymbolsInternal()`)
  - sanity check: are there any other places this modification needs to be propogated?
  - sanity check: specifically so that symbol resolve/rename/goto def/etc aren't broken?
- error handling: unsure what the pre/post conditions are of the parse tree when `getDocumentSymbolsInternal` is invoked
  so there might be superflous guards/checks
- any tests to add?