### PR TITLE
fix off by one error in documentRange

### DIFF
--- a/src/offsets.zig
+++ b/src/offsets.zig
@@ -190,6 +190,8 @@ pub fn documentRange(doc: types.TextDocument, encoding: Encoding) !types.Range {
         curr_line = line;
     }
 
+    if (line_idx > 0) line_idx -= 1;
+
     if (encoding == .utf8) {
         return types.Range{
             .start = .{


### PR DESCRIPTION
Previously ZLS would report the wrong line number as the range end when replying to a `format` request. This is why Helix refused to apply any change.

This same problem might be present somewhere else, I only checked this function in order to fix my own problem.