### PR TITLE
Improve Test coverage

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -82,11 +82,12 @@ pub fn build(b: *std.build.Builder) !void {
     unit_tests.setTarget(target);
     test_step.dependOn(&unit_tests.step);
 
-    var session_tests = b.addTest("tests/sessions.zig");
-    session_tests.use_stage1 = true;
-    session_tests.addPackage(.{ .name = "header", .source = .{ .path = "src/header.zig" } });
-    session_tests.addPackage(.{ .name = "server", .source = .{ .path = "src/Server.zig" }, .dependencies = exe.packages.items });
-    session_tests.setBuildMode(.Debug);
-    session_tests.setTarget(target);
-    test_step.dependOn(&session_tests.step);
+    var tests = b.addTest("tests/tests.zig");
+    tests.use_stage1 = true;
+    tests.addPackage(.{ .name = "zls", .source = .{ .path = "src/zls.zig" }, .dependencies = exe.packages.items });
+    tests.addPackage(.{ .name = "helper", .source = .{ .path = "tests/helper.zig" } });
+    tests.addPackage(.{ .name = "context", .source = .{ .path = "tests/context.zig" } });
+    tests.setBuildMode(.Debug);
+    tests.setTarget(target);
+    test_step.dependOn(&tests.step);
 }

--- a/src/zls.zig
+++ b/src/zls.zig
@@ -1,0 +1,6 @@
+// used by tests as a package
+pub const header = @import("header.zig");
+pub const types = @import("types.zig");
+pub const requests = @import("requests.zig");
+pub const Server = @import("Server.zig");
+pub const translate_c = @import("translate_c.zig");

--- a/tests/context.zig
+++ b/tests/context.zig
@@ -1,6 +1,8 @@
 const std = @import("std");
-const headerPkg = @import("header");
-const Server = @import("server");
+const zls = @import("zls");
+
+const headerPkg = zls.header;
+const Server = zls.Server;
 
 const initialize_msg =
     \\{"processId":6896,"clientInfo":{"name":"vscode","version":"1.46.1"},"rootPath":null,"rootUri":null,"capabilities":{"workspace":{"applyEdit":true,"workspaceEdit":{"documentChanges":true,"resourceOperations":["create","rename","delete"],"failureHandling":"textOnlyTransactional"},"didChangeConfiguration":{"dynamicRegistration":true},"didChangeWatchedFiles":{"dynamicRegistration":true},"symbol":{"dynamicRegistration":true,"symbolKind":{"valueSet":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26]},"tagSupport":{"valueSet":[1]}},"executeCommand":{"dynamicRegistration":true},"configuration":true,"workspaceFolders":true},"textDocument":{"publishDiagnostics":{"relatedInformation":true,"versionSupport":false,"tagSupport":{"valueSet":[1,2]},"complexDiagnosticCodeSupport":true},"synchronization":{"dynamicRegistration":true,"willSave":true,"willSaveWaitUntil":true,"didSave":true},"completion":{"dynamicRegistration":true,"contextSupport":true,"completionItem":{"snippetSupport":true,"commitCharactersSupport":true,"documentationFormat":["markdown","plaintext"],"deprecatedSupport":true,"preselectSupport":true,"tagSupport":{"valueSet":[1]},"insertReplaceSupport":true},"completionItemKind":{"valueSet":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25]}},"hover":{"dynamicRegistration":true,"contentFormat":["markdown","plaintext"]},"signatureHelp":{"dynamicRegistration":true,"signatureInformation":{"documentationFormat":["markdown","plaintext"],"parameterInformation":{"labelOffsetSupport":true}},"contextSupport":true},"definition":{"dynamicRegistration":true,"linkSupport":true},"references":{"dynamicRegistration":true},"documentHighlight":{"dynamicRegistration":true},"documentSymbol":{"dynamicRegistration":true,"symbolKind":{"valueSet":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26]},"hierarchicalDocumentSymbolSupport":true,"tagSupport":{"valueSet":[1]}},"codeAction":{"dynamicRegistration":true,"isPreferredSupport":true,"codeActionLiteralSupport":{"codeActionKind":{"valueSet":["","quickfix","refactor","refactor.extract","refactor.inline","refactor.rewrite","source","source.organizeImports"]}}},"codeLens":{"dynamicRegistration":true},"formatting":{"dynamicRegistration":true},"rangeFormatting":{"dynamicRegistration":true},"onTypeFormatting":{"dynamicRegistration":true},"rename":{"dynamicRegistration":true,"prepareSupport":true},"documentLink":{"dynamicRegistration":true,"tooltipSupport":true},"typeDefinition":{"dynamicRegistration":true,"linkSupport":true},"implementation":{"dynamicRegistration":true,"linkSupport":true},"colorProvider":{"dynamicRegistration":true},"foldingRange":{"dynamicRegistration":true,"rangeLimit":5000,"lineFoldingOnly":true},"declaration":{"dynamicRegistration":true,"linkSupport":true},"selectionRange":{"dynamicRegistration":true},"semanticTokens":{"dynamicRegistration":true,"tokenTypes":["comment","keyword","number","regexp","operator","namespace","type","struct","class","interface","enum","typeParameter","function","member","macro","variable","parameter","property","label"],"tokenModifiers":["declaration","documentation","static","abstract","deprecated","readonly"]}},"window":{"workDoneProgress":true}},"trace":"off","workspaceFolders":[{"uri":"file://./tests", "name":"root"}]}
@@ -32,12 +34,11 @@ pub const Context = struct {
         self.server.deinit();
     }
 
-    pub fn request(
+    pub fn requestAlloc(
         self: *Context,
         method: []const u8,
         params: []const u8,
-        expect: ?[]const u8,
-    ) !void {
+    ) ![]const u8 {
         var output = std.ArrayListUnmanaged(u8){};
         defer output.deinit(allocator);
 
@@ -51,19 +52,30 @@ pub const Context = struct {
         //  send the request to the server
         try self.server.processJsonRpc(output.writer(allocator), req);
 
-        // if we don't expect a response ignore it
-        const expected = expect orelse return;
-
         // get the output from the server
         var buffer_stream = std.io.fixedBufferStream(output.items);
         const header = try headerPkg.readRequestHeader(allocator, buffer_stream.reader());
         defer header.deinit(allocator);
 
         var response_bytes = try allocator.alloc(u8, header.content_length);
-        defer allocator.free(response_bytes);
+        errdefer allocator.free(response_bytes);
 
         const content_length = try buffer_stream.reader().readAll(response_bytes);
         try std.testing.expectEqual(content_length, header.content_length);
+
+        return response_bytes;
+    }
+
+    pub fn request(
+        self: *Context,
+        method: []const u8,
+        params: []const u8,
+        expect: ?[]const u8,
+    ) !void {
+        const response_bytes = try self.requestAlloc(method, params);
+        defer allocator.free(response_bytes);
+
+        const expected = expect orelse return;
 
         // parse the response
         var parser = std.json.Parser.init(allocator, false);

--- a/tests/helper.zig
+++ b/tests/helper.zig
@@ -1,0 +1,102 @@
+const std = @import("std");
+
+pub const Placeholder = struct {
+    loc: Loc,
+
+    pub const Loc = std.zig.Token.Loc;
+
+    pub fn placeholderSlice(self: Placeholder, source: []const u8) []const u8 {
+        return source[self.loc.start..self.loc.end];
+    }
+};
+
+/// returns an array of all placeholder locations
+pub fn collectPlaceholder(allocator: std.mem.Allocator, source: []const u8) ![]Placeholder {
+    var placeholders = std.ArrayListUnmanaged(Placeholder){};
+    errdefer placeholders.deinit(allocator);
+
+    var source_index: usize = 0;
+    while (std.mem.indexOfScalarPos(u8, source, source_index, '<')) |start_index| {
+        const end_index = std.mem.indexOfScalarPos(u8, source, start_index + 1, '>') orelse return error.Invalid;
+
+        try placeholders.append(allocator, .{ .loc = .{
+            .start = start_index,
+            .end = end_index,
+        } });
+
+        source_index = end_index + 1;
+    }
+
+    return placeholders.toOwnedSlice(allocator);
+}
+
+/// returns `source` without any placeholders
+pub fn clearPlaceholders(allocator: std.mem.Allocator, source: []const u8) ![]const u8 {
+    var output = std.ArrayListUnmanaged(u8){};
+    errdefer output.deinit(allocator);
+
+    var source_index: usize = 0;
+    while (std.mem.indexOfScalarPos(u8, source, source_index, '<')) |start_index| {
+        try output.appendSlice(allocator, source[source_index..start_index]);
+
+        source_index = std.mem.indexOfScalarPos(u8, source, start_index + 1, '>') orelse return error.Invalid;
+        source_index += 1;
+    }
+    try output.appendSlice(allocator, source[source_index..source.len]);
+
+    return output.toOwnedSlice(allocator);
+}
+
+const CollectClearPlaceholdersResult = struct {
+    /// placeholders relative to the `source` parameter in `collectClearPlaceholders`
+    placeholders: []Placeholder,
+    /// placeholders locations to `source`
+    placeholder_locations: []usize,
+    /// source without any placeholders
+    source: []const u8,
+
+    pub fn deinit(self: @This(), allocator: std.mem.Allocator) void {
+        allocator.free(self.placeholders);
+        allocator.free(self.placeholder_locations);
+        allocator.free(self.source);
+    }
+};
+
+/// see `CollectClearPlaceholdersResult`
+pub fn collectClearPlaceholders(allocator: std.mem.Allocator, source: []const u8) !CollectClearPlaceholdersResult {
+    var placeholders = std.ArrayListUnmanaged(Placeholder){};
+    errdefer placeholders.deinit(allocator);
+
+    var locations = std.ArrayListUnmanaged(usize){};
+    errdefer locations.deinit(allocator);
+
+    var new_source = std.ArrayListUnmanaged(u8){};
+    errdefer new_source.deinit(allocator);
+
+    var source_index: usize = 0;
+    var new_source_index: usize = 0;
+    while (std.mem.indexOfScalarPos(u8, source, source_index, '<')) |start_index| {
+        const end_index = std.mem.indexOfScalarPos(u8, source, start_index + 1, '>') orelse return error.Invalid;
+
+        const placeholder = Placeholder{ .loc = .{
+            .start = start_index + 1,
+            .end = end_index,
+        } };
+
+        try placeholders.append(allocator, placeholder);
+
+        new_source_index = new_source_index + (start_index - source_index);
+        try locations.append(allocator, new_source_index);
+        try new_source.appendSlice(allocator, source[source_index..start_index]);
+
+        source_index = end_index + 1;
+    }
+    try new_source.appendSlice(allocator, source[source_index..source.len]);
+
+    return CollectClearPlaceholdersResult{
+        .placeholders = placeholders.toOwnedSlice(allocator),
+        .placeholder_locations = locations.toOwnedSlice(allocator),
+        .source = new_source.toOwnedSlice(allocator),
+    };
+}
+

--- a/tests/language_features/cimport.zig
+++ b/tests/language_features/cimport.zig
@@ -1,0 +1,85 @@
+const std = @import("std");
+const zls = @import("zls");
+
+const Ast = std.zig.Ast;
+
+const translate_c = zls.translate_c;
+
+const allocator: std.mem.Allocator = std.testing.allocator;
+
+test "convertCInclude - empty" {
+    try testConvertCInclude("@cImport()", "");
+    try testConvertCInclude("@cImport({})", "");
+    try testConvertCInclude("@cImport({{}, {}})", "");
+}
+
+test "convertCInclude - cInclude" {
+    try testConvertCInclude(
+        \\@cImport(@cInclude("foo.zig"))
+    ,
+        \\#include <foo.zig>
+    );
+
+    try testConvertCInclude(
+        \\@cImport(@cInclude("foo.zig"), @cInclude("bar.zig"))
+    ,
+        \\#include <foo.zig>
+        \\#include <bar.zig>
+    );
+}
+
+test "translate_c - cDefine" {
+    try testConvertCInclude(
+        \\@cImport(@cDefine("FOO", "BAR"))
+    ,
+        \\#define FOO BAR
+    );
+    try testConvertCInclude(
+        \\@cImport(@cDefine("FOO", {}))
+    ,
+        \\#define FOO
+    );
+}
+
+test "translate_c - cUndef" {
+    try testConvertCInclude(
+        \\@cImport(@cUndef("FOO"))
+    ,
+        \\#undef FOO
+    );
+}
+
+fn testConvertCInclude(cimport_source: []const u8, expected: []const u8) !void {
+    const source: [:0]u8 = try std.fmt.allocPrintZ(allocator, "const c = {s};", .{cimport_source});
+    defer allocator.free(source);
+
+    var ast = try std.zig.parse(allocator, source);
+    defer ast.deinit(allocator);
+
+    const main_tokens = ast.nodes.items(.main_token);
+
+    const node: Ast.Node.Index = blk: {
+        for (ast.nodes.items(.tag)) |tag, index| {
+            switch (tag) {
+                .builtin_call_two,
+                .builtin_call_two_comma,
+                .builtin_call,
+                .builtin_call_comma,
+                => {},
+                else => continue,
+            }
+            
+            if(!std.mem.eql(u8, ast.tokenSlice(main_tokens[index]), "@cImport")) continue;
+
+            break :blk @intCast(Ast.Node.Index, index);
+        }
+        return error.TestUnexpectedResult; // source doesn't contain a cImport
+    };
+
+    const output = try translate_c.convertCInclude(allocator, ast, node);
+    defer allocator.free(output);
+
+    const trimmed_output = std.mem.trimRight(u8, output, &.{'\n'});
+
+    try std.testing.expectEqualStrings(expected, trimmed_output);
+}

--- a/tests/lsp_features/inlay_hints.zig
+++ b/tests/lsp_features/inlay_hints.zig
@@ -1,0 +1,163 @@
+const std = @import("std");
+const zls = @import("zls");
+
+const helper = @import("helper");
+const Context = @import("context").Context;
+
+const types = zls.types;
+const requests = zls.requests;
+
+const allocator: std.mem.Allocator = std.testing.allocator;
+
+test "inlayhints - empty" {
+    try testInlayHints("");
+}
+
+test "inlayhints - function call" {
+    try testInlayHints(
+        \\fn foo(alpha: u32) void {}
+        \\const _ = foo(<alpha>5);
+    );
+    try testInlayHints(
+        \\fn foo(alpha: u32, beta: u64) void {}
+        \\const _ = foo(<alpha>5,<beta>4);
+    );
+    try testInlayHints(
+        \\fn foo(alpha: u32, beta: u64) void {}
+        \\const _ = foo(  <alpha>3 + 2 ,  <beta>(3 - 2));
+    );
+    try testInlayHints(
+        \\fn foo(alpha: u32, beta: u64) void {}
+        \\const _ = foo(
+        \\    <alpha>3 + 2,
+        \\    <beta>(3 - 2),
+        \\);
+    );
+}
+
+test "inlayhints - function self parameter" {
+    try testInlayHints(
+        \\const Foo = struct { pub fn bar(self: *Foo, alpha: u32) void {} };
+        \\const foo: Foo = .{};
+        \\const _ = foo.bar(<alpha>5);
+    );
+    try testInlayHints(
+        \\const Foo = struct { pub fn bar(_: Foo, alpha: u32, beta: []const u8) void {} };
+        \\const foo: Foo = .{};
+        \\const _ = foo.bar(<alpha>5,<beta>"");
+    );
+}
+
+test "inlayhints - builtin call" {
+    try testInlayHints(
+        \\const _ = @intCast(<DestType>u32,<int>5);
+    );
+    try testInlayHints(
+        \\const _ = @memcpy(<dest>null,<source>null,<byte_count>0);
+    );
+
+    try testInlayHints(
+        \\const _ = @sizeOf(u32);
+    );
+    try testInlayHints(
+        \\const _ = @TypeOf(5);
+    );
+}
+
+fn testInlayHints(source: []const u8) !void {
+    const phr = try helper.collectClearPlaceholders(allocator, source);
+    defer phr.deinit(allocator);
+
+    var ctx = try Context.init();
+    defer ctx.deinit();
+
+    ctx.server.config.enable_inlay_hints = true;
+    ctx.server.config.inlay_hints_exclude_single_argument = false;
+    ctx.server.config.inlay_hints_show_builtin = true;
+
+    const open_document = requests.OpenDocument{
+        .params = .{
+            .textDocument = .{
+                .uri = "file:///test.zig",
+                // .languageId = "zig",
+                // .version = 420,
+                .text = phr.source,
+            },
+        },
+    };
+
+    const did_open_method = try std.json.stringifyAlloc(allocator, open_document.params, .{});
+    defer allocator.free(did_open_method);
+
+    try ctx.request("textDocument/didOpen", did_open_method, null);
+
+    const range = types.Range{
+        .start = types.Position{ .line = 0, .character = 0 },
+        .end = sourceIndexPosition(phr.source, phr.source.len),
+    };
+
+    const method = try std.json.stringifyAlloc(allocator, .{
+        .textDocument = .{
+            .uri = "file:///test.zig",
+        },
+        .range = range,
+    }, .{});
+    defer allocator.free(method);
+
+    const response_bytes = try ctx.requestAlloc("textDocument/inlayHint", method);
+    defer allocator.free(response_bytes);
+
+    const InlayHint = struct {
+        position: types.Position,
+        label: []const u8,
+        kind: types.InlayHintKind,
+    };
+
+    const Response = struct {
+        jsonrpc: []const u8,
+        id: types.RequestId,
+        result: []InlayHint,
+    };
+
+    const parse_options = std.json.ParseOptions{
+        .allocator = allocator,
+        .ignore_unknown_fields = true,
+    };
+    var token_stream = std.json.TokenStream.init(response_bytes);
+    var response = try std.json.parse(Response, &token_stream, parse_options);
+    defer std.json.parseFree(Response, response, parse_options);
+
+    const hints = response.result;
+
+    try std.testing.expectEqual(phr.placeholder_locations.len, hints.len);
+
+    outer: for (phr.placeholder_locations) |loc, i| {
+        const name = phr.placeholders[i].placeholderSlice(source);
+
+        const position = sourceIndexPosition(phr.source, loc);
+
+        for (hints) |hint| {
+            if (position.line != hint.position.line or position.character != hint.position.character) continue;
+
+            try std.testing.expect(hint.label.len != 0);
+            const trimmedLabel = hint.label[0 .. hint.label.len - 1]; // exclude :
+            try std.testing.expectEqualStrings(name, trimmedLabel);
+            try std.testing.expectEqual(types.InlayHintKind.Parameter, hint.kind);
+
+            continue :outer;
+        }
+        std.debug.print("Placeholder '{s}' at {}:{} (line:colon) not found!", .{ name, position.line, position.character });
+        return error.PlaceholderNotFound;
+    }
+}
+
+fn sourceIndexPosition(source: []const u8, index: usize) types.Position {
+    const line = std.mem.count(u8, source[0..index], &.{'\n'});
+    const last_line_index = if (std.mem.lastIndexOfScalar(u8, source[0..index], '\n')) |idx| idx + 1 else 0;
+    const last_line_character = index - last_line_index;
+
+    return types.Position{
+        .line = @intCast(i64, line),
+        .character = @intCast(i64, last_line_character),
+    };
+}

--- a/tests/lsp_features/semantic_tokens.zig
+++ b/tests/lsp_features/semantic_tokens.zig
@@ -1,0 +1,55 @@
+const std = @import("std");
+const zls = @import("zls");
+
+const Context = @import("context").Context;
+
+const requests = zls.requests;
+
+const allocator: std.mem.Allocator = std.testing.allocator;
+
+test "semantic tokens - empty" {
+    try testSemanticTokens("", &.{});
+}
+
+test "semantic tokens" {
+    try testSemanticTokens(
+        \\const std = @import("std");
+    ,
+        &.{ 0, 0, 5, 7, 0, 0, 6, 3, 0, 33, 0, 4, 1, 11, 0, 0, 2, 7, 12, 0, 0, 8, 5, 9, 0 },
+    );
+    // TODO more tests
+}
+
+fn testSemanticTokens(source: []const u8, expected: []const u32) !void {
+    var ctx = try Context.init();
+    defer ctx.deinit();
+
+    ctx.server.config.enable_semantic_tokens = true;
+
+    const open_document = requests.OpenDocument{
+        .params = .{
+            .textDocument = .{
+                .uri = "file:///test.zig",
+                // .languageId = "zig",
+                // .version = 420,
+                .text = source,
+            },
+        },
+    };
+
+    const did_open_method = try std.json.stringifyAlloc(allocator, open_document.params, .{});
+    defer allocator.free(did_open_method);
+
+    try ctx.request("textDocument/didOpen", did_open_method, null);
+
+    const Response = struct {
+        data: []const u32,
+    };
+
+    const expected_bytes = try std.json.stringifyAlloc(allocator, Response{ .data = expected }, .{});
+    defer allocator.free(expected_bytes);
+
+    try ctx.request("textDocument/semanticTokens/full",
+        \\{"textDocument":{"uri":"file:///test.zig"}}
+    , expected_bytes);
+}

--- a/tests/sessions.zig
+++ b/tests/sessions.zig
@@ -3,21 +3,6 @@ const Context = @import("context.zig").Context;
 
 const allocator = std.testing.allocator;
 
-test "Open file, ask for semantic tokens" {
-    var ctx = try Context.init();
-    defer ctx.deinit();
-
-    try ctx.request("textDocument/didOpen",
-        \\{"textDocument":{"uri":"file:///test.zig","languageId":"zig","version":420,"text":"const std = @import(\"std\");"}}
-    , null);
-
-    try ctx.request("textDocument/semanticTokens/full",
-        \\{"textDocument":{"uri":"file:///test.zig"}}
-    ,
-        \\{"data":[0,0,5,7,0,0,6,3,0,33,0,4,1,11,0,0,2,7,12,0,0,8,5,9,0]}
-    );
-}
-
 test "Request completion in an empty file" {
     var ctx = try Context.init();
     defer ctx.deinit();

--- a/tests/tests.zig
+++ b/tests/tests.zig
@@ -7,6 +7,7 @@ test {
 
     // LSP features
     _ = @import("lsp_features/semantic_tokens.zig");
+    _ = @import("lsp_features/inlay_hints.zig");
 
     // TODO Language features
 }

--- a/tests/tests.zig
+++ b/tests/tests.zig
@@ -9,5 +9,6 @@ test {
     _ = @import("lsp_features/semantic_tokens.zig");
     _ = @import("lsp_features/inlay_hints.zig");
 
-    // TODO Language features
+    // Language features
+    _ = @import("language_features/cimport.zig");
 }

--- a/tests/tests.zig
+++ b/tests/tests.zig
@@ -5,7 +5,8 @@ test {
 
     // TODO Document Synchronization
 
-    // TODO LSP features
+    // LSP features
+    _ = @import("lsp_features/semantic_tokens.zig");
 
     // TODO Language features
 }

--- a/tests/tests.zig
+++ b/tests/tests.zig
@@ -1,0 +1,11 @@
+test {
+    _ = @import("sessions.zig");
+
+    // TODO Lifecycle Messages
+
+    // TODO Document Synchronization
+
+    // TODO LSP features
+
+    // TODO Language features
+}

--- a/tests/tests.zig
+++ b/tests/tests.zig
@@ -1,4 +1,4 @@
-test {
+comptime {
     _ = @import("sessions.zig");
 
     // TODO Lifecycle Messages


### PR DESCRIPTION
implements basic tests for:
- semantic tokens (only one tests but easy to expand)
- inlay hints
- cimport

small step toward #7