### PR TITLE
Add target to Env struct

### DIFF
--- a/src/Config.zig
+++ b/src/Config.zig
@@ -147,6 +147,7 @@ pub fn configChanged(config: *Config, allocator: std.mem.Allocator, builtin_crea
                             std_dir: []const u8,
                             global_cache_dir: []const u8,
                             version: []const u8,
+                            target: ?[]const u8 = null,
                         };
 
                         var json_env = std.json.parse(


### PR DESCRIPTION
Fixes an issue where zls couldn't parse the output from `zig env` causing it to repeatedly print

```
debug: (store ): Cannot resolve std library import, path is null.
```

and fail to autocomplete.

See: https://github.com/ziglang/zig/pull/11741

