### PR TITLE
Fix missing includes by passing -lc to translate-c

### DIFF
--- a/src/translate_c.zig
+++ b/src/translate_c.zig
@@ -134,6 +134,7 @@ pub fn translate(allocator: std.mem.Allocator, config: Config, include_dirs: []c
         config.zig_lib_path.?,
         "--cache-dir",
         config.global_cache_path.?,
+        "-lc",
     };
 
     const argc = base_args.len + 2 * (include_dirs.len + if (base_include_dirs) |dirs| dirs.len else 0) + 1;


### PR DESCRIPTION
I was trying out the new cImport feature in ZLS and noticed that it was unable to offer completion for the SDL2 library's `SDL.h`. Looking at the Debug window of VSCode, I noticed it was erroring out because it could not find one of the included files (`<process.h>`, part of the Windows C standard library). It appears that translate-c does not know how to find libc header files unless `-lc` is explicitly used.

By passing `-lc` to the translate-c invocation, SDL now has full autocompletion via ZLS.