### PR TITLE
Pass allocator to NativeTargetInfo.detect

### DIFF
--- a/src/translate_c.zig
+++ b/src/translate_c.zig
@@ -113,7 +113,7 @@ pub fn translate(allocator: std.mem.Allocator, config: Config, include_dirs: []c
     };
 
     const base_include_dirs = blk: {
-        const target_info = std.zig.system.NativeTargetInfo.detect(.{}) catch break :blk null;
+        const target_info = std.zig.system.NativeTargetInfo.detect(allocator, .{}) catch break :blk null;
         var native_paths = std.zig.system.NativePaths.detect(allocator, target_info) catch break :blk null;
         defer native_paths.deinit();
 


### PR DESCRIPTION
All allocations are cleaned up before returning, and it is planned that the allocator requirement will be removed at some point.

For more details see: https://github.com/ziglang/zig/commit/9e070b653c89a9216f9dd9f78ed7c78c11460ac7