### PR TITLE
wip: more accurate symbol kinds in analysis.getDocumentSymbols

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -1837,7 +1837,7 @@ fn resolveNodeKind(tree: Ast, node_idx: Ast.Node.Index, tag: std.zig.Ast.Node.Ta
         // [pub] var|const Type = struct|enum|union {}
         .simple_var_decl, .aligned_var_decl, .global_var_decl => {
             switch (token_tags[node_maintokens[node_idx]]) {
-                .keyword_var => .Variable,
+                .keyword_var => return .Variable,
                 .keyword_const => {
                     const rhs_token = node_maintokens[node_datum[node_idx].rhs];
                     return switch (token_tags[rhs_token]) {

--- a/src/types.zig
+++ b/src/types.zig
@@ -271,7 +271,7 @@ pub const CompletionItemLabelDetails = struct {
 };
 
 pub const DocumentSymbol = struct {
-    const Kind = enum(u32) {
+    pub const Kind = enum(u32) {
         File = 1,
         Module = 2,
         Namespace = 3,


### PR DESCRIPTION
hi, i'm trying to make analysis.getDocumentSymbols recognize more Symbol.Kind, do you think this is worth it?
and what must be done to make this pr mergeable?

todo:
* [x] `[pub] fn Function() type {};`
* [x] `[pub] var|const Type = struct|enum|union {}`
* [ ] `const Foo = @import("Foo.zig");`
* [ ] `pub var|const Type = std.ArrayList(u8);`

i have no idea to deal with the last two cases at now.
