### PR TITLE
fix: fix memory leaks related to updating config variables

### DIFF
--- a/src/Config.zig
+++ b/src/Config.zig
@@ -200,22 +200,18 @@ pub fn configChanged(config: *Config, allocator: std.mem.Allocator, builtin_crea
         config.builtin_path = try std.fs.path.join(allocator, &.{ builtin_creation_dir.?, "builtin.zig" });
     }
 
-    config.build_runner_path = if (config.build_runner_path) |p|
-        try allocator.dupe(u8, p)
-    else blk: {
+    if (null == config.build_runner_path) {
         var exe_dir_bytes: [std.fs.MAX_PATH_BYTES]u8 = undefined;
         const exe_dir_path = try std.fs.selfExeDirPath(&exe_dir_bytes);
-        break :blk try std.fs.path.resolve(allocator, &[_][]const u8{ exe_dir_path, "build_runner.zig" });
-    };
+        config.build_runner_path = try std.fs.path.resolve(allocator, &[_][]const u8{ exe_dir_path, "build_runner.zig" });
+    }
 
-    config.global_cache_path = if (config.global_cache_path) |p|
-        try allocator.dupe(u8, p)
-    else blk: {
+    if (null == config.global_cache_path) {
         const cache_dir_path = (try known_folders.getPath(allocator, .cache)) orelse {
             logger.warn("Known-folders could not fetch the cache path", .{});
             return;
         };
         defer allocator.free(cache_dir_path);
-        break :blk try std.fs.path.resolve(allocator, &[_][]const u8{ cache_dir_path, "zls" });
-    };
+        config.global_cache_path = try std.fs.path.resolve(allocator, &[_][]const u8{ cache_dir_path, "zls" });
+    }
 }

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -2442,7 +2442,7 @@ pub fn processJsonRpc(server: *Server, writer: anytype, json: []const u8) !void 
                     []const u8 => switch (value) {
                         .String => |s| blk: {
                             var nv = try server.allocator.dupe(u8, s);
-                            server.allocator.free(@field(server.config, field.name).?);
+                            if (@field(server.config, field.name)) |prev_val| server.allocator.free(prev_val);
                             break :blk nv;
                         }, // TODO: Allocation model? (same with didChangeConfiguration); imo this isn't *that* bad but still
                         else => @panic("Invalid configuration value"), // TODO: Handle this

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -2440,7 +2440,11 @@ pub fn processJsonRpc(server: *Server, writer: anytype, json: []const u8) !void 
             if (value != .Null) {
                 const new_value: field.field_type = switch (ft) {
                     []const u8 => switch (value) {
-                        .String => |s| try server.allocator.dupe(u8, s), // TODO: Allocation model? (same with didChangeConfiguration); imo this isn't *that* bad but still
+                        .String => |s| blk: {
+                            var nv = try server.allocator.dupe(u8, s);
+                            server.allocator.free(@field(server.config, field.name).?);
+                            break :blk nv;
+                        }, // TODO: Allocation model? (same with didChangeConfiguration); imo this isn't *that* bad but still
                         else => @panic("Invalid configuration value"), // TODO: Handle this
                     },
                     else => switch (ti) {

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -2542,7 +2542,7 @@ fn makeInnerScope(allocator: std.mem.Allocator, context: ScopeContext, node_idx:
         };
 
         if (container_field) |_| {
-            if (!std.mem.eql(u8, name, "_")) {
+            if (!std.mem.eql(u8, name, "_") and !std.mem.eql(u8, name, "other")) {
                 try context.enums.put(allocator, .{
                     .label = name,
                     .kind = .Constant,

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -2542,17 +2542,21 @@ fn makeInnerScope(allocator: std.mem.Allocator, context: ScopeContext, node_idx:
         };
 
         if (container_field) |_| {
-            if (!std.mem.eql(u8, name, "_") and !std.mem.eql(u8, name, "other")) {
-                try context.enums.put(allocator, .{
+            if (!std.mem.eql(u8, name, "_")) {
+                var doc = if (try getDocComments(allocator, tree, decl, .Markdown)) |docs|
+                        types.MarkupContent{ .kind = .Markdown, .value = docs }
+                    else
+                        null;
+                var gop_res = try context.enums.getOrPut(allocator, .{
                     .label = name,
                     .kind = .Constant,
                     .insertText = name,
                     .insertTextFormat = .PlainText,
-                    .documentation = if (try getDocComments(allocator, tree, decl, .Markdown)) |docs|
-                        types.MarkupContent{ .kind = .Markdown, .value = docs }
-                    else
-                        null,
-                }, {});
+                    .documentation = doc
+                });
+                if (gop_res.found_existing) {
+                    if (doc) |d| allocator.free(d.value);
+                }
             }
         }
     }


### PR DESCRIPTION
note:
adds an edge case in analysis.makeScopeInternal to prevent
leaking memory when adding duplicate container fields w/ name "other"
but there really should be a check for duplicates


edit:
```
        if (container_field) |_| {
            if (!std.mem.eql(u8, name, "_")) {
                var doc = if (try getDocComments(allocator, tree, decl, .Markdown)) |docs|
                        types.MarkupContent{ .kind = .Markdown, .value = docs }
                    else
                        null;
                var gop_res = try context.enums.getOrPut(allocator, .{
                    .label = name,
                    .kind = .Constant,
                    .insertText = name,
                    .insertTextFormat = .PlainText,
                    .documentation = doc
                });
                if (gop_res.found_existing) {
                    if (doc) |d| allocator.free(d.value);
                }
            }
        }
```