### PR TITLE
Workspace configuration server request model implemented!

### DIFF
--- a/src/Config.zig
+++ b/src/Config.zig
@@ -9,10 +9,10 @@ enable_unused_variable_warnings: bool = false,
 /// Whether to enable import/embedFile argument completions (NOTE: these are triggered manually as updating the autotrigger characters may cause issues)
 enable_import_embedfile_argument_completions: bool = false,
 
-/// zig library path
+/// Zig library path
 zig_lib_path: ?[]const u8 = null,
 
-/// zig executable path used to run the custom build runner.
+/// Zig executable path used to run the custom build runner.
 /// May be used to find a lib path if none is provided.
 zig_exe_path: ?[]const u8 = null,
 
@@ -36,10 +36,11 @@ operator_completions: bool = true,
 include_at_in_builtins: bool = false,
 
 /// The detail field of completions is truncated to be no longer than this (in bytes).
-max_detail_length: usize = 1024 * 1024,
+max_detail_length: usize = 1048576,
 
 /// Skips references to std. This will improve lookup speeds.
 /// Going to definition however will continue to work
 skip_std_references: bool = false,
 
+/// Path to "builtin;" useful for debugging, automatically set if let null
 builtin_path: ?[]const u8 = null,

--- a/src/data/generate-vscode-config.js
+++ b/src/data/generate-vscode-config.js
@@ -1,0 +1,47 @@
+// Run with node
+
+const fs = require("fs");
+const path = require("path");
+
+const sourceOfTruth = fs.readFileSync(path.join(__dirname, "..", "Config.zig"));
+
+const lines = sourceOfTruth.toString().split("\n");
+
+function mapType(type) {
+    switch (type) {
+        case "?[]const u8":
+            return "string";
+
+        case "bool":
+            return "boolean";
+
+        case "usize":
+            return "integer";
+    
+        default:
+            throw new Error("unknown type!");
+    }
+}
+
+let comment = null;
+for (const line of lines) {
+    if (line.startsWith("///")) {
+        if (comment === null) comment = line.slice(3).trim();
+        else comment += line.slice(3);
+    } else if (comment) {
+        const name = line.split(":")[0].trim();
+        const type = line.split(":")[1].split("=")[0].trim();
+        const defaultValue = line.split(":")[1].split("=")[1].trim().replace(",","");
+        
+        // console.log(name, type, defaultValue);
+
+        console.log(`"zls.${name}": ${JSON.stringify({
+            "scope": "resource",
+            "type": mapType(type),
+            "description": comment,
+            "default": JSON.parse(defaultValue)
+        })},`);
+
+        comment = null;
+    }
+}

--- a/src/requests.zig
+++ b/src/requests.zig
@@ -148,6 +148,9 @@ pub const Initialize = struct {
     pub const ClientCapabilities = struct {
         workspace: ?struct {
             configuration: Default(bool, false),
+            didChangeConfiguration: ?struct {
+                dynamicRegistration: Default(bool, false), // NOTE: Should this be true? Seems like this critical feature should be nearly universal
+            },
             workspaceFolders: Default(bool, false),
         },
         textDocument: ?struct {

--- a/src/types.zig
+++ b/src/types.zig
@@ -44,6 +44,7 @@ pub const ResponseParams = union(enum) {
     WorkspaceEdit: WorkspaceEdit,
     InitializeResult: InitializeResult,
     ConfigurationParams: ConfigurationParams,
+    RegistrationParams: RegistrationParams,
 };
 
 /// JSONRPC notifications
@@ -77,6 +78,7 @@ pub const Response = struct {
 
 pub const Request = struct {
     jsonrpc: string = "2.0",
+    id: RequestId,
     method: []const u8,
     params: ?ResponseParams,
 };
@@ -398,5 +400,16 @@ pub const ConfigurationParams = struct {
     pub const ConfigurationItem = struct {
         scopeUri: ?[]const u8,
         section: ?[]const u8,
+    };
+};
+
+pub const RegistrationParams = struct {
+    registrations: []const Registration,
+
+    pub const Registration = struct {
+        id: string,
+        method: string,
+
+        // registerOptions?: LSPAny;
     };
 };


### PR DESCRIPTION
This PR builds on Vesim's excellent #436 to completely implement workspace configuration! Major caveat is that this "works on my machine™️" - I've tried to make this as backwards compatible as possible (shouldn't break any zls.json-only installs, hopefully...)

I'll be opening a corresponding PR in the zls-vscode repo as some changes were needed there too; how does editor-side configuration work in other editors?