### PR TITLE
make loadPackages() work for big build.zig files

### DIFF
--- a/src/DocumentStore.zig
+++ b/src/DocumentStore.zig
@@ -147,6 +147,7 @@ fn loadPackages(context: LoadPackagesContext) !void {
             context.cache_root,
             context.global_cache_root,
         },
+        .max_output_bytes = 50 * 1024 * 1024,
     });
 
     defer {


### PR DESCRIPTION
Hey there, I'm currently working on a project in which the build.zig file has been steadily growing, and at some point my ZLS just stopped working: no autocompletion, no gotodef, no nothing for any package outside of `std`. :(

Turns out the culprit was the `loadPackages` function that `exec`s some parsing stuff and pipes back the output... unfortunately the default parameters for `exec` only allow up to 50k of data to be collected through stdout by default ¯\\\_(ツ)\_/¯.
