### PR TITLE
Adds a 'format to camelCase' codeaction for function names

### DIFF
--- a/src/code_actions.zig
+++ b/src/code_actions.zig
@@ -76,7 +76,13 @@ fn handleNonCamelcaseFunction(builder: *Builder, actions: *std.ArrayListUnmanage
 
     const tree = builder.handle.tree;
 
-    const decl = (try analysis.lookupSymbolGlobal(builder.document_store, builder.arena, builder.handle, identifier_name, loc.start)) orelse return;
+    const decl = (try analysis.lookupSymbolGlobal(
+        builder.document_store,
+        builder.arena,
+        builder.handle,
+        identifier_name,
+        loc.start,
+    )) orelse return;
 
     const name_token_idx = decl.nameToken();
     const name_loc = offsets.tokenToLoc(tree, name_token_idx);
@@ -85,7 +91,7 @@ fn handleNonCamelcaseFunction(builder: *Builder, actions: *std.ArrayListUnmanage
 
     const action1 = types.CodeAction{
         .title = "make function name camelCase",
-        .kind = .SourceFixAll,
+        .kind = .QuickFix,
         .isPreferred = true,
         .edit = try builder.createWorkspaceEdit(&.{builder.createTextEditLoc(name_loc, new_text)}),
     };

--- a/src/code_actions.zig
+++ b/src/code_actions.zig
@@ -82,7 +82,7 @@ fn handleNonCamelcaseFunction(builder: *Builder, actions: *std.ArrayListUnmanage
 
     const action1 = types.CodeAction{
         .title = "make function name camelCase",
-        .kind = .QuickFix,
+        .kind = .SourceFixAll,
         .isPreferred = true,
         .edit = try builder.createWorkspaceEdit(&.{builder.createTextEditLoc(loc, new_text)}),
     };

--- a/src/code_actions.zig
+++ b/src/code_actions.zig
@@ -82,7 +82,7 @@ fn handleNonCamelcaseFunction(builder: *Builder, actions: *std.ArrayListUnmanage
 
     const action1 = types.CodeAction{
         .title = "make function name camelCase",
-        .kind = .SourceFixAll,
+        .kind = .QuickFix,
         .isPreferred = true,
         .edit = try builder.createWorkspaceEdit(&.{builder.createTextEditLoc(loc, new_text)}),
     };
@@ -173,7 +173,7 @@ fn handleUnusedVariableOrConstant(builder: *Builder, actions: *std.ArrayListUnma
 
     try actions.append(builder.arena.allocator(), .{
         .title = "discard value",
-        .kind = .QuickFix,
+        .kind = .SourceFixAll,
         .isPreferred = true,
         .edit = try builder.createWorkspaceEdit(&.{builder.createTextEditPos(index, new_text)}),
     });

--- a/src/code_actions.zig
+++ b/src/code_actions.zig
@@ -82,7 +82,7 @@ fn handleNonCamelcaseFunction(builder: *Builder, actions: *std.ArrayListUnmanage
 
     const action1 = types.CodeAction{
         .title = "make function name camelCase",
-        .kind = .SourceFixAll,
+        .kind = .QuickFix,
         .isPreferred = true,
         .edit = try builder.createWorkspaceEdit(&.{builder.createTextEditLoc(loc, new_text)}),
     };

--- a/src/code_actions.zig
+++ b/src/code_actions.zig
@@ -74,13 +74,7 @@ pub const Builder = struct {
 fn handleNonCamelcaseFunction(builder: *Builder, actions: *std.ArrayListUnmanaged(types.CodeAction), loc: offsets.Loc) !void {
     const identifier_name = offsets.locToSlice(builder.text(), loc);
 
-    // const decl = (try analysis.lookupSymbolGlobal(
-    //     builder.document_store,
-    //     builder.arena,
-    //     builder.handle,
-    //     identifier_name,
-    //     loc.start,
-    // )) orelse return;
+    if (std.mem.allEqual(u8, identifier_name, '_')) return;
 
     const new_text = try createCamelcaseText(builder.arena.allocator(), identifier_name);
 
@@ -277,12 +271,11 @@ fn createCamelcaseText(allocator: std.mem.Allocator, identifier: []const u8) ![]
             while (trimmed_identifier[idx] == '_') : (idx += 1) {}
             const ch2 = trimmed_identifier[idx];
             new_text.appendAssumeCapacity(std.ascii.toUpper(ch2));
-
-            idx += 1;
         } else {
             new_text.appendAssumeCapacity(std.ascii.toLower(ch));
-            idx += 1;
         }
+
+        idx += 1;
     }
 
     return new_text.toOwnedSlice(allocator);

--- a/src/code_actions.zig
+++ b/src/code_actions.zig
@@ -266,7 +266,7 @@ fn handlePointlessDiscard(builder: *Builder, actions: *std.ArrayListUnmanaged(ty
 fn createCamelcaseText(allocator: std.mem.Allocator, identifier: []const u8) ![]const u8 {
     var num_separators: usize = 0;
     
-    const new_text_len = 1 + identifier.len - num_separators;
+    const new_text_len = identifier.len - num_separators;
     var new_text = try std.ArrayListUnmanaged(u8).initCapacity(allocator, new_text_len);
     errdefer new_text.deinit(allocator);
     


### PR DESCRIPTION
Does as the title says, this PR adds a code action that reformats non-camelCase function names to be camelCase.
 ___
![camelcase1](https://user-images.githubusercontent.com/19677138/192639733-f1d527a3-dce8-41a8-a7d5-d9a00008f90a.gif)
![camelcase2](https://user-images.githubusercontent.com/19677138/192639739-1838f358-dcd6-4059-9c4b-fc11056d0330.gif)
