### PR TITLE
Skip char and string literals when highlighting comments

### DIFF
--- a/src/semantic_tokens.zig
+++ b/src/semantic_tokens.zig
@@ -138,6 +138,30 @@ const Builder = struct {
 
         var i: usize = from;
         while (i < to - 1) : (i += 1) {
+            // Skip multi-line string literals
+            if (source[i] == '\\' and source[i + 1] == '\\') {
+                while (i < to - 1 and source[i] != '\n') : (i += 1) {}
+                continue;
+            }
+            // Skip normal string literals
+            if (source[i] == '"') {
+                i += 1;
+                while (i < to - 1 and
+                    source[i] != '\n' and
+                    !(source[i] == '"' and source[i - 1] != '\\')) : (i += 1)
+                {}
+                continue;
+            }
+            // Skip char literals
+            if (source[i] == '\'') {
+                i += 1;
+                while (i < to - 1 and
+                    source[i] != '\n' and
+                    !(source[i] == '\'' and source[i - 1] != '\\')) : (i += 1)
+                {}
+                continue;
+            }
+ 
             if (source[i] != '/' or source[i + 1] != '/')
                 continue;
 


### PR DESCRIPTION
The comment highlighting appears to take priority over string and char literals, leading to syntax highlighting like this:
![image](https://user-images.githubusercontent.com/7458092/154175873-91dfa61d-f6e5-48d6-b080-b3d14d30adda.png)

These changes should make it skip string and char literals when scanning for comments.
