### PR TITLE
Highlight orelse as a keyword

### DIFF
--- a/src/semantic_tokens.zig
+++ b/src/semantic_tokens.zig
@@ -871,7 +871,7 @@ fn writeNodeTokens(builder: *Builder, arena: *std.heap.ArenaAllocator, store: *D
         => {
             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, node_data[node].lhs });
             const token_type: TokenType = switch (tag) {
-                .bool_and, .bool_or => .keyword,
+                .bool_and, .bool_or, .@"orelse" => .keyword,
                 else => .operator,
             };
 


### PR DESCRIPTION
colorizing it like `or` and `and` makes more sense

```zig
const value = (foo orelse bar) and (foo or bar);
```
