### PR TITLE
Fix build.zig typo for enable_tracy using better wording

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -22,7 +22,7 @@ pub fn build(b: *std.build.Builder) !void {
         b.option(std.log.Level, "log_level", "The Log Level to be used.") orelse .info,
     );
 
-    const enable_tracy = b.option(bool, "enable_tracy", "Whether of not tracy should be enabled.") orelse false;
+    const enable_tracy = b.option(bool, "enable_tracy", "Whether tracy should be enabled.") orelse false;
 
     exe_options.addOption(
         bool,


### PR DESCRIPTION
Fixes the misspelling of `to` as `of` by removing `of not` at [build.zig#L25](https://github.com/zigtools/zls/blob/5838a34101343e801f19cb080c0dc70c68dd0c93/build.zig#L25) as it is not required for the sentence to make sense.