### PR TITLE
zig env includes target

### DIFF
--- a/src/Config.zig
+++ b/src/Config.zig
@@ -147,6 +147,7 @@ pub fn configChanged(config: *Config, allocator: std.mem.Allocator, builtin_crea
                             std_dir: []const u8,
                             global_cache_dir: []const u8,
                             version: []const u8,
+                            target: ?[]const u8 = null,
                         };
 
                         var json_env = std.json.parse(
@@ -202,7 +203,6 @@ pub fn configChanged(config: *Config, allocator: std.mem.Allocator, builtin_crea
         config.builtin_path = try std.fs.path.join(allocator, &.{ builtin_creation_dir.?, "builtin.zig" });
     }
 
-
     if (null == config.global_cache_path) {
         const cache_dir_path = (try known_folders.getPath(allocator, .cache)) orelse {
             logger.warn("Known-folders could not fetch the cache path", .{});
@@ -212,7 +212,7 @@ pub fn configChanged(config: *Config, allocator: std.mem.Allocator, builtin_crea
 
         config.global_cache_path = try std.fs.path.resolve(allocator, &[_][]const u8{ cache_dir_path, "zls" });
 
-        std.fs.makeDirAbsolute(config.global_cache_path.?) catch |err| switch(err) {
+        std.fs.makeDirAbsolute(config.global_cache_path.?) catch |err| switch (err) {
             error.PathAlreadyExists => {},
             else => return err,
         };
@@ -226,5 +226,4 @@ pub fn configChanged(config: *Config, allocator: std.mem.Allocator, builtin_crea
 
         try file.writeAll(@embedFile("special/build_runner.zig"));
     }
-
 }


### PR DESCRIPTION
```
$ zig version
0.10.0-dev.4110+dfcadd22b
$ zig env
{
 "zig_exe": "/home/lee/src/zig/build/stage3/bin/zig",
 "lib_dir": "/home/lee/src/zig/lib",
 "std_dir": "/home/lee/src/zig/lib/std",
 "global_cache_dir": "/home/lee/.cache/zig",
 "version": "0.10.0-dev.4110+dfcadd22b",
 "target": "x86_64-linux.5.19.9...5.19.9-gnu.2.36"
}
```

before this change:
```
info : (config): Using zig executable /home/lee/bin/zig
error: (config): Failed to parse zig env JSON result
warning: (config): Zig standard library path not specified in zls.json and could not be resolved from the zig executable
```