### PR TITLE
fix: "f..o.o;" crashes the server

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -808,8 +808,8 @@ pub fn resolveTypeOfNodeInternal(store: *DocumentStore, arena: *std.heap.ArenaAl
         },
         .field_access => {
             if (datas[node].rhs == 0) return null;
-            if (node >= tree.nodes.len - 1) return null; // #boundsCheck
-            const rhs_str = tree.tokenSlice(datas[node].rhs);
+            const rhs_str = ast.tokenSlice(tree, datas[node].rhs) catch return null;
+
             // If we are accessing a pointer type, remove one pointerness level :)
             const left_type = try resolveFieldAccessLhsType(
                 store,
@@ -1342,7 +1342,7 @@ pub fn nodeToString(tree: Ast, node: Ast.Node.Index) ?[]const u8 {
         .fn_decl,
         => if (ast.fnProto(tree, node, &buf).?.name_token) |name|
             return tree.tokenSlice(name),
-        .field_access => return tree.tokenSlice(data[node].rhs),
+        .field_access => return ast.tokenSlice(tree, data[node].rhs) catch return null,
         .call,
         .call_comma,
         .async_call,

--- a/src/offsets.zig
+++ b/src/offsets.zig
@@ -179,7 +179,8 @@ pub fn tokenLocation(tree: Ast, token_index: Ast.TokenIndex) Loc {
     };
 
     const token = tokenizer.next();
-    std.debug.assert(token.tag == tag);
+    // HACK, should return error.UnextectedToken
+    if (token.tag != tag) return .{ .start = 0, .end = 0 }; //std.debug.assert(token.tag == tag);
     return .{ .start = token.loc.start, .end = token.loc.end };
 }
 

--- a/src/references.zig
+++ b/src/references.zig
@@ -392,7 +392,7 @@ fn symbolReferencesInternal(arena: *std.heap.ArenaAllocator, store: *DocumentSto
         .field_access => {
             try symbolReferencesInternal(arena, store, .{ .node = datas[node].lhs, .handle = handle }, decl, encoding, context, handler);
 
-            const rhs_str = tree.tokenSlice(datas[node].rhs);
+            const rhs_str = ast.tokenSlice(tree, datas[node].rhs) catch return;
             var bound_type_params = analysis.BoundTypeParams{};
             const left_type = try analysis.resolveFieldAccessLhsType(
                 store,

--- a/src/semantic_tokens.zig
+++ b/src/semantic_tokens.zig
@@ -854,7 +854,7 @@ fn writeNodeTokens(builder: *Builder, arena: *std.heap.ArenaAllocator, store: *D
         .field_access => {
             const data = node_data[node];
             if (data.rhs == 0) return;
-            const rhs_str = tree.tokenSlice(data.rhs);
+            const rhs_str = ast.tokenSlice(tree, data.rhs) catch return;
 
             try await @asyncCall(child_frame, {}, writeNodeTokens, .{ builder, arena, store, data.lhs });
 


### PR DESCRIPTION
this is a fix for #381 and a hack for #409
(related, get triggered by "f..o.o;")

merge or use as an inspiration to fix these

PS. only covers .field_access
ideally all calls to tree.tokenSlice(token) should be reworked to use ast.tokenSlice(tree, token)

Regards