### PR TITLE
Add Cimport support

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The following options are currently available.
 | `zig_exe_path` | `?[]const u8` | `null` | zig executable path, e.g. `/path/to/zig/zig`, used to run the custom build runner. If `null`, zig is looked up in `PATH`. Will be used to infer the zig standard library path if none is provided. |
 | `warn_style` | `bool` | `false` | Enables warnings for style *guideline* mismatches |
 | `build_runner_path` | `?[]const u8` | `null` | Path to the build_runner.zig file provided by zls. `null` is equivalent to `${executable_directory}/build_runner.zig` |
-| `build_runner_cache_path` | `?[]const u8` | `null` | Path to a directroy that will be used as zig's cache when running `zig run build_runner.zig ...`. `null` is equivalent to `${KnownFloders.Cache}/zls` |
+| `global_cache_path` | `?[]const u8` | `null` | Path to a directroy that will be used as zig's cache. `null` is equivalent to `${KnownFloders.Cache}/zls` |
 | `enable_semantic_tokens` | `bool` | `true` | Enables semantic token support when the client also supports it. |
 | `enable_inlay_hints` | `bool` | `false` | Enables inlay hint support when the client also supports it. |
 | `operator_completions` | `bool` | `true` | Enables `*` and `?` operators in completion lists. |

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -32,8 +32,8 @@ warn_style: bool = false,
 /// Path to the build_runner.zig file.
 build_runner_path: ?[]const u8 = null,
 
-/// Path to a directory that will be used as cache when `zig run`ning the build runner
-build_runner_cache_path: ?[]const u8 = null,
+/// Path to the global cache directory
+global_cache_path: ?[]const u8 = null,
 
 /// Semantic token support
 enable_semantic_tokens: bool = true,
@@ -208,7 +208,7 @@ pub fn configChanged(config: *Config, allocator: std.mem.Allocator, builtin_crea
         break :blk try std.fs.path.resolve(allocator, &[_][]const u8{ exe_dir_path, "build_runner.zig" });
     };
 
-    config.build_runner_cache_path = if (config.build_runner_cache_path) |p|
+    config.global_cache_path = if (config.global_cache_path) |p|
         try allocator.dupe(u8, p)
     else blk: {
         const cache_dir_path = (try known_folders.getPath(allocator, .cache)) orelse {

--- a/src/DocumentStore.zig
+++ b/src/DocumentStore.zig
@@ -605,12 +605,15 @@ fn translate(self: *DocumentStore, handle: *Handle, source: []const u8) !?[]cons
     };
     defer self.allocator.free(include_dirs);
 
-    return translate_c.translate(
+    const file_path = (try translate_c.translate(
         self.allocator,
         self.config,
         include_dirs,
         source,
-    );
+    )) orelse return null;
+    defer self.allocator.free(file_path);
+
+    return try URI.fromPath(self.allocator, file_path);
 }
 
 fn refreshDocument(self: *DocumentStore, handle: *Handle) !void {

--- a/src/DocumentStore.zig
+++ b/src/DocumentStore.zig
@@ -110,7 +110,7 @@ const LoadBuildConfigContext = struct {
     build_file: *BuildFile,
     allocator: std.mem.Allocator,
     build_runner_path: []const u8,
-    build_runner_cache_path: []const u8,
+    global_cache_path: []const u8,
     zig_exe_path: []const u8,
     build_file_path: ?[]const u8 = null,
     cache_root: []const u8,
@@ -124,7 +124,7 @@ fn loadBuildConfiguration(context: LoadBuildConfigContext) !void {
     const allocator = context.allocator;
     const build_file = context.build_file;
     const build_runner_path = context.build_runner_path;
-    const build_runner_cache_path = context.build_runner_cache_path;
+    const global_cache_path = context.global_cache_path;
     const zig_exe_path = context.zig_exe_path;
 
     const build_file_path = context.build_file_path orelse try URI.parse(allocator, build_file.uri);
@@ -136,7 +136,7 @@ fn loadBuildConfiguration(context: LoadBuildConfigContext) !void {
         "run",
         build_runner_path,
         "--cache-dir",
-        build_runner_cache_path,
+        global_cache_path,
         "--pkg-begin",
         "@build@",
         build_file_path,
@@ -255,7 +255,7 @@ fn newDocument(self: *DocumentStore, uri: []const u8, text: [:0]u8) anyerror!*Ha
             .build_file = build_file,
             .allocator = self.allocator,
             .build_runner_path = self.config.build_runner_path.?,
-            .build_runner_cache_path = self.config.build_runner_cache_path.?,
+            .global_cache_path = self.config.global_cache_path.?,
             .zig_exe_path = self.config.zig_exe_path.?,
             .build_file_path = build_file_path,
             .cache_root = self.zig_cache_root,
@@ -522,7 +522,7 @@ pub fn applySave(self: *DocumentStore, handle: *Handle) !void {
             .build_file = build_file,
             .allocator = self.allocator,
             .build_runner_path = self.config.build_runner_path.?,
-            .build_runner_cache_path = self.config.build_runner_cache_path.?,
+            .global_cache_path = self.config.global_cache_path.?,
             .zig_exe_path = self.config.zig_exe_path.?,
             .cache_root = self.zig_cache_root,
             .global_cache_root = self.zig_global_cache_root,

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -2048,9 +2048,9 @@ fn completionHandler(server: *Server, writer: anytype, id: types.RequestId, req:
 
             if (!subpath_present and pos_context == .import_string_literal) {
                 if (handle.associated_build_file) |bf| {
-                    try fsl_completions.ensureUnusedCapacity(server.arena.allocator(), bf.packages.items.len);
+                    try fsl_completions.ensureUnusedCapacity(server.arena.allocator(), bf.config.packages.len);
 
-                    for (bf.packages.items) |pkg| {
+                    for (bf.config.packages) |pkg| {
                         try fsl_completions.append(server.arena.allocator(), .{
                             .label = pkg.name,
                             .kind = .Module,

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -334,7 +334,8 @@ fn resolveVarDeclAliasInternal(store: *DocumentStore, arena: *std.heap.ArenaAllo
         const lhs = datas[node_handle.node].lhs;
 
         const container_node = if (ast.isBuiltinCall(tree, lhs)) block: {
-            if (!std.mem.eql(u8, tree.tokenSlice(main_tokens[lhs]), "@import"))
+            const name = tree.tokenSlice(main_tokens[lhs]);
+            if (!std.mem.eql(u8, name, "@import") and !std.mem.eql(u8, name, "@cImport"))
                 return null;
 
             const inner_node = (try resolveTypeOfNode(store, arena, .{ .node = lhs, .handle = handle })) orelse return null;
@@ -901,20 +902,28 @@ pub fn resolveTypeOfNodeInternal(store: *DocumentStore, arena: *std.heap.ArenaAl
                 return resolved_type;
             }
 
-            if (!std.mem.eql(u8, call_name, "@import")) return null;
-            if (params.len == 0) return null;
+            if (std.mem.eql(u8, call_name, "@import")) {
+                if (params.len == 0) return null;
+                const import_param = params[0];
+                if (node_tags[import_param] != .string_literal) return null;
 
-            const import_param = params[0];
-            if (node_tags[import_param] != .string_literal) return null;
+                const import_str = tree.tokenSlice(main_tokens[import_param]);
+                const new_handle = (store.resolveImport(handle, import_str[1 .. import_str.len - 1]) catch |err| {
+                    log.debug("Error {} while processing import {s}", .{ err, import_str });
+                    return null;
+                }) orelse return null;
 
-            const import_str = tree.tokenSlice(main_tokens[import_param]);
-            const new_handle = (store.resolveImport(handle, import_str[1 .. import_str.len - 1]) catch |err| {
-                log.debug("Error {} while processing import {s}", .{ err, import_str });
-                return null;
-            }) orelse return null;
+                // reference to node '0' which is root
+                return TypeWithHandle.typeVal(.{ .node = 0, .handle = new_handle });
+            } else if (std.mem.eql(u8, call_name, "@cImport")) {
+                const new_handle = (store.resolveCImport(handle, node) catch |err| {
+                    log.debug("Error {} while processing cImport", .{err}); // TODO improve
+                    return null;
+                }) orelse return null;
 
-            // reference to node '0' which is root
-            return TypeWithHandle.typeVal(.{ .node = 0, .handle = new_handle });
+                // reference to node '0' which is root
+                return TypeWithHandle.typeVal(.{ .node = 0, .handle = new_handle });
+            }
         },
         .fn_proto,
         .fn_proto_multi,
@@ -1074,8 +1083,17 @@ pub fn resolveTypeOfNode(store: *DocumentStore, arena: *std.heap.ArenaAllocator,
     return resolveTypeOfNodeInternal(store, arena, node_handle, &bound_type_params);
 }
 
-/// Collects all imports we can find into a slice of import paths (without quotes).
-pub fn collectImports(import_arr: *std.ArrayList([]const u8), tree: Ast) !void {
+/// Collects all `@import`'s we can find into a slice of import paths (without quotes).
+/// Caller owns returned memory.
+pub fn collectImports(allocator: std.mem.Allocator, tree: Ast) error{OutOfMemory}![][]const u8 {
+    var imports = std.ArrayListUnmanaged([]const u8){};
+    errdefer {
+        for (imports.items) |imp| {
+            allocator.free(imp);
+        }
+        imports.deinit(allocator);
+    }
+
     const tags = tree.tokens.items(.tag);
 
     var i: usize = 0;
@@ -1095,9 +1113,33 @@ pub fn collectImports(import_arr: *std.ArrayList([]const u8), tree: Ast) !void {
                 continue;
 
             const str = tree.tokenSlice(@intCast(u32, i + 2));
-            try import_arr.append(str[1 .. str.len - 1]);
+            try imports.append(allocator, str[1 .. str.len - 1]);
         }
     }
+
+    return imports.toOwnedSlice(allocator);
+}
+
+/// Collects all `@cImport` nodes
+/// Caller owns returned memory.
+pub fn collectCImportNodes(allocator: std.mem.Allocator, tree: Ast) error{OutOfMemory}![]Ast.Node.Index {
+    var import_nodes = std.ArrayListUnmanaged(Ast.Node.Index){};
+    errdefer import_nodes.deinit(allocator);
+
+    const node_tags = tree.nodes.items(.tag);
+    const main_tokens = tree.nodes.items(.main_token);
+
+    var i: usize = 0;
+    while (i < node_tags.len) : (i += 1) {
+        const node = @intCast(Ast.Node.Index, i);
+        if (!ast.isBuiltinCall(tree, node)) continue;
+
+        if (!std.mem.eql(u8, Ast.tokenSlice(tree, main_tokens[node]), "@cImport")) continue;
+
+        try import_nodes.append(allocator, node);
+    }
+
+    return import_nodes.toOwnedSlice(allocator);
 }
 
 pub const NodeWithHandle = struct {
@@ -1338,26 +1380,22 @@ pub fn getImportStr(tree: Ast, node: Ast.Node.Index, source_index: usize) ?[]con
         return getImportStr(tree, tree.nodes.items(.data)[node].lhs, source_index);
     }
 
-    if (!nodeContainsSourceIndex(tree, node, source_index)) {
-        return null;
-    }
+    if (!nodeContainsSourceIndex(tree, node, source_index)) return null;
 
-    if (ast.isBuiltinCall(tree, node)) {
-        const builtin_token = tree.nodes.items(.main_token)[node];
-        const call_name = tree.tokenSlice(builtin_token);
+    if (!ast.isBuiltinCall(tree, node)) return null;
 
-        if (!std.mem.eql(u8, call_name, "@import")) return null;
+    const builtin_token = tree.nodes.items(.main_token)[node];
+    const call_name = tree.tokenSlice(builtin_token);
 
-        var buffer: [2]Ast.Node.Index = undefined;
-        const params = ast.builtinCallParams(tree, node, &buffer).?;
+    if (!std.mem.eql(u8, call_name, "@import")) return null;
 
-        if (params.len != 1) return null;
+    var buffer: [2]Ast.Node.Index = undefined;
+    const params = ast.builtinCallParams(tree, node, &buffer).?;
 
-        const import_str = tree.tokenSlice(tree.nodes.items(.main_token)[params[0]]);
-        return import_str[1 .. import_str.len - 1];
-    }
+    if (params.len != 1) return null;
 
-    return null;
+    const import_str = tree.tokenSlice(tree.nodes.items(.main_token)[params[0]]);
+    return import_str[1 .. import_str.len - 1];
 }
 
 pub const SourceRange = std.zig.Token.Loc;

--- a/src/requests.zig
+++ b/src/requests.zig
@@ -282,7 +282,7 @@ pub const Configuration = struct {
             zig_exe_path: ?[]const u8,
             warn_style: ?bool,
             build_runner_path: ?[]const u8,
-            build_runner_cache_path: ?[]const u8,
+            global_cache_path: ?[]const u8,
             enable_semantic_tokens: ?bool,
             enable_inlay_hints: ?bool,
             inlay_hints_show_builtin: ?bool,

--- a/src/translate_c.zig
+++ b/src/translate_c.zig
@@ -1,0 +1,186 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const Config = @import("Config.zig");
+const ast = @import("ast.zig");
+const Ast = std.zig.Ast;
+const URI = @import("uri.zig");
+
+/// converts a `@cInclude` node into an equivalent c header file
+/// which can then be handed over to `zig translate-c`
+/// Caller owns returned memory.
+///
+/// **Example**
+/// ```zig
+/// const glfw = @cImport(
+///     @cDefine("GLFW_INCLUDE_VULKAN", {})
+///     @cInclude("GLFW/glfw3.h")
+/// );
+/// ```
+/// gets converted into:
+/// ```c
+/// #define GLFW_INCLUDE_VULKAN
+/// #include "GLFW/glfw3.h"
+/// ```
+pub fn convertCInclude(allocator: std.mem.Allocator, tree: Ast, node: Ast.Node.Index) error{ OutOfMemory, Unsupported }![]const u8 {
+    const main_tokens = tree.nodes.items(.main_token);
+
+    std.debug.assert(ast.isBuiltinCall(tree, node));
+    std.debug.assert(std.mem.eql(u8, Ast.tokenSlice(tree, main_tokens[node]), "@cImport"));
+
+    var output = std.ArrayList(u8).init(allocator);
+    errdefer output.deinit();
+
+    var stack_allocator = std.heap.stackFallback(512, allocator);
+
+    var buffer: [2]Ast.Node.Index = undefined;
+    for (ast.builtinCallParams(tree, node, &buffer).?) |child| {
+        try convertCIncludeInternal(stack_allocator.get(), tree, child, &output);
+    }
+
+    return output.toOwnedSlice();
+}
+
+fn convertCIncludeInternal(allocator: std.mem.Allocator, tree: Ast, node: Ast.Node.Index, output: *std.ArrayList(u8)) error{ OutOfMemory, Unsupported }!void {
+    const node_tags = tree.nodes.items(.tag);
+    const main_tokens = tree.nodes.items(.main_token);
+
+    var buffer: [2]Ast.Node.Index = undefined;
+    if (ast.isBlock(tree, node)) {
+        const FrameSize = @sizeOf(@Frame(convertCIncludeInternal));
+        var child_frame = try allocator.alignedAlloc(u8, std.Target.stack_align, FrameSize);
+        defer allocator.free(child_frame);
+
+        for (ast.blockStatements(tree, node, &buffer).?) |statement| {
+            try await @asyncCall(child_frame, {}, convertCIncludeInternal, .{ allocator, tree, statement, output });
+        }
+    } else if (ast.builtinCallParams(tree, node, &buffer)) |params| {
+        if (params.len < 1) return;
+
+        const call_name = Ast.tokenSlice(tree, main_tokens[node]);
+
+        if (node_tags[params[0]] != .string_literal) return error.Unsupported;
+        const first = extractString(Ast.tokenSlice(tree, main_tokens[params[0]]));
+
+        if (std.mem.eql(u8, call_name, "@cInclude")) {
+            try output.writer().print("#include <{s}>\n", .{first});
+        } else if (std.mem.eql(u8, call_name, "@cDefine")) {
+            if (params.len < 2) return;
+
+            var buffer2: [2]Ast.Node.Index = undefined;
+            const is_void = if (ast.blockStatements(tree, params[1], &buffer2)) |block| block.len == 0 else false;
+
+            if (is_void) {
+                try output.writer().print("#define {s}\n", .{first});
+            } else {
+                if (node_tags[params[1]] != .string_literal) return error.Unsupported;
+                const second = extractString(Ast.tokenSlice(tree, main_tokens[params[1]]));
+                try output.writer().print("#define {s} {s}\n", .{ first, second });
+            }
+        } else if (std.mem.eql(u8, call_name, "@cUndef")) {
+            try output.writer().print("#undefine {s}\n", .{first});
+        } else {
+            return error.Unsupported;
+        }
+    }
+}
+
+/// takes a c header file and returns the result from calling `zig translate-c`
+/// returns the file path to the generated zig file
+/// Caller owns returned memory.
+pub fn translate(allocator: std.mem.Allocator, config: Config, include_dirs: []const []const u8, source: []const u8) error{OutOfMemory}!?[]const u8 {
+    const file_path = try std.fs.path.join(allocator, &[_][]const u8{ config.global_cache_path.?, "cimport.h" });
+    defer allocator.free(file_path);
+
+    var file = std.fs.createFileAbsolute(file_path, .{}) catch |err| {
+        std.log.warn("failed to create file '{s}': {}", .{ file_path, err });
+        return null;
+    };
+    defer file.close();
+    defer std.fs.deleteFileAbsolute(file_path) catch |err| {
+        std.log.warn("failed to delete file '{s}': {}", .{ file_path, err });
+    };
+
+    _ = file.write(source) catch |err| {
+        std.log.warn("failed to write to '{s}': {}", .{ file_path, err });
+    };
+
+    const base_include_dirs = blk: {
+        const target_info = std.zig.system.NativeTargetInfo.detect(allocator, .{}) catch break :blk null;
+        var native_paths = std.zig.system.NativePaths.detect(allocator, target_info) catch break :blk null;
+        defer native_paths.deinit();
+
+        break :blk native_paths.include_dirs.toOwnedSlice();
+    };
+    defer if (base_include_dirs) |dirs| {
+        for (dirs) |path| {
+            allocator.free(path);
+        }
+        allocator.free(dirs);
+    };
+
+    const base_args = &[_][]const u8{
+        config.zig_exe_path.?,
+        "translate-c",
+        "--enable-cache",
+        "--zig-lib-dir",
+        config.zig_lib_path.?,
+        "--cache-dir",
+        config.global_cache_path.?,
+    };
+
+    const argc = base_args.len + 2 * (include_dirs.len + if (base_include_dirs) |dirs| dirs.len else 0) + 1;
+    var argv = try std.ArrayListUnmanaged([]const u8).initCapacity(allocator, argc);
+    defer argv.deinit(allocator);
+
+    argv.appendSliceAssumeCapacity(base_args);
+
+    if (base_include_dirs) |dirs| {
+        for (dirs) |include_dir| {
+            argv.appendAssumeCapacity("-I");
+            argv.appendAssumeCapacity(include_dir);
+        }
+    }
+
+    for (include_dirs) |include_dir| {
+        argv.appendAssumeCapacity("-I");
+        argv.appendAssumeCapacity(include_dir);
+    }
+
+    argv.appendAssumeCapacity(file_path);
+
+    const result = std.ChildProcess.exec(.{
+        .allocator = allocator,
+        .argv = argv.items,
+    }) catch |err| {
+        std.log.err("Failed to execute zig translate-c process, error: {}", .{err});
+        return null;
+    };
+
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
+
+    return switch (result.term) {
+        .Exited => |code| if (code == 0) {
+            return try std.mem.join(allocator, "", &.{
+                "file://",
+                std.mem.sliceTo(result.stdout, '\n'),
+            });
+        } else {
+            // TODO convert failure to `textDocument/publishDiagnostics`
+            std.log.err("zig translate-c process failed, code: {}, stderr: '{s}'", .{ code, result.stderr });
+            return null;
+        },
+        else => {
+            std.log.err("zig translate-c process terminated '{}'", .{result.term});
+            return null;
+        },
+    };
+}
+
+fn extractString(str: []const u8) []const u8 {
+    if (std.mem.startsWith(u8, str, "\"") and std.mem.endsWith(u8, str, "\"")) {
+        return str[1 .. str.len - 1];
+    } else {
+        return str;
+    }
+}

--- a/src/translate_c.zig
+++ b/src/translate_c.zig
@@ -161,10 +161,7 @@ pub fn translate(allocator: std.mem.Allocator, config: Config, include_dirs: []c
 
     return switch (result.term) {
         .Exited => |code| if (code == 0) {
-            return try std.mem.join(allocator, "", &.{
-                "file://",
-                std.mem.sliceTo(result.stdout, '\n'),
-            });
+            return try allocator.dupe(u8, std.mem.sliceTo(result.stdout, '\n'));
         } else {
             // TODO convert failure to `textDocument/publishDiagnostics`
             std.log.err("zig translate-c process failed, code: {}, stderr: '{s}'", .{ code, result.stderr });


### PR DESCRIPTION
Runs `zig translate-c` on `cImport` nodes if possible. Results are globally cached and only re-translated if necessary.
Without comptime evaluation only simple `cImport` are translatable. fixes #366 and fixes #313

NOTE Currently there is not `Goto Definition` support when hovering over the `cImport` node itself. You have to use one of its exported symbols.
*NOTE* this PR also renames `build_runner_cache_path` to `global_cache_path` because it is also used as `zig translate-c`'s cache-dir
## Examples taken from VS Code
![Screenshot_20220819_000949](https://user-images.githubusercontent.com/19954306/185504118-79fe0cfc-771e-4c61-83f4-9b71cac458d0.png)
![Screenshot_20220819_001056](https://user-images.githubusercontent.com/19954306/185504120-71b81e71-0a9a-42de-a499-975bcbb3765a.png)
