### PR TITLE
Report cImport failure using `textDocument/publishDiagnostics`

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -322,6 +322,24 @@ fn publishDiagnostics(server: *Server, writer: anytype, handle: DocumentStore.Ha
         }
     }
 
+    for (handle.cimports) |cimport| {
+        if (cimport.result != .failure) continue;
+        const stderr = std.mem.trim(u8, cimport.result.failure, " ");
+
+        var pos_and_diag_iterator = std.mem.split(u8, stderr, ":");
+        _ = pos_and_diag_iterator.next(); // skip file path
+        _ = pos_and_diag_iterator.next(); // skip line
+        _ = pos_and_diag_iterator.next(); // skip character
+
+        try diagnostics.append(allocator, .{
+            .range = offsets.nodeToRange(handle.tree, cimport.node, server.offset_encoding),
+            .severity = .Error,
+            .code = "cImport",
+            .source = "zls",
+            .message = try allocator.dupe(u8, pos_and_diag_iterator.rest()),
+        });
+    }
+
     try send(writer, server.arena.allocator(), types.Notification{
         .method = "textDocument/publishDiagnostics",
         .params = .{


### PR DESCRIPTION
Pretty self explanatory
![Screenshot_20220919_195710](https://user-images.githubusercontent.com/19954306/191082776-a78a47b3-4aa1-4e12-8793-8d02647f7713.png)
This PR also includes some improvements on how zls avoids having to re-translate some cImport nodes while editing the code.
fixes #661