### PR TITLE
Implement textDocument/documentHighlight

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -1151,6 +1151,7 @@ fn referencesDefinitionGlobal(
         &locs,
         std.ArrayList(types.Location).append,
         server.config.skip_std_references,
+        !highlight,
     );
 
     const result: types.ResponseParams = if (highlight) result: {
@@ -1185,7 +1186,17 @@ fn referencesDefinitionFieldAccess(
 
     const decl = (try server.getSymbolFieldAccess(handle, arena, position, range)) orelse return try respondGeneric(id, null_result_response);
     var locs = std.ArrayList(types.Location).init(arena.allocator());
-    try references.symbolReferences(arena, &server.document_store, decl, server.offset_encoding, include_decl, &locs, std.ArrayList(types.Location).append, server.config.skip_std_references);
+    try references.symbolReferences(
+        arena,
+        &server.document_store,
+        decl,
+        server.offset_encoding,
+        include_decl,
+        &locs,
+        std.ArrayList(types.Location).append,
+        server.config.skip_std_references,
+        !highlight,
+    );
     const result: types.ResponseParams = if (highlight) result: {
         var highlights = try std.ArrayList(types.DocumentHighlight).initCapacity(arena.allocator(), locs.items.len);
         for (locs.items) |loc| {

--- a/src/rename.zig
+++ b/src/rename.zig
@@ -31,7 +31,7 @@ pub fn renameSymbol(arena: *std.heap.ArenaAllocator, store: *DocumentStore, decl
         .edits = edits,
         .allocator = arena.allocator(),
         .new_name = new_name,
-    }, refHandler, true);
+    }, refHandler, true, true);
 }
 
 pub fn renameLabel(arena: *std.heap.ArenaAllocator, decl_handle: analysis.DeclWithHandle, new_name: []const u8, edits: *std.StringHashMap([]types.TextEdit), encoding: offsets.Encoding) !void {

--- a/src/requests.zig
+++ b/src/requests.zig
@@ -165,6 +165,7 @@ pub const Initialize = struct {
                     documentationFormat: MaybeStringArray,
                 },
             },
+            documentHighlight: Exists,
         },
         offsetEncoding: MaybeStringArray,
     };
@@ -244,6 +245,7 @@ pub const GotoDeclaration = TextDocumentIdentifierPositionRequest;
 pub const Hover = TextDocumentIdentifierPositionRequest;
 pub const DocumentSymbols = TextDocumentIdentifierRequest;
 pub const Formatting = TextDocumentIdentifierRequest;
+pub const DocumentHighlight = TextDocumentIdentifierPositionRequest;
 pub const Rename = struct {
     params: struct {
         textDocument: TextDocumentIdentifier,

--- a/src/types.zig
+++ b/src/types.zig
@@ -45,6 +45,7 @@ pub const ResponseParams = union(enum) {
     InitializeResult: InitializeResult,
     ConfigurationParams: ConfigurationParams,
     RegistrationParams: RegistrationParams,
+    DocumentHighlight: []DocumentHighlight,
 };
 
 /// JSONRPC notifications
@@ -411,4 +412,19 @@ pub const RegistrationParams = struct {
 
         // registerOptions?: LSPAny;
     };
+};
+
+pub const DocumentHighlightKind = enum(u8) {
+    Text = 1,
+    Read = 2,
+    Write = 3,
+
+    pub fn jsonStringify(value: DocumentHighlightKind, options: std.json.StringifyOptions, out_stream: anytype) !void {
+        try std.json.stringify(@enumToInt(value), options, out_stream);
+    }
+};
+
+pub const DocumentHighlight = struct {
+    range: Range,
+    kind: ?DocumentHighlightKind,
 };


### PR DESCRIPTION
This is an attempt to implement the `textDocument/documentHighlight` response.

`documentHighlight` is essentially the same as `textDocument/references` with the only differences being:

1. There are no parameters sent in the request
2. The response includes a `DocumentHighlightKind`

For now I've hardcoded the `kind` to simply `Text`, but a more sophisticated implementation would correctly set the kind to `Read` or `Write` where appropriate. I will look into doing this, but help is appreciated.

In my limited testing this seems to mostly work, but there are still some bugs I need to chase down. I wanted to go ahead and open this PR though to get some early feedback on the approach.
