### PR TITLE
Fix `std.math.cast`, `std.ChildProcess`, tests on Windows and enable Windows in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,9 +27,7 @@ jobs:
       - name: Build
         run: zig build
 
-      # ZLS Tests currently fail on windows? Once they are passing and kept up to date, this can be enabled everywhere
       - name: Run Tests
-        if: ${{ matrix.os == 'ubuntu-latest' }}
         run: zig build test
 
       - name: Build artifacts

--- a/build.zig
+++ b/build.zig
@@ -36,10 +36,12 @@ pub fn build(b: *std.build.Builder) !void {
 
     var unit_tests = b.addTest("src/unit_tests.zig");
     unit_tests.setBuildMode(.Debug);
+    unit_tests.setTarget(target);
     test_step.dependOn(&unit_tests.step);
 
     var session_tests = b.addTest("tests/sessions.zig");
     session_tests.addPackage(.{ .name = "header", .source = .{ .path = "src/header.zig" } });
     session_tests.setBuildMode(.Debug);
+    session_tests.setTarget(target);
     test_step.dependOn(&session_tests.step);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -1454,8 +1454,7 @@ fn formattingHandler(arena: *std.heap.ArenaAllocator, id: types.RequestId, req: 
             return try respondGeneric(id, null_result_response);
         };
 
-        var process = try std.ChildProcess.init(&[_][]const u8{ zig_exe_path, "fmt", "--stdin" }, allocator);
-        defer process.deinit();
+        var process = std.ChildProcess.init(&[_][]const u8{ zig_exe_path, "fmt", "--stdin" }, allocator);
         process.stdin_behavior = .Pipe;
         process.stdout_behavior = .Pipe;
 
@@ -1656,7 +1655,7 @@ pub fn main() anyerror!void {
     // Check arguments.
     var args_it = try std.process.ArgIterator.initWithAllocator(allocator);
     defer args_it.deinit();
-    if(!args_it.skip()) @panic("Could not find self argument");
+    if (!args_it.skip()) @panic("Could not find self argument");
 
     var config_path: ?[]const u8 = null;
     var next_arg_config_path = false;

--- a/src/requests.zig
+++ b/src/requests.zig
@@ -114,11 +114,11 @@ fn fromDynamicTreeInternal(arena: *std.heap.ArenaAllocator, value: std.json.Valu
         if (value != .Integer) return error.MalformedJson;
         out.* = std.meta.intToEnum(
             T,
-            std.math.cast(TagType, value.Integer) catch return error.MalformedJson,
+            std.math.cast(TagType, value.Integer) orelse return error.MalformedJson,
         ) catch return error.MalformedJson;
     } else if (comptime std.meta.trait.is(.Int)(T)) {
         if (value != .Integer) return error.MalformedJson;
-        out.* = std.math.cast(T, value.Integer) catch return error.MalformedJson;
+        out.* = std.math.cast(T, value.Integer) orelse return error.MalformedJson;
     } else switch (T) {
         bool => {
             if (value != .Bool) return error.MalformedJson;

--- a/tests/sessions.zig
+++ b/tests/sessions.zig
@@ -13,7 +13,7 @@ const initialize_msg_offs =
 ;
 
 const Server = struct {
-    process: *std.ChildProcess,
+    process: std.ChildProcess,
     request_id: u32 = 1,
 
     fn start(initialization: []const u8, expect: ?[]const u8) !Server {
@@ -103,12 +103,11 @@ const Server = struct {
         // FIXME this shutdown request fails with a broken pipe on stdin on the CI
         self.request("shutdown", "{}", null) catch @panic("Could not send shutdown request");
         // waitNoError(self.process) catch @panic("Server error");
-        self.process.deinit();
     }
 };
 
-fn startZls() !*std.ChildProcess {
-    var process = try std.ChildProcess.init(&[_][]const u8{"zig-out/bin/zls" ++ suffix}, allocator);
+fn startZls() !std.ChildProcess {
+    var process = std.ChildProcess.init(&[_][]const u8{"zig-out/bin/zls" ++ suffix}, allocator);
     process.stdin_behavior = .Pipe;
     process.stdout_behavior = .Pipe;
     process.stderr_behavior = .Inherit;

--- a/tests/sessions.zig
+++ b/tests/sessions.zig
@@ -154,10 +154,10 @@ test "Open file, ask for semantic tokens" {
     defer server.shutdown();
 
     try server.request("textDocument/didOpen",
-        \\{"textDocument":{"uri":"file://./tests/test.zig","languageId":"zig","version":420,"text":"const std = @import(\"std\");"}}
+        \\{"textDocument":{"uri":"file:///test.zig","languageId":"zig","version":420,"text":"const std = @import(\"std\");"}}
     , null);
     try server.request("textDocument/semanticTokens/full",
-        \\{"textDocument":{"uri":"file://./tests/test.zig"}}
+        \\{"textDocument":{"uri":"file:///test.zig"}}
     ,
         \\{"data":[0,0,5,7,0,0,6,3,0,33,0,4,1,11,0,0,2,7,12,0,0,8,5,9,0]}
     );
@@ -217,19 +217,23 @@ test "Self-referential definition" {
         \\{"isIncomplete":false,"items":[{"label":"h","kind":21,"textEdit":null,"filterText":null,"insertText":"h","insertTextFormat":1,"detail":"const h = h(0)","documentation":null}]}
     );
 }
-test "Missing return type" {
-    var server = try Server.start(initialize_msg, null);
-    defer server.shutdown();
 
-    try server.request("textDocument/didOpen",
-        \\{"textDocument":{"uri":"file:///test.zig","languageId":"zig","version":420,"text":"fn w() {}\nc"}}
-    , null);
-    try server.request("textDocument/completion",
-        \\{"textDocument":{"uri":"file:///test.zig"}, "position":{"line":1,"character":1}}
-    ,
-        \\{"isIncomplete":false,"items":[{"label":"w","kind":3,"textEdit":null,"filterText":null,"insertText":"w","insertTextFormat":1,"detail":"fn","documentation":null}]}
-    );
-}
+// This test as written depends on the configuration in the *host* machines zls.json, if `enable_snippets` is true then
+// the insert text is "w()" if it is false it is "w"
+//
+// test "Missing return type" {
+//     var server = try Server.start(initialize_msg, null);
+//     defer server.shutdown();
+
+//     try server.request("textDocument/didOpen",
+//         \\{"textDocument":{"uri":"file:///test.zig","languageId":"zig","version":420,"text":"fn w() {}\nc"}}
+//     , null);
+//     try server.request("textDocument/completion",
+//         \\{"textDocument":{"uri":"file:///test.zig"}, "position":{"line":1,"character":1}}
+//     ,
+//         \\{"isIncomplete":false,"items":[{"label":"w","kind":3,"textEdit":null,"filterText":null,"insertText":"w","insertTextFormat":1,"detail":"fn","documentation":null}]}
+//     );
+// }
 
 test "Pointer and optional deref" {
     var server = try Server.start(initialize_msg, null);


### PR DESCRIPTION
The length of time ZLS has been unbuildable with zig master has gotten rather long and there has been multiple PRs to fix it each with a different set of patches...

- #493 Doesn't fix every usage of `std.ChildProcess` and tests are broken
- #490 Doesn't fix every usage of `std.ChildProcess`, tests are broken and doesn't fix `std.math.cast`
- #485 Tests are broken and doesn't fix `std.math.cast`
- #481 Tests are broken and doesn't fix `std.math.cast`

The test "Missing return type" is not a good test as the expected result is dependant on the content of zls.json on the host machine, so I have commented it out.

The test "Open file, ask for semantic tokens" uses a file uri that is invalid on windows, I've changed it to the the same file uri as the other tests.

With these changes the tests pass on windows and can be enabled in the CI.

Fixes #491 
Fixes #483