### PR TITLE
NativeTargetInfo.detect() no longer takes an Allocator param

### DIFF
--- a/src/translate_c.zig
+++ b/src/translate_c.zig
@@ -113,7 +113,7 @@ pub fn translate(allocator: std.mem.Allocator, config: Config, include_dirs: []c
     };
 
     const base_include_dirs = blk: {
-        const target_info = std.zig.system.NativeTargetInfo.detect(allocator, .{}) catch break :blk null;
+        const target_info = std.zig.system.NativeTargetInfo.detect(.{}) catch break :blk null;
         var native_paths = std.zig.system.NativePaths.detect(allocator, target_info) catch break :blk null;
         defer native_paths.deinit();
 


### PR DESCRIPTION
as of https://github.com/ziglang/zig/commit/3ee01c14ee7ba42b484f15daeacb67da90a81c9e std.zig.system.NativeTargetInfo.detect(...) no longer takes an Allocator param

Closes #638