### PR TITLE
Only globally log to stderr

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -19,6 +19,19 @@ var actual_log_level: std.log.Level = switch (zig_builtin.mode) {
     else => @intToEnum(std.log.Level, @enumToInt(build_options.log_level)), // temporary fix to build failing on release-safe due to a Zig bug
 };
 
+pub fn log(
+    comptime level: std.log.Level,
+    comptime scope: @TypeOf(.EnumLiteral),
+    comptime format: []const u8,
+    args: anytype,
+) void {
+    if (@enumToInt(level) > @enumToInt(actual_log_level)) return;
+
+    const level_txt = comptime level.asText();
+    const prefix2 = if (scope == .default) ": " else "(" ++ @tagName(scope) ++ "): ";
+    std.debug.print(level_txt ++ prefix2 ++ format ++ "\n", args);
+}
+
 fn loop(server: *Server) !void {
     var reader = std.io.getStdIn().reader();
 
@@ -258,7 +271,6 @@ pub fn main() !void {
         allocator,
         config.config,
         config.config_path,
-        actual_log_level,
     );
     defer server.deinit();
 

--- a/tests/context.zig
+++ b/tests/context.zig
@@ -26,7 +26,6 @@ pub const Context = struct {
                     .inlay_hints_show_builtin = true,
                 },
                 null,
-                .debug,
             ),
         };
 

--- a/tests/sessions.zig
+++ b/tests/sessions.zig
@@ -8,7 +8,7 @@ test "Request completion in an empty file" {
     defer ctx.deinit();
 
     try ctx.request("textDocument/didOpen",
-        \\{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"file:///test.zig","languageId":"zig","version":420,"text":""}}}
+        \\{"textDocument":{"uri":"file:///test.zig","languageId":"zig","version":420,"text":""}}
     , null);
     try ctx.request("textDocument/completion",
         \\{"textDocument":{"uri":"file:///test.zig"}, "position":{"line":0,"character":0}}


### PR DESCRIPTION
Previously zls tries to log messages in `Server.zig` using `window/logMessage`. This PR gets rid of this behavior and instead simply writes to stderr like in every other file.