### PR TITLE
Fix missing doc comment for `inline fn`

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -55,6 +55,7 @@ pub fn getDocCommentTokenIndex(tokens: []std.zig.Token.Tag, base_token: Ast.Toke
     if (tokens[idx] == .string_literal and idx > 1 and tokens[idx - 1] == .keyword_extern) idx -= 1;
     if (tokens[idx] == .keyword_extern and idx > 0) idx -= 1;
     if (tokens[idx] == .keyword_export and idx > 0) idx -= 1;
+    if (tokens[idx] == .keyword_inline and idx > 0) idx -= 1;
     if (tokens[idx] == .keyword_pub and idx > 0) idx -= 1;
 
     // Find first doc comment token


### PR DESCRIPTION
<img width="928" alt="image" src="https://user-images.githubusercontent.com/709451/164643247-4a0b9370-0bd7-4d00-b5d3-761de7e3c817.png">
