### PR TITLE
support pkgconfig

### DIFF
--- a/src/DocumentStore.zig
+++ b/src/DocumentStore.zig
@@ -32,7 +32,7 @@ const BuildFile = struct {
 
 pub const BuildFileConfig = struct {
     packages: []Pkg,
-    include_dirs: []IncludeDir,
+    include_dirs: []const []const u8,
 
     pub fn deinit(self: BuildFileConfig, allocator: std.mem.Allocator) void {
         for (self.packages) |pkg| {
@@ -42,7 +42,7 @@ pub const BuildFileConfig = struct {
         allocator.free(self.packages);
 
         for (self.include_dirs) |dir| {
-            allocator.free(dir.path);
+            allocator.free(dir);
         }
         allocator.free(self.include_dirs);
     }
@@ -51,8 +51,6 @@ pub const BuildFileConfig = struct {
         name: []const u8,
         uri: []const u8,
     };
-
-    pub const IncludeDir = BuildConfig.IncludeDir;
 };
 
 pub const Handle = struct {
@@ -223,10 +221,10 @@ fn loadBuildConfiguration(context: LoadBuildConfigContext) !void {
                 packages.deinit(allocator);
             }
 
-            var include_dirs = try std.ArrayListUnmanaged(BuildFileConfig.IncludeDir).initCapacity(allocator, config.include_dirs.len);
+            var include_dirs = try std.ArrayListUnmanaged([]const u8).initCapacity(allocator, config.include_dirs.len);
             errdefer {
                 for (include_dirs.items) |dir| {
-                    allocator.free(dir.path);
+                    allocator.free(dir);
                 }
                 include_dirs.deinit(allocator);
             }
@@ -245,10 +243,10 @@ fn loadBuildConfiguration(context: LoadBuildConfigContext) !void {
             }
 
             for (config.include_dirs) |dir| {
-                const path = try allocator.dupe(u8, dir.path);
+                const path = try allocator.dupe(u8, dir);
                 errdefer allocator.free(path);
 
-                include_dirs.appendAssumeCapacity(.{ .path = path, .system = dir.system });
+                include_dirs.appendAssumeCapacity(path);
             }
 
             build_file.config = .{
@@ -655,18 +653,7 @@ fn collectCIncludes(self: *DocumentStore, handle: *Handle) ![]CImportHandle {
 }
 
 fn translate(self: *DocumentStore, handle: *Handle, source: []const u8) error{OutOfMemory}!?translate_c.Result {
-    const dirs: []BuildConfig.IncludeDir = if (handle.associated_build_file) |build_file| build_file.config.include_dirs else &.{};
-    const include_dirs = blk: {
-        var result = try self.allocator.alloc([]const u8, dirs.len);
-        errdefer self.allocator.free(result);
-
-        for (dirs) |dir, i| {
-            result[i] = dir.path;
-        }
-
-        break :blk result;
-    };
-    defer self.allocator.free(include_dirs);
+    const include_dirs: []const []const u8 = if (handle.associated_build_file) |build_file| build_file.config.include_dirs else &.{};
 
     const maybe_result = try translate_c.translate(
         self.allocator,


### PR DESCRIPTION
Support getting include paths using pkgconfig, requires https://github.com/ziglang/zig/pull/12981

This allows `cImport` completion to include all the include paths that things like `exe.linkSystemLibrary("gtk+-3.0");` add.

With master zls:
```
$ /home/lee/bin/zig run /home/lee/src/zls/src/special/build_runner.zig --cache-dir /home/lee/.cache/zls --pkg-begin @build@ /home/lee/src/fff/build.zig --pkg-end -- /home/lee/bin/zig /home/lee/src/fff/ zig-cache ZLS_DONT_CARE
{
    "packages": [],
    "include_dirs": []
}%
```

With this PR:
```
$ /home/lee/bin/zig run /home/lee/src/zls/src/special/build_runner.zig --cache-dir /home/lee/.cache/zls --pkg-begin @build@ /home/lee/src/fff/build.zig --pkg-end -- /home/lee/bin/zig /home/lee/src/fff/ zig-cache ZLS_DONT_CARE
{
    "packages": [],
    "include_dirs": [
        "/usr/include/gtk-3.0",
        "/usr/include/pango-1.0",
        "/usr/include/glib-2.0",
        "/usr/lib/glib-2.0/include",
        "/usr/include/sysprof-4",
        "/usr/include/harfbuzz",
        "/usr/include/freetype2",
        "/usr/include/libpng16",
        "/usr/include/libmount",
        "/usr/include/blkid",
        "/usr/include/fribidi",
        "/usr/include/cairo",
        "/usr/include/lzo",
        "/usr/include/pixman-1",
        "/usr/include/gdk-pixbuf-2.0",
        "/usr/include/gio-unix-2.0",
        "/usr/include/cloudproviders",
        "/usr/include/atk-1.0",
        "/usr/include/at-spi2-atk/2.0",
        "/usr/include/dbus-1.0",
        "/usr/lib/dbus-1.0/include",
        "/usr/include/at-spi-2.0"
    ]
}%
```