### PR TITLE
Correctly handle sentinel slices

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -876,6 +876,7 @@ pub fn resolveTypeOfNodeInternal(store: *DocumentStore, arena: *std.heap.ArenaAl
         .array_type_sentinel,
         .optional_type,
         .ptr_type_aligned,
+        .ptr_type_sentinel,
         .ptr_type,
         .ptr_type_bit_range,
         .error_union,


### PR DESCRIPTION
fix #482
```zig
const CString = [:0]const u8; // now recognizes `CString` as a type
const String = []const u8;
```