### PR TITLE
fix build for tip of zig

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -1987,7 +1987,7 @@ fn completionHandler(server: *Server, arena: *std.heap.ArenaAllocator, id: types
 
             fsc: {
                 var document_path = try uri_utils.parse(arena.allocator(), handle.uri());
-                var document_dir_path = std.fs.openIterableDirAbsolute(std.fs.path.dirname(document_path) orelse break :fsc, .{}) catch break :fsc;
+                var document_dir_path = std.fs.openDirAbsolute(std.fs.path.dirname(document_path) orelse break :fsc, .{}) catch break :fsc;
                 defer document_dir_path.close();
 
                 if (std.mem.lastIndexOfScalar(u8, completing, '/')) |subpath_index| {
@@ -2000,7 +2000,7 @@ fn completionHandler(server: *Server, arena: *std.heap.ArenaAllocator, id: types
                     }
 
                     var old = document_dir_path;
-                    document_dir_path = document_dir_path.dir.openIterableDir(subpath, .{}) catch break :fsc // NOTE: Is this even safe lol?
+                    document_dir_path = document_dir_path.openDir(subpath, .{}) catch break :fsc // NOTE: Is this even safe lol?
                     old.close();
 
                     subpath_present = true;


### PR DESCRIPTION
I'm using zig 0.10.0-dev.2878+3a03872af. I got build error.

```
./src/Server.zig:1990:47: error: container 'std.fs' has no member called 'openIterableDirAbsolute'
                var document_dir_path = std.fs.openIterableDirAbsolute(std.fs.path.dirname(document_path) orelse break :fsc, .{}) catch break :fsc;
                                              ^
zls...The following command exited with error code 1:
/usr/local/zig/zig build-exe /home/mattn/.local/share/vim-lsp-settings/servers/zls/src/Server.zig --cache-dir /home/mattn/.local/share/vim-lsp-settings/servers/zls/zig-cache --global-cache-dir /home/mattn/.cache/zig --name zls --pkg-begin build_options /home/mattn/.local/share/vim-lsp-settings/servers/zls/zig-cache/options/ZN5T5qs__MtT8K02r_1S-BHCIQm36qquqqxMkxJvDpZqrwQ-wS_m2895sSwEs1B_ --pkg-end --pkg-begin known-folders /home/mattn/.local/share/vim-lsp-settings/servers/zls/src/known-folders/known-folders.zig --pkg-end --enable-cache
error: the following build command failed with exit code 1:
/home/mattn/.local/share/vim-lsp-settings/servers/zls/zig-cache/o/ba02554f2862f38e193ce7476c750d04/build /usr/local/zig/zig /home/mattn/.local/share/vim-lsp-settings/servers/zls /home/mattn/.local/share/vim-lsp-settings/servers/zls/zig-cache /home/mattn/.cache/zig

```

