### PR TITLE
build_runner: support 0.9 and master

### DIFF
--- a/src/special/build_runner.zig
+++ b/src/special/build_runner.zig
@@ -84,7 +84,8 @@ fn processStep(stdout_stream: anytype, step: *std.build.Step) anyerror!void {
 }
 
 fn processPackage(out_stream: anytype, pkg: Pkg) anyerror!void {
-    switch (pkg.source) {
+    const source = if (@hasField(Pkg, "source")) pkg.source else pkg.path;
+    switch (source) {
         .path => |path| try out_stream.print("{s}\x00{s}\n", .{ pkg.name, path }),
         .generated => |generated| if (generated.path != null) try out_stream.print("{s}\x00{s}\n", .{ pkg.name, generated.path.? }),
     }


### PR DESCRIPTION
Due to the `std.build.Pkg` change the build_runner.zig that zls uses does not function with 0.9, meaning no package completion.

Since Feburary I've been stuck with 0.9 half the time due to https://github.com/ziglang/zig/issues/10847 and I made this change to allow me to swap out the zig version and still get package completion.
