### PR TITLE
Label details support

### DIFF
--- a/src/requests.zig
+++ b/src/requests.zig
@@ -158,6 +158,7 @@ pub const Initialize = struct {
             completion: ?struct {
                 completionItem: ?struct {
                     snippetSupport: Default(bool, false),
+                    labelDetailsSupport: Default(bool, true),
                     documentationFormat: MaybeStringArray,
                 },
             },

--- a/src/types.zig
+++ b/src/types.zig
@@ -208,7 +208,7 @@ pub const InsertTextFormat = enum(i64) {
 };
 
 pub const CompletionItem = struct {
-    const Kind = enum(i64) {
+    pub const Kind = enum(i64) {
         Text = 1,
         Method = 2,
         Function = 3,
@@ -241,13 +241,25 @@ pub const CompletionItem = struct {
     };
 
     label: string,
+    labelDetails: ?CompletionItemLabelDetails = null,
     kind: Kind,
-    textEdit: ?TextEdit = null,
-    filterText: ?string = null,
-    insertText: string = "",
-    insertTextFormat: ?InsertTextFormat = .PlainText,
     detail: ?string = null,
+
+    sortText: ?string = null,
+    filterText: ?string = null,
+    insertText: ?string = null,
+
+    insertTextFormat: ?InsertTextFormat = .PlainText,
     documentation: ?MarkupContent = null,
+    
+    // FIXME: i commented this out, because otherwise the vscode client complains about *ranges*
+    // and breaks code completion entirely
+    // textEdit: ?TextEdit = null, 
+};
+
+pub const CompletionItemLabelDetails = struct {
+    detail: ?string,
+    description: ?string,
 };
 
 pub const DocumentSymbol = struct {
@@ -338,6 +350,7 @@ const InitializeResult = struct {
         completionProvider: struct {
             resolveProvider: bool,
             triggerCharacters: []const string,
+            completionItem: struct { labelDetailsSupport: bool },
         },
         documentHighlightProvider: bool,
         hoverProvider: bool,

--- a/src/types.zig
+++ b/src/types.zig
@@ -254,6 +254,7 @@ pub const CompletionItem = struct {
     
     // FIXME: i commented this out, because otherwise the vscode client complains about *ranges*
     // and breaks code completion entirely
+    // see: https://github.com/zigtools/zls-vscode/pull/33
     // textEdit: ?TextEdit = null, 
 };
 


### PR DESCRIPTION
This enables label details support for the server for compatible clients

I don't really like the implementation, i left a note, it is very loosy and to be honest, i don't think we should rely on it, but it gets the job done for now, and the result is anyways, IMO, much better than before, so i guess it worth keeping for now, i made sure it sits in a separate function and is not coupled to the entire program, so it is easy to just remove

It can get very noisy though, so maybe some more work needs to be done to slim things a little bit and only show more function detail when the item is selected/hovered for example, but i'm not sure how to do that yet!

To enable it, you'll also need an updated version of the vscode plugin, i sent a PR here: https://github.com/zigtools/zls-vscode/pull/33

There is also a bug in ZLS somewhere (not related to this PR), so it should be investigated, please read the PR on the vscode plugin repo for details

Here some screenshots: 

![image](https://user-images.githubusercontent.com/44361234/175329745-095a6bbb-0c71-4db3-9bd5-91f73f416c83.png)


![image](https://user-images.githubusercontent.com/44361234/175327687-231abf88-b7b9-4a4c-a843-f94088b7ac17.png)

![image](https://user-images.githubusercontent.com/44361234/175327416-fac1c8c8-4072-498e-9d3d-2425fbd83c20.png)

![image](https://user-images.githubusercontent.com/44361234/175327991-7dc9fde0-b8c7-4ebd-929d-5cabd271e3e1.png)

![image](https://user-images.githubusercontent.com/44361234/175328116-3e150a65-0c91-4433-8d33-a401dd206861.png)

And here the noisy screenshot

![image](https://user-images.githubusercontent.com/44361234/175328440-329bc351-1921-4d12-bb6a-87d2d08476be.png)
