### PR TITLE
fix format string

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -1525,7 +1525,7 @@ fn formatDetailledLabel(item: *types.CompletionItem, alloc: std.mem.Allocator) !
         var s: usize = std.mem.indexOf(u8, it, "(") orelse return;
         var e: usize = std.mem.lastIndexOf(u8, it, ")") orelse return;
         if (e < s) {
-            logger.warn("something wrong when trying to build label detail for {s} kind: {s}", .{ it, item.kind });
+            logger.warn("something wrong when trying to build label detail for {s} kind: {}", .{ it, item.kind });
             return;
         }
 


### PR DESCRIPTION
```
/home/lee/src/zig/lib/std/fmt.zig:458:5: error: invalid format string 's' for type 'types.CompletionItem.Kind'
    @compileError("invalid format string '" ++ fmt ++ "' for type '" ++ @typeName(@TypeOf(value)) ++ "'");
    ^
/home/lee/src/zig/lib/std/fmt.zig:524:55: note: called from here
                if (actual_fmt.len != 0) invalidFmtErr(fmt, value);
                                                      ^
/home/lee/src/zig/lib/std/fmt.zig:183:23: note: called from here
        try formatType(
                      ^
/home/lee/src/zig/lib/std/io/writer.zig:28:34: note: called from here
            return std.fmt.format(self, format, args);
                                 ^
/home/lee/src/zig/lib/std/debug.zig:93:27: note: called from here
    nosuspend stderr.print(fmt, args) catch return;
                          ^
./src/Server.zig:54:24: note: called from here
        std.debug.print("[{?s}-{?s}] " ++ format ++ "\n", .{ @tagName(message_level), @tagName(scope) } ++ args);
                       ^
/home/lee/src/zig/lib/std/log.zig:139:21: note: called from here
            root.log(message_level, scope, format, args);
                    ^
/home/lee/src/zig/lib/std/log.zig:194:16: note: called from here
            log(.warn, scope, format, args);
               ^
./src/Server.zig:1528:24: note: called from here
            logger.warn("something wrong when trying to build label detail for {s} kind: {s}", .{ it, item.kind });
                       ^
./src/Server.zig:1490:86: note: called from here
fn formatDetailledLabel(item: *types.CompletionItem, alloc: std.mem.Allocator) !void {
                                                                                     ^
```