### PR TITLE
Fix function snippets not working with details

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1307,8 +1307,6 @@ fn formatDetailledLabel(item: *types.CompletionItem, alloc: std.mem.Allocator) !
             return;
         }
 
-        item.insertText = item.label;
-        item.insertTextFormat = .PlainText;
         item.detail = item.label;
         item.labelDetails = .{ .detail = it[s .. e + 1], .description = it[e + 1 ..] };
 


### PR DESCRIPTION
Let's hope this fix works on all editors and not just VSCode; LSP "standard" moment...

Closes #510