### PR TITLE
handle `OptionsStep` in build_runner

### DIFF
--- a/src/special/build_runner.zig
+++ b/src/special/build_runner.zig
@@ -120,7 +120,10 @@ pub fn main() !void {
 
 fn reifyOptions(step: *std.build.Step) !void {
     if (step.cast(OptionsStep)) |option| {
-        try option.step.make();
+        // We don't know how costly the dependency tree might be, so err on the side of caution
+        if (step.dependencies.items.len == 0) {
+            try option.step.make();
+        }
     }
 
     for (step.dependencies.items) |unknown_step| {


### PR DESCRIPTION
This allows generated files from `OptionsStep` to be resolved.

This is dependant on https://github.com/ziglang/zig/pull/13003 I will leave it as a draft until it is merged.

I'm not 100% happy with this due to:
- We can't know how costly the dependencies of the step might be so i've decided to only support `OptionsStep`s that have no dependencies.
Thankfully this is the most common situation, I don't think i've ever seen an `OptionsStep` have any dependencies.
- It's extremely common for the pacakge to be called `build_options`, this could easily result in multiple packages with the same name pointing to different files.
As before this is an uncommon issue to hit as multiple `OptionsStep`s is rare. 
This is one more reason the TODO in `build_runner.zig` would be nice to fix.
https://github.com/zigtools/zls/blob/8cf93fc96a705d30771843de6415ddfce097022f/src/special/build_runner.zig#L93-L95


Before:
```
$ /home/lee/bin/zig run /home/lee/src/zls/src/special/build_runner.zig --cache-dir /home/lee/.cache/zls --pkg-begin @build@ build.zig --pkg-end -- /home/lee/bin/zig /home/lee/src/fff/ zig-cache ZLS_DONT_CARE
{
    "packages": [
        {
            "name": "args",
            "path": "libraries/zig-args/args.zig"
        },
        {
            "name": "known_folders",
            "path": "libraries/known-folders/known-folders.zig"
        },
        {
            "name": "bestline",
            "path": "libraries/bestline/bestline.zig"
        },
        {
            "name": "tracy",
            "path": "libraries/tracy/tracy.zig"
        },
        {
            "name": "zriscv",
            "path": "zriscv/zriscv.zig"
        },
        {
            "name": "bitjuggle",
            "path": "libraries/zig-bitjuggle/bitjuggle.zig"
        }
    ],
    "include_dirs": [
        "libraries/bestline/bestline"
    ]
}%
```

After:
```
$ /home/lee/bin/zig run /home/lee/src/zls/src/special/build_runner.zig --cache-dir /home/lee/.cache/zls --pkg-begin @build@ build.zig --pkg-end -- /home/lee/bin/zig /home/lee/src/fff/ zig-cache ZLS_DONT_CARE
{
    "packages": [
        {
            "name": "build_options",
            "path": "/home/lee/src/zriscv/zig-cache/options/_OHWmub1P7ZxHbsba8NlAXpkS2ryAiTxuWgRR8iH9_AHeEPbLP9T8iSLLH4QQeqm"
        },
        {
            "name": "args",
            "path": "libraries/zig-args/args.zig"
        },
        {
            "name": "known_folders",
            "path": "libraries/known-folders/known-folders.zig"
        },
        {
            "name": "bestline",
            "path": "libraries/bestline/bestline.zig"
        },
        {
            "name": "tracy",
            "path": "libraries/tracy/tracy.zig"
        },
        {
            "name": "zriscv",
            "path": "zriscv/zriscv.zig"
        },
        {
            "name": "bitjuggle",
            "path": "libraries/zig-bitjuggle/bitjuggle.zig"
        }
    ],
    "include_dirs": [
        "libraries/bestline/bestline"
    ]
}%
```