### PR TITLE
Add flake support

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -42,7 +42,9 @@ pub fn build(b: *std.build.Builder) !void {
         b.option(bool, "enable_tracy_callstack", "Enable callstack graphs.") orelse false,
     );
 
-    exe.addPackage(.{ .name = "known-folders", .source = .{ .path = "src/known-folders/known-folders.zig" } });
+    const KNOWN_FOLDERS_DEFAULT_PATH = "src/known-folders/known-folders.zig";
+    const known_folders_path = b.option([]const u8, "known-folders", "Path to known-folders package (default: " ++ KNOWN_FOLDERS_DEFAULT_PATH ++ ")") orelse KNOWN_FOLDERS_DEFAULT_PATH;
+    exe.addPackage(.{ .name = "known-folders", .source = .{ .path = known_folders_path } });
 
     if (enable_tracy) {
         const client_cpp = "src/tracy/TracyClient.cpp";

--- a/flake.lock
+++ b/flake.lock
@@ -50,6 +50,22 @@
         "type": "github"
       }
     },
+    "known-folders": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1640092413,
+        "narHash": "sha256-eqaZxIax8C75L2UwDbVKSUZ7iThm/iWblfoaTfPyHLM=",
+        "owner": "ziglibs",
+        "repo": "known-folders",
+        "rev": "9db1b99219c767d5e24994b1525273fe4031e464",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ziglibs",
+        "repo": "known-folders",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1658119717,
@@ -70,6 +86,7 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "gitignore": "gitignore",
+        "known-folders": "known-folders",
         "nixpkgs": "nixpkgs",
         "zig-overlay": "zig-overlay"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -2,6 +2,21 @@
   "nodes": {
     "flake-utils": {
       "locked": {
+        "lastModified": 1656928814,
+        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
         "lastModified": 1629481132,
         "narHash": "sha256-JHgasjPR0/J1J3DRm4KxM4zTyAj4IOJY8vIl75v/kPI=",
         "owner": "numtide",
@@ -53,6 +68,7 @@
     },
     "root": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "gitignore": "gitignore",
         "nixpkgs": "nixpkgs",
         "zig-overlay": "zig-overlay"
@@ -60,7 +76,7 @@
     },
     "zig-overlay": {
       "inputs": {
-        "flake-utils": "flake-utils",
+        "flake-utils": "flake-utils_2",
         "nixpkgs": [
           "nixpkgs"
         ]

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,85 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1629481132,
+        "narHash": "sha256-JHgasjPR0/J1J3DRm4KxM4zTyAj4IOJY8vIl75v/kPI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "997f7efcb746a9c140ce1f13c72263189225f482",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1657706534,
+        "narHash": "sha256-5jIzNHKtDu06mA325K/5CshUVb5r7sSmnRiula6Gr7o=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "f840a659d57e53fa751a9248b17149fd0cf2a221",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1658119717,
+        "narHash": "sha256-4upOZIQQ7Bc4CprqnHsKnqYfw+arJeAuU+QcpjYBXW0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9eb60f25aff0d2218c848dd4574a0ab5e296cabe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "gitignore": "gitignore",
+        "nixpkgs": "nixpkgs",
+        "zig-overlay": "zig-overlay"
+      }
+    },
+    "zig-overlay": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1658105291,
+        "narHash": "sha256-3EXG2r5/h/iyzytRqI+tWTP11f1PdaJJ8Hl5QRe95OE=",
+        "owner": "arqv",
+        "repo": "zig-overlay",
+        "rev": "bfd640ef3c9bf8b4cd300af9f79a7ba950823ef5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "arqv",
+        "repo": "zig-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -9,9 +9,12 @@
     gitignore.inputs.nixpkgs.follows = "nixpkgs";
 
     flake-utils.url = "github:numtide/flake-utils";
+
+    known-folders.url = "github:ziglibs/known-folders";
+    known-folders.flake = false;
   };
   
-  outputs = {self, nixpkgs, zig-overlay, gitignore, flake-utils }:
+  outputs = {self, nixpkgs, zig-overlay, gitignore, flake-utils, known-folders }:
     let
       systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
       inherit (gitignore.lib) gitignoreSource;
@@ -19,21 +22,6 @@
       let
         pkgs = nixpkgs.legacyPackages.${system};
         zig = zig-overlay.packages.${system}.master.latest;
-        known-folders = pkgs.stdenvNoCC.mkDerivation {
-          name = "known-folders";
-          src = pkgs.fetchFromGitHub {
-            owner = "ziglibs";
-            repo = "known-folders";
-            rev = "9db1b99219c767d5e24994b1525273fe4031e464";
-            sha256 = "sha256-eqaZxIax8C75L2UwDbVKSUZ7iThm/iWblfoaTfPyHLM=";
-          };
-          dontConfigure = true;
-          dontInstall = true;
-          buildPhase = ''
-            mkdir -p $out
-            cp known-folders.zig $out
-          '';
-        };
       in rec {
         packages.default = packages.zls;
         packages.zls = pkgs.stdenvNoCC.mkDerivation {
@@ -41,7 +29,6 @@
           version = "master";
           src = gitignoreSource ./.;
           nativeBuildInputs = [ zig ];
-          buildInputs = [ known-folders ];
           dontConfigure = true;
           dontInstall = true;
           buildPhase = ''

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,43 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+    zig-overlay.url = "github:arqv/zig-overlay";
+    zig-overlay.inputs.nixpkgs.follows = "nixpkgs";
+
+    gitignore.url = "github:hercules-ci/gitignore.nix";
+    gitignore.inputs.nixpkgs.follows = "nixpkgs";
+  };
+  
+  outputs = {self, nixpkgs, zig-overlay, gitignore }:
+    let
+      inherit (gitignore.lib) gitignoreSource;
+      zls-derivation-fn = (system: nixpkgs.legacyPackages.${system}.stdenvNoCC.mkDerivation {
+        name = "zls";
+        version = "master";
+        src = gitignoreSource ./.;
+        nativeBuildInputs = [
+          zig-overlay.packages.${system}.master.latest
+        ];
+        dontConfigure = true;
+        dontInstall = true;
+        buildPhase = ''
+          mkdir -p $out
+          zig build install -Drelease-safe=true -Ddata_version=master --prefix $out
+        '';
+        XDG_CACHE_HOME = ".cache";
+      });
+    in {
+      packages = rec {
+        x86_64-linux.zls = zls-derivation-fn "x86_64-linux";
+        aarch64-linux.zls = zls-derivation-fn "aarch64-linux";
+        x86_64-darwin.zls = zls-derivation-fn "x86_64-darwin";
+        aarch64-darwin.zls = zls-derivation-fn "aarch64-darwin";
+
+        x86_64-linux.default = x86_64-linux.zls;
+        aarch64-linux.default = aarch64-linux.zls;
+        x86_64-darwin.default = x86_64-darwin.zls;
+        aarch64-darwin.default = aarch64-darwin.zls;
+      };
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -12,21 +12,43 @@
   outputs = {self, nixpkgs, zig-overlay, gitignore }:
     let
       inherit (gitignore.lib) gitignoreSource;
-      zls-derivation-fn = (system: nixpkgs.legacyPackages.${system}.stdenvNoCC.mkDerivation {
+
+      known-folders-fetch = (system: nixpkgs.legacyPackages.${system}.stdenvNoCC.mkDerivation {
+        name = "known-folders";
+        src = nixpkgs.legacyPackages.${system}.fetchFromGitHub {
+          owner = "ziglibs";
+          repo = "known-folders";
+          rev = "9db1b99219c767d5e24994b1525273fe4031e464";
+          sha256 = "sha256-eqaZxIax8C75L2UwDbVKSUZ7iThm/iWblfoaTfPyHLM=";
+        };
+        dontConfigure = true;
+        dontInstall = true;
+        buildPhase = ''
+          mkdir -p $out
+          cp known-folders.zig $out
+        '';
+      });
+
+      zls-derivation-fn = (system: nixpkgs.legacyPackages.${system}.stdenvNoCC.mkDerivation
+        (let known-folders = known-folders-fetch system;
+        in {
         name = "zls";
         version = "master";
         src = gitignoreSource ./.;
         nativeBuildInputs = [
           zig-overlay.packages.${system}.master.latest
         ];
+        buildInputs = [
+          known-folders
+        ];
         dontConfigure = true;
         dontInstall = true;
         buildPhase = ''
           mkdir -p $out
-          zig build install -Drelease-safe=true -Ddata_version=master --prefix $out
+          zig build install -Drelease-safe=true -Ddata_version=master -Dknown-folders=${known-folders}/known-folders.zig --prefix $out
         '';
         XDG_CACHE_HOME = ".cache";
-      });
+      }));
     in {
       packages = rec {
         x86_64-linux.zls = zls-derivation-fn "x86_64-linux";


### PR DESCRIPTION
This pull request will add `flake.nix`, `flake.lock`, and a build option `-Dknown-folders=<path>` to override the path to the `known-folders` package.

Will allow zls to be run like so:

```
nix run github:zigtools/zls 
```

Or used in another flake:

```nix 
{
    inputs.zls.url = "github:zigtools/zls";
    outputs = { self, zls}: {
        # flake stuff here
    };
}
```