### PR TITLE
Testing improvements

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -117,8 +117,6 @@ pub fn build(b: *std.build.Builder) !void {
     var tests = b.addTest("tests/tests.zig");
     tests.use_stage1 = true;
     tests.addPackage(.{ .name = "zls", .source = .{ .path = "src/zls.zig" }, .dependencies = exe.packages.items });
-    tests.addPackage(.{ .name = "helper", .source = .{ .path = "tests/helper.zig" } });
-    tests.addPackage(.{ .name = "context", .source = .{ .path = "tests/context.zig" } });
     tests.setBuildMode(.Debug);
     tests.setTarget(target);
     test_step.dependOn(&tests.step);

--- a/src/offsets.zig
+++ b/src/offsets.zig
@@ -94,10 +94,7 @@ pub fn tokenLength(tree: Ast, token_index: Ast.TokenIndex, encoding: Encoding) u
 }
 
 pub fn rangeLength(text: []const u8, range: types.Range, encoding: Encoding) usize {
-    const loc: Loc = .{
-        .start = positionToIndex(text, range.start, encoding),
-        .end = positionToIndex(text, range.end, encoding),
-    };
+    const loc = rangeToLoc(text, range, encoding);
     return locLength(text, loc, encoding);
 }
 
@@ -160,6 +157,17 @@ pub fn locToRange(text: []const u8, loc: Loc, encoding: Encoding) types.Range {
     return .{
         .start = start,
         .end = advancePosition(text, start, loc.start, loc.end, encoding),
+    };
+}
+
+pub fn rangeToSlice(text: []const u8, range: types.Range, encodig: Encoding) []const u8 {
+    return locToSlice(text, rangeToLoc(text, range, encodig));
+}
+
+pub fn rangeToLoc(text: []const u8, range: types.Range, encodig: Encoding) Loc {
+    return .{
+        .start = positionToIndex(text, range.start, encodig),
+        .end = positionToIndex(text, range.end, encodig),
     };
 }
 

--- a/src/references.zig
+++ b/src/references.zig
@@ -516,7 +516,7 @@ pub fn symbolReferences(
                 try imports.resize(arena.allocator(), 0);
             }
         },
-        .param_decl => |param| {
+        .param_decl => |param| blk: {
             // Rename the param tok.
             for (curr_handle.document_scope.scopes.items) |scope| {
                 if (scope.data != .function) continue;
@@ -530,9 +530,9 @@ pub fn symbolReferences(
                 while (ast.nextFnParam(&it)) |candidate| {
                     if (!std.meta.eql(candidate, param)) continue;
 
-                    if (curr_handle.tree.nodes.items(.tag)[proto] != .fn_decl) break;
+                    if (curr_handle.tree.nodes.items(.tag)[proto] != .fn_decl) break :blk;
                     try symbolReferencesInternal(&builder, curr_handle.tree.nodes.items(.data)[proto].rhs, curr_handle);
-                    break;
+                    break :blk;
                 }
             }
             log.warn("Could not find param decl's function", .{});

--- a/tests/ErrorBuilder.zig
+++ b/tests/ErrorBuilder.zig
@@ -1,0 +1,99 @@
+const std = @import("std");
+
+const zls = @import("zls");
+
+const offsets = zls.offsets;
+
+const ErrorBuilder = @This();
+
+allocator: std.mem.Allocator,
+items: std.ArrayListUnmanaged(MsgItem) = .{},
+source: []const u8,
+
+pub fn init(allocator: std.mem.Allocator, source: []const u8) ErrorBuilder {
+    return ErrorBuilder{
+        .allocator = allocator,
+        .source = source,
+    };
+}
+
+pub fn deinit(builder: *ErrorBuilder) void {
+    for (builder.items.items) |item| {
+        builder.allocator.free(item.message);
+    }
+    builder.items.deinit(builder.allocator);
+}
+
+pub fn msgAtLoc(builder: *ErrorBuilder, comptime fmt: []const u8, loc: offsets.Loc, level: std.log.Level, args: anytype) !void {
+    try builder.items.append(builder.allocator, .{
+        .loc = loc,
+        .level = level,
+        .message = try std.fmt.allocPrint(builder.allocator, fmt, args),
+    });
+}
+
+pub fn msgAtIndex(builder: *ErrorBuilder, comptime fmt: []const u8, index: usize, level: std.log.Level, args: anytype) !void {
+    return msgAtLoc(builder, fmt, .{ .start = index, .end = index }, level, args);
+}
+
+pub fn hasMessages(builder: *ErrorBuilder) bool {
+    return builder.items.items.len != 0;
+}
+
+pub fn write(builder: *ErrorBuilder, writer: anytype) !void {
+    if (!builder.hasMessages()) return;
+
+    std.sort.sort(MsgItem, builder.items.items, builder, ErrorBuilder.lessThan);
+
+    try writer.writeByte('\n');
+
+    var start: usize = 0;
+    for (builder.items.items) |item| {
+        const line = offsets.lineLocAtIndex(builder.source, item.loc.start);
+        defer start = line.end;
+
+        try writer.writeAll(builder.source[start..line.end]);
+        try writer.writeByte('\n');
+        {
+            var i: usize = line.start;
+            while (i < item.loc.start) : (i += 1) try writer.writeByte(' ');
+            while (i < item.loc.end) : (i += 1) try writer.writeByte('^');
+            if (item.loc.start == item.loc.end) try writer.writeByte('^');
+        }
+        const level_txt: []const u8 = switch (item.level) {
+            .err => "error",
+            .warn => "warning",
+            .info => "info",
+            .debug => "debug",
+        };
+        try writer.print(" {s}: {s}", .{ level_txt, item.message });
+    }
+
+    try writer.writeAll(builder.source[start..builder.source.len]);
+    try writer.writeByte('\n');
+}
+
+pub fn writeDebug(builder: *ErrorBuilder) void {
+    if (!builder.hasMessages()) return;
+    std.debug.getStderrMutex().lock();
+    defer std.debug.getStderrMutex().unlock();
+    nosuspend builder.write(std.io.getStdErr().writer()) catch return;
+}
+
+const MsgItem = struct {
+    loc: offsets.Loc,
+    level: std.log.Level,
+    message: []const u8,
+};
+
+fn lessThan(builder: *ErrorBuilder, lhs: MsgItem, rhs: MsgItem) bool {
+    const is_less = lhs.loc.start < rhs.loc.start;
+    const text = if (is_less) builder.source[lhs.loc.start..rhs.loc.start] else builder.source[rhs.loc.start..lhs.loc.start];
+
+    // report messages on the same line in reverse order
+    if (std.mem.indexOfScalar(u8, text, '\n') == null) {
+        return !is_less;
+    }
+
+    return is_less;
+}

--- a/tests/lsp_features/inlay_hints.zig
+++ b/tests/lsp_features/inlay_hints.zig
@@ -1,8 +1,8 @@
 const std = @import("std");
 const zls = @import("zls");
 
-const helper = @import("helper");
-const Context = @import("context").Context;
+const helper = @import("../helper.zig");
+const Context = @import("../context.zig").Context;
 const ErrorBuilder = @import("../ErrorBuilder.zig");
 
 const types = zls.types;

--- a/tests/lsp_features/references.zig
+++ b/tests/lsp_features/references.zig
@@ -1,0 +1,189 @@
+const std = @import("std");
+const zls = @import("zls");
+
+const helper = @import("../helper.zig");
+const Context = @import("../context.zig").Context;
+const ErrorBuilder = @import("../ErrorBuilder.zig");
+
+const types = zls.types;
+const requests = zls.requests;
+const offsets = zls.offsets;
+
+const allocator: std.mem.Allocator = std.testing.allocator;
+
+// TODO fix references so that we can stop skipping these tests
+const skip_references_tests = true;
+
+test "references" {
+    if (skip_references_tests) return error.SkipZigTest;
+    try testReferences(
+        \\const <0> = 0;
+        \\const foo = <0>;
+    );
+    try testReferences(
+        \\var <0> = 0;
+        \\var foo = <0>;
+    );
+    try testReferences(
+        \\const <0> = struct {};
+        \\var foo: <0> = <0>{};
+    );
+    try testReferences(
+        \\const <0> = enum {};
+        \\var foo: <0> = undefined;
+    );
+    try testReferences(
+        \\const <0> = union {};
+        \\var foo: <0> = <0>{};
+    );
+    try testReferences(
+        \\fn <0>() void {}
+        \\var foo = <0>();
+    );
+    try testReferences(
+        \\const <0> = error{};
+        \\fn bar() <0>!void {}
+    );
+}
+
+test "references - global scope" {
+    if (skip_references_tests) return error.SkipZigTest;
+    try testReferences(
+        \\const foo = <0>;
+        \\const <0> = 0;
+        \\const bar = <0>;
+    );
+}
+
+test "references - local scope" {
+    try testReferences(
+        \\fn foo(<0>: u32, bar: u32) void {
+        \\    return <0> + bar;
+        \\}
+    );
+    if (skip_references_tests) return error.SkipZigTest;
+    try testReferences(
+        \\const foo = blk: {
+        \\    _ = blk: {
+        \\        const <0> = 0;
+        \\        break :blk <0>;
+        \\    };
+        \\    const <1> = 0;
+        \\    break :blk <1>;
+        \\};
+        \\const bar = foo;
+    );
+}
+
+test "references - label" {
+    if (skip_references_tests) return error.SkipZigTest;
+    try testReferences(
+        \\const foo = <0>: {
+        \\    break :<0> 0;
+        \\};
+    );
+}
+
+fn testReferences(source: []const u8) !void {
+    const file_uri = "file:///test.zig";
+    const new_name = "placeholder";
+
+    var phr = try helper.collectReplacePlaceholders(allocator, source, new_name);
+    defer phr.deinit(allocator);
+
+    var ctx = try Context.init();
+    defer ctx.deinit();
+
+    try ctx.requestDidOpen(file_uri, phr.new_source);
+
+    var i: usize = 0;
+    while (i < phr.locations.len) : (i += 1) {
+        const var_loc = phr.locations.items(.old)[i];
+        const var_name = offsets.locToSlice(source, var_loc);
+        const var_loc_middle = var_loc.start + (var_loc.end - var_loc.start) / 2;
+
+        const request = requests.References{
+            .params = .{
+                .textDocument = .{ .uri = file_uri },
+                .position = offsets.indexToPosition(source, var_loc_middle, ctx.server.offset_encoding),
+                .context = .{ .includeDeclaration = true },
+            },
+        };
+
+        const response = try ctx.requestGetResponse(?[]types.Location, "textDocument/references", request);
+        defer response.deinit();
+
+        const locations: []types.Location = response.result orelse {
+            std.debug.print("Server returned `null` as the result\n", .{});
+            return error.InvalidResponse;
+        };
+
+        for (locations) |response_location| {
+            const actual_name = offsets.rangeToSlice(phr.new_source, response_location.range, ctx.server.offset_encoding);
+            try std.testing.expectEqualStrings(file_uri, response_location.uri);
+            try std.testing.expectEqualStrings(new_name, actual_name);
+        }
+
+        // collect all new placeholder locations with the given name
+        const expected_locs: []offsets.Loc = blk: {
+            var locs = std.ArrayListUnmanaged(offsets.Loc){};
+            errdefer locs.deinit(allocator);
+
+            var j: usize = 0;
+            while (j < phr.locations.len) : (j += 1) {
+                const old_loc = phr.locations.items(.old)[j];
+                const new_loc = phr.locations.items(.new)[j];
+
+                const old_loc_name = offsets.locToSlice(source, old_loc);
+                if (!std.mem.eql(u8, var_name, old_loc_name)) continue;
+                try locs.append(allocator, new_loc);
+            }
+
+            break :blk locs.toOwnedSlice(allocator);
+        };
+        defer allocator.free(expected_locs);
+
+        var error_builder = ErrorBuilder.init(allocator, phr.new_source);
+        defer error_builder.deinit();
+        errdefer {
+            const note_loc = phr.locations.items(.new)[i];
+            error_builder.msgAtLoc("asked for references here", note_loc, .info, .{}) catch {};
+            error_builder.writeDebug();
+        }
+
+        // keeps track of expected locations that have been given by the server
+        // used to detect double references and missing references
+        var visited = try std.DynamicBitSetUnmanaged.initEmpty(allocator, expected_locs.len);
+        defer visited.deinit(allocator);
+
+        for (locations) |response_location| {
+            const actual_loc = offsets.rangeToLoc(phr.new_source, response_location.range, ctx.server.offset_encoding);
+
+            const index = found_index: {
+                for (expected_locs) |expected_loc, idx| {
+                    if (expected_loc.start != actual_loc.start) continue;
+                    if (expected_loc.end != actual_loc.end) continue;
+                    break :found_index idx;
+                }
+                try error_builder.msgAtLoc("server returned unexpected reference!", actual_loc, .err, .{});
+                return error.UnexpectedReference;
+            };
+
+            if (visited.isSet(index)) {
+                try error_builder.msgAtLoc("server returned duplicate reference!", actual_loc, .err, .{});
+                return error.DuplicateReference;
+            } else {
+                visited.set(index);
+            }
+        }
+
+        var has_unvisited = false;
+        var unvisited_it = visited.iterator(.{ .kind = .unset });
+        while (unvisited_it.next()) |index| {
+            try error_builder.msgAtLoc("expected reference here!", expected_locs[index], .err, .{});
+            has_unvisited = true;
+        }
+
+        if (has_unvisited) return error.ExpectedReference;
+    }
+}

--- a/tests/lsp_features/semantic_tokens.zig
+++ b/tests/lsp_features/semantic_tokens.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const zls = @import("zls");
 
-const Context = @import("context").Context;
+const Context = @import("../context.zig").Context;
 
 const requests = zls.requests;
 

--- a/tests/tests.zig
+++ b/tests/tests.zig
@@ -13,6 +13,7 @@ comptime {
     // LSP features
     _ = @import("lsp_features/semantic_tokens.zig");
     _ = @import("lsp_features/inlay_hints.zig");
+    _ = @import("lsp_features/references.zig");
 
     // Language features
     _ = @import("language_features/cimport.zig");

--- a/tests/tests.zig
+++ b/tests/tests.zig
@@ -1,5 +1,7 @@
 comptime {
+    _ = @import("helper.zig");
     _ = @import("sessions.zig");
+
     _ = @import("utility/offsets.zig");
     _ = @import("utility/position_context.zig");
     _ = @import("utility/uri.zig");


### PR DESCRIPTION
## Notable changes
- adds tests for references (they are currently all skipped because references mostly doesn't work except for one test case)
- improved error explanations (see `tests/ErrorBuilder.zig`)
- adds `offsets.rangeToLoc` & `offsets.rangeToSlice`

## Improved error explanations
given this invalid test
```zig
try testInlayHints(
    \\fn foo(alpha: u32, beta: u64) void {}
    \\const _ = foo(<beta>5,<alpha>4);
);
```
previously `zig build test` would report something like:
```
====== expected this output: =========
beta␃

======== instead found this: =========
alpha␃

======================================
First difference occurs on line 1:
expected:
beta
^ ('\x62')
found:
alpha
^ ('\x61')
```
with this PR you would see:
```
fn foo(alpha: u32, beta: u64) void {}
const _ = foo(5,4);
                ^ error: expected label `alpha` here but got `beta`!
              ^ error: expected label `beta` here but got `alpha`!
```
or for references test you get:
```
fn foo(placeholder: u32, bar: u32) void {
       ^^^^^^^^^^^ info: asked for references here
    return foo + bar;
           ^^^ error: server returned unexpected reference!
}
```