### PR TITLE
Allow user defined options to be passed to build_runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Zig Language Server, or `zls`, is a language server for Zig. The Zig wiki states
     - [Build Options](#build-options)
     - [Updating Data Files](#updating-data-files)
   - [Configuration Options](#configuration-options)
+  - [Per-build Configuration Options](#per-build-configuration-options)
+    - [`BuildOption`](#buildoption)
 - [Features](#features)
   - [VS Code](#vs-code)
   - [Sublime Text](#sublime-text)
@@ -116,6 +118,28 @@ The following options are currently available.
 |`include_at_in_builtins`|`bool`|`false`| Whether the @ sign should be part of the completion of builtins.
 |`max_detail_length`|`usize`|`1024 * 1024`| The detail field of completions is truncated to be no longer than this (in bytes).
 | `skip_std_references` | `bool` | `false` | When true, skips searching for references in std. Improves lookup speed for functions in user's code. Renaming and go-to-definition will continue to work as is.
+
+### Per-build Configuration Options
+
+The following options can be set on a per-project basis by placing `zls.user.json` in the project root directory next to `build.zig`.
+
+| Option | Type | Default value | What it Does |
+| --- | --- | --- | --- |
+| `relative_builtin_path` | `?[]const u8` | `null` | If present, this path is used to resolve `@import("builtin")` |
+| `build_options` | `?[]BuildOption` | `null` | If present, this contains a list of user options to pass to the build. This is useful when options are used to conditionally add packages in `build.zig`. |
+
+#### `BuildOption`
+
+`BuildOption` is defined as follows:
+
+```zig
+const BuildOption = struct {
+    name: []const u8,
+    value: ?[]const u8 = null,
+};
+```
+
+When `value` is present, the option will be passed the same as in `zig build -Dname=value`. When `value` is `null`, the option will be passed as a flag instead as in `zig build -Dflag`.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ The following options are currently available.
 
 ### Per-build Configuration Options
 
-The following options can be set on a per-project basis by placing `zls.user.json` in the project root directory next to `build.zig`.
+The following options can be set on a per-project basis by placing `zls.build.json` in the project root directory next to `build.zig`.
 
 | Option | Type | Default value | What it Does |
 | --- | --- | --- | --- |

--- a/src/BuildAssociatedConfig.zig
+++ b/src/BuildAssociatedConfig.zig
@@ -1,4 +1,44 @@
-// Configuration options related to a specific `BuildFile`.
+//! Configuration options related to a specific `BuildFile`.
+const std = @import("std");
+
+pub const BuildOption = struct {
+    name: []const u8,
+    value: ?[]const u8 = null,
+
+    /// Frees the strings assocated with this `BuildOption` and invalidates `self`.
+    pub fn deinit(self: *BuildOption, allocator: std.mem.Allocator) void {
+        allocator.free(self.name);
+        if (self.value) |val| {
+            allocator.free(val);
+        }
+        self.* = undefined;
+    }
+
+    /// Duplicates the `BuildOption`, copying internal strings. Caller owns returned option with contents
+    /// allocated using `allocator`.
+    pub fn dupe(self: BuildOption, allocator: std.mem.Allocator) !BuildOption {
+        const copy_name = try allocator.dupe(u8, self.name);
+        errdefer allocator.free(copy_name);
+        const copy_value = if (self.value) |val|
+            try allocator.dupe(u8, val)
+        else
+            null;
+        return BuildOption{
+            .name = copy_name,
+            .value = copy_value,
+        };
+    }
+
+    /// Formats the `BuildOption` as a command line parameter compatible with `zig build`. This will either be
+    /// `-Dname=value` or `-Dname`. Caller owns returned slice allocated using `allocator`.
+    pub fn formatParam(self: BuildOption, allocator: std.mem.Allocator) ![]const u8 {
+        if (self.value) |val| {
+            return try std.fmt.allocPrint(allocator, "-D{s}={s}", .{ self.name, val });
+        } else {
+            return try std.fmt.allocPrint(allocator, "-D{s}", .{self.name});
+        }
+    }
+};
 
 /// If provided this path is used when resolving `@import("builtin")`
 /// It is relative to the directory containing the `build.zig`
@@ -6,3 +46,6 @@
 /// This file should contain the output of:
 /// `zig build-exe/build-lib/build-obj --show-builtin <options>`
 relative_builtin_path: ?[]const u8 = null,
+
+/// If provided, this list of options will be passed to `build.zig`.
+build_options: ?[]BuildOption = null,

--- a/src/DocumentStore.zig
+++ b/src/DocumentStore.zig
@@ -178,7 +178,7 @@ fn loadBuildConfiguration(context: LoadBuildConfigContext) !void {
     defer if (context.build_file_path == null) allocator.free(build_file_path);
     const directory_path = build_file_path[0 .. build_file_path.len - "build.zig".len];
 
-    const standard_args = &[_][]const u8{
+    const standard_args = [_][]const u8{
         zig_exe_path,
         "run",
         build_runner_path,
@@ -198,7 +198,7 @@ fn loadBuildConfiguration(context: LoadBuildConfigContext) !void {
     var args = try arena_allocator.alloc([]const u8, standard_args.len + if (build_file.build_options) |opts| opts.len else 0);
     defer arena_allocator.free(args);
 
-    args[0..standard_args.len].* = standard_args.*;
+    args[0..standard_args.len].* = standard_args;
     if (build_file.build_options) |opts| {
         for (opts) |opt, i| {
             args[standard_args.len + i] = try opt.formatParam(arena_allocator);

--- a/src/DocumentStore.zig
+++ b/src/DocumentStore.zig
@@ -118,7 +118,7 @@ fn loadBuildAssociatedConfiguration(allocator: std.mem.Allocator, build_file: *B
     const directory_path = build_file_path[0 .. build_file_path.len - "build.zig".len];
 
     const options = std.json.ParseOptions{ .allocator = allocator };
-    const build_associated_config = blk: {
+    var build_associated_config = blk: {
         const config_file_path = try std.fs.path.join(allocator, &[_][]const u8{ directory_path, "zls.build.json" });
         defer allocator.free(config_file_path);
 
@@ -144,18 +144,8 @@ fn loadBuildAssociatedConfiguration(allocator: std.mem.Allocator, build_file: *B
     }
 
     if (build_associated_config.build_options) |opts| {
-        // Copy options out of json parse result since they will be invalidated
-        var build_opts = try std.ArrayListUnmanaged(BuildAssociatedConfig.BuildOption).initCapacity(allocator, opts.len);
-        errdefer {
-            for (build_opts.items) |*opt| {
-                opt.deinit(allocator);
-            }
-            build_opts.deinit(allocator);
-        }
-        for (opts) |opt| {
-            try build_opts.append(allocator, try opt.dupe(allocator));
-        }
-        build_file.build_options = build_opts.toOwnedSlice(allocator);
+        build_file.build_options = opts;
+        build_associated_config.build_options = null;
     }
 }
 


### PR DESCRIPTION
### Problem

Build options (`-Dname=value`, `-Dflag`) can change the dependency graph resulting from running `build.zig`. If `build.zig` is incorrectly configured, zls will either not be able to extract dependency information[1] or it may do so incorrectly[2].

[1] This can happen when the build script is designed to exit if a required option is not present. This will cause `build_runner` to fail. [Example from zig](https://github.com/ziglang/zig/blob/f3a1b5c481646ee35813cbe8bb2b0a3979df3ab8/build.zig#L183-L188)
[2] This can happen when options have default values that differ from those passed during actual builds. Since zls currently does not pass any user options to `build.zig`, it will always use defaults. [Example from zig](https://github.com/ziglang/zig/blob/f3a1b5c481646ee35813cbe8bb2b0a3979df3ab8/build.zig#L51-L62)

### Motivation

I have projects that use a mixture of C, C++, and zig libraries. I prefer to keep these out of tree since there are some especially large libraries like opencv and zigwin32, and they are shared between multiple projects. To accomplish this, library paths are passed on the command line via `Builder.option`:

```
> zig build -Dopencv-root-dir=D:\Scratch\opencv-4.6.0-zigbuild\install -Dzigwin32-root-dir=D:\Scratch\zigwin32 -Dautomate-root-dir=D:\Dev\Projects\ZigAutomate
```

```zig
    // somewhere in a build.zig
    const automate_root_dir = b.option([]const u8, "automate-root-dir", "root directory for automate");
    if (automate_root_dir == null) {
        std.debug.print("missing required option: -Dautomate-root-dir=[string]\n\n", .{});
        std.process.exit(1);
    }
    const automate_root_src = b.pathJoin(&[_][]const u8{ automate_root_dir.?, "src/lib.zig" });
    const automate = Pkg{
        .name = "auto",
        .source = .{ .path = automate _root_src },
        .dependencies = &[_]Pkg{ win32 },
    };
    // similar things for other packages
```

The project I'm doing this in is not getting autocomplete from zls because it does not pass these options through `build_runner`, which then fails because I use the idiom in [1].

### Implementation

This PR adds a `build_options` field to `BuildAssociatedConfig`. These can be set in a project-local `zls.build.json`. Example:

```json
{
    "build_options": [
        {
            "name": "automate-root-dir",
            "value": "D:\\Dev\\Projects\\ZigAutomate"
        },
        {
            "name": "opencv-root-dir",
            "value": "D:\\Scratch\\opencv-4.6.0-zigbuild\\install"
        },
        {
            "name": "zigwin32-root-dir",
            "value": "D:\\Scratch\\zigwin32"
        }
    ]
}
```

Options with a `name` and `value` are passed to `build.zig` as `-Dname=value`. If `value` is omitted, the option is treated as a flag and passed as `-Dname`.
