### PR TITLE
Fix ZLS config not found crash #410

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1721,6 +1721,7 @@ pub fn main() anyerror!void {
             }
         }
         logger.info("No config file zls.json found.", .{});
+        config_path = null;
     }
 
     // Find the zig executable in PATH


### PR DESCRIPTION
Hi there, first open source contribution to other project. Please review the PR and comment if you see anything wrong.
This fixes a crash when the ZLS configuration file could not be found and yet still the value of the string wasn't null.