### PR TITLE
Switch to using mitchellh's zig-overlay

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -99,15 +99,15 @@
         ]
       },
       "locked": {
-        "lastModified": 1658105291,
-        "narHash": "sha256-3EXG2r5/h/iyzytRqI+tWTP11f1PdaJJ8Hl5QRe95OE=",
-        "owner": "arqv",
+        "lastModified": 1661317012,
+        "narHash": "sha256-3Lm//qoKwWj9p/gdCaLSASB9kvBw1vfC9BBYUvhVbWU=",
+        "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "bfd640ef3c9bf8b4cd300af9f79a7ba950823ef5",
+        "rev": "252c13ba498106f37054ad2c4db8e261f569a81e",
         "type": "github"
       },
       "original": {
-        "owner": "arqv",
+        "owner": "mitchellh",
         "repo": "zig-overlay",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
-    zig-overlay.url = "github:arqv/zig-overlay";
+    zig-overlay.url = "github:mitchellh/zig-overlay";
     zig-overlay.inputs.nixpkgs.follows = "nixpkgs";
 
     gitignore.url = "github:hercules-ci/gitignore.nix";
@@ -21,7 +21,7 @@
     in flake-utils.lib.eachSystem systems (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-        zig = zig-overlay.packages.${system}.master.latest;
+        zig = zig-overlay.packages.${system}.master;
       in rec {
         packages.default = packages.zls;
         packages.zls = pkgs.stdenvNoCC.mkDerivation {


### PR DESCRIPTION
arqv stopped existing on GitHub, including his zig-overlay repository. This commit switches the flake to use the new one (based on arqv's) provided by mitchellh