### PR TITLE
expected error union type, found 'std.child_process.ChildProcess'

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1454,8 +1454,7 @@ fn formattingHandler(arena: *std.heap.ArenaAllocator, id: types.RequestId, req: 
             return try respondGeneric(id, null_result_response);
         };
 
-        var process = try std.ChildProcess.init(&[_][]const u8{ zig_exe_path, "fmt", "--stdin" }, allocator);
-        defer process.deinit();
+        var process = std.ChildProcess.init(&[_][]const u8{ zig_exe_path, "fmt", "--stdin" }, allocator);
         process.stdin_behavior = .Pipe;
         process.stdout_behavior = .Pipe;
 


### PR DESCRIPTION
as I understand that std.ChildProcess.init doesn't return error union type anymore:
```
./src/main.zig:1457:48: error: expected error union type, found 'std.child_process.ChildProcess'
        var process = try std.ChildProcess.init(&[_][]const u8{ zig_exe_path, "fmt", "--stdin" }, allocator);
```
Also, ChildProcess doesn't have deinit() method.