### PR TITLE
Avoid config copy for document store

### DIFF
--- a/src/DocumentStore.zig
+++ b/src/DocumentStore.zig
@@ -82,8 +82,7 @@ allocator: std.mem.Allocator,
 handles: UriToHandleMap = .{},
 build_files: BuildFileList = .{},
 
-// TODO use pointer back to Server.config
-config: Config,
+config: *Config,
 std_uri: ?[]const u8,
 // TODO make this configurable
 // We can't figure it out ourselves since we don't know what arguments
@@ -95,7 +94,7 @@ zig_global_cache_root: []const u8 = "ZLS_DONT_CARE",
 
 pub fn init(
     allocator: std.mem.Allocator,
-    config: Config,
+    config: *Config,
 ) !DocumentStore {
     return DocumentStore{
         .allocator = allocator,
@@ -671,7 +670,7 @@ fn translate(self: *DocumentStore, handle: *Handle, source: []const u8) error{Ou
 
     const maybe_result = try translate_c.translate(
         self.allocator,
-        self.config,
+        self.config.*,
         include_dirs,
         source,
     );

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -23,7 +23,7 @@ const log = std.log.scoped(.server);
 
 // Server fields
 
-config: Config,
+config: *Config,
 allocator: std.mem.Allocator = undefined,
 arena: std.heap.ArenaAllocator = undefined,
 document_store: DocumentStore = undefined,
@@ -1164,7 +1164,7 @@ fn completeBuiltin(server: *Server, writer: anytype, id: types.RequestId) !void 
 
     if (server.builtin_completions == null) {
         server.builtin_completions = try std.ArrayListUnmanaged(types.CompletionItem).initCapacity(server.allocator, data.builtins.len);
-        try populateBuiltinCompletions(&server.builtin_completions.?, server.config);
+        try populateBuiltinCompletions(&server.builtin_completions.?, server.config.*);
     }
 
     try send(writer, server.arena.allocator(), types.Response{
@@ -2054,7 +2054,7 @@ fn didChangeConfigurationHandler(server: *Server, writer: anytype, id: types.Req
             }
         }
 
-        try server.configChanged(null);
+        try server.config.configChanged(server.allocator, null);
     } else if (server.client_capabilities.supports_configuration)
         try server.requestConfiguration(writer);
 }
@@ -2210,7 +2210,7 @@ fn inlayHintHandler(server: *Server, writer: anytype, id: types.RequestId, req: 
         // with caching it would also make sense to generate all hints instead of only the visible ones
         const hints = try inlay_hints.writeRangeInlayHint(
             &server.arena,
-            &server.config,
+            server.config.*,
             &server.document_store,
             handle,
             req.params.range,
@@ -2318,7 +2318,7 @@ pub fn processJsonRpc(server: *Server, writer: anytype, json: []const u8) !void 
             }
         }
 
-        try server.configChanged(null);
+        try server.config.configChanged(server.allocator, null);
 
         return;
     }
@@ -2425,14 +2425,9 @@ pub fn processJsonRpc(server: *Server, writer: anytype, json: []const u8) !void 
     log.debug("Method without return value not implemented: {s}", .{method});
 }
 
-pub fn configChanged(server: *Server, builtin_creation_dir: ?[]const u8) !void {
-    try server.config.configChanged(server.allocator, builtin_creation_dir);
-    server.document_store.config = server.config;
-}
-
 pub fn init(
     allocator: std.mem.Allocator,
-    config: Config,
+    config: *Config,
     config_path: ?[]const u8,
 ) !Server {
     // TODO replace global with something like an Analyser struct
@@ -2440,23 +2435,21 @@ pub fn init(
     // see: https://github.com/zigtools/zls/issues/536
     analysis.init(allocator);
 
-    var cfg = config;
+    try config.configChanged(allocator, config_path);
 
-    try cfg.configChanged(allocator, config_path);
+    var document_store = try DocumentStore.init(allocator, config);
+    errdefer document_store.deinit();
 
     return Server{
-        .config = cfg,
+        .config = config,
         .allocator = allocator,
-        .document_store = try DocumentStore.init(allocator, cfg),
+        .document_store = document_store,
     };
 }
 
 pub fn deinit(server: *Server) void {
     server.document_store.deinit();
     analysis.deinit();
-
-    const config_parse_options = std.json.ParseOptions{ .allocator = server.allocator };
-    defer std.json.parseFree(Config, server.config, config_parse_options);
 
     if (server.builtin_completions) |*compls| {
         compls.deinit(server.allocator);

--- a/src/inlay_hints.zig
+++ b/src/inlay_hints.zig
@@ -660,7 +660,7 @@ fn writeNodeInlayHint(builder: *Builder, arena: *std.heap.ArenaAllocator, store:
 /// `InlayHint.tooltip.value` has to deallocated separately
 pub fn writeRangeInlayHint(
     arena: *std.heap.ArenaAllocator,
-    config: *const Config,
+    config: Config,
     store: *DocumentStore,
     handle: *DocumentStore.Handle,
     range: types.Range,
@@ -669,7 +669,7 @@ pub fn writeRangeInlayHint(
 ) error{OutOfMemory}![]types.InlayHint {
     var builder: Builder = .{
         .allocator = arena.child_allocator,
-        .config = config,
+        .config = &config,
         .handle = handle,
         .hints = .{},
         .hover_kind = hover_kind,

--- a/src/main.zig
+++ b/src/main.zig
@@ -264,13 +264,15 @@ pub fn main() !void {
     }
 
     config = try getConfig(allocator, config.config_path, true);
+    defer std.json.parseFree(Config, config.config, .{ .allocator = allocator });
+
     if (config.config_path == null) {
         logger.info("No config file zls.json found.", .{});
     }
 
     var server = try Server.init(
         allocator,
-        config.config,
+        &config.config,
         config.config_path,
     );
     defer server.deinit();

--- a/src/zls.zig
+++ b/src/zls.zig
@@ -3,6 +3,7 @@ pub const analysis = @import("analysis.zig");
 pub const header = @import("header.zig");
 pub const offsets = @import("offsets.zig");
 pub const requests = @import("requests.zig");
+pub const Config = @import("Config.zig");
 pub const Server = @import("Server.zig");
 pub const translate_c = @import("translate_c.zig");
 pub const types = @import("types.zig");


### PR DESCRIPTION
`DocumentStore` is keeping a copy of the `Config` struct. This PR reverts back to pointing into `Server.config`
https://github.com/zigtools/zls/blob/0fa788b7275891f5bd924ca983c8ff397de23cc7/src/DocumentStore.zig#L85-L86