### PR TITLE
Revamp bulid.zig discovery

### DIFF
--- a/src/DocumentStore.zig
+++ b/src/DocumentStore.zig
@@ -273,19 +273,11 @@ const BuildDotZigIterator = struct {
     fn init(allocator: std.mem.Allocator, uri_path: []const u8) !BuildDotZigIterator {
         const dir_path = std.fs.path.dirname(uri_path) orelse uri_path;
 
-        // not sure about windows drives and paths, so deferring to this
-        // function to figure it out for me?
-        const root_dir_path = try URI.parse(allocator, "file:///");
-        defer allocator.free(root_dir_path);
-
         return BuildDotZigIterator{
             .allocator = allocator,
             .uri_path = uri_path,
             .dir_path = dir_path,
-            .i = switch (builtin.os.tag) {
-                .windows => std.fs.path.diskDesignator(uri_path).len + 1,
-                else => 1,
-            },
+            .i = std.fs.path.diskDesignator(uri_path).len + 1,
         };
     }
 

--- a/src/special/build_runner.zig
+++ b/src/special/build_runner.zig
@@ -97,11 +97,18 @@ fn processStep(
     step: *std.build.Step,
 ) anyerror!void {
     if (step.cast(InstallArtifactStep)) |install_exe| {
+        if(install_exe.artifact.root_src) |src| {
+          try packages.append(allocator, .{.name = "root", .path = src.path });
+        }
+
         try processIncludeDirs(allocator, include_dirs, install_exe.artifact.include_dirs.items);
         for (install_exe.artifact.packages.items) |pkg| {
             try processPackage(allocator, packages, pkg);
         }
     } else if (step.cast(LibExeObjStep)) |exe| {
+        if(exe.root_src) |src| {
+          try packages.append(allocator, .{.name = "root", .path = src.path });
+        }
         try processIncludeDirs(allocator, include_dirs, exe.include_dirs.items);
         for (exe.packages.items) |pkg| {
             try processPackage(allocator, packages, pkg);

--- a/tests/lsp_features/references.zig
+++ b/tests/lsp_features/references.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const zls = @import("zls");
+const builtin = @import("builtin");
 
 const helper = @import("../helper.zig");
 const Context = @import("../context.zig").Context;
@@ -85,7 +86,10 @@ test "references - label" {
 }
 
 fn testReferences(source: []const u8) !void {
-    const file_uri = "file:///test.zig";
+    const file_uri: []const u8 = switch (builtin.os.tag) {
+        .windows => "file:///C:\\test.zig",
+        else => "file:///test.zig",
+    };
     const new_name = "placeholder";
 
     var phr = try helper.collectReplacePlaceholders(allocator, source, new_name);

--- a/tests/lsp_features/semantic_tokens.zig
+++ b/tests/lsp_features/semantic_tokens.zig
@@ -22,7 +22,7 @@ test "semantic tokens" {
 }
 
 const file_uri = switch (builtin.os.tag) {
-    .windows => "file:///C:\\\\test.zig",
+    .windows => "file:///C:\\\\\\\\test.zig",
     else => "file:///test.zig",
 };
 

--- a/tests/lsp_features/semantic_tokens.zig
+++ b/tests/lsp_features/semantic_tokens.zig
@@ -22,7 +22,7 @@ test "semantic tokens" {
 }
 
 const file_uri = switch (builtin.os.tag) {
-    .windows => "file:///C:\\\\\\\\test.zig",
+    .windows => "file:///C:/test.zig",
     else => "file:///test.zig",
 };
 

--- a/tests/lsp_features/semantic_tokens.zig
+++ b/tests/lsp_features/semantic_tokens.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const zls = @import("zls");
+const builtin = @import("builtin");
 
 const Context = @import("../context.zig").Context;
 
@@ -27,7 +28,10 @@ fn testSemanticTokens(source: []const u8, expected: []const u32) !void {
     const open_document = requests.OpenDocument{
         .params = .{
             .textDocument = .{
-                .uri = "file:///test.zig",
+                .uri = switch (builtin.os.tag) {
+                    .windows => "file:///C:\\test.zig",
+                    else => "file:///test.zig",
+                },
                 // .languageId = "zig",
                 // .version = 420,
                 .text = source,

--- a/tests/lsp_features/semantic_tokens.zig
+++ b/tests/lsp_features/semantic_tokens.zig
@@ -53,7 +53,9 @@ fn testSemanticTokens(source: []const u8, expected: []const u32) !void {
     const expected_bytes = try std.json.stringifyAlloc(allocator, Response{ .data = expected }, .{});
     defer allocator.free(expected_bytes);
 
-    try ctx.request("textDocument/semanticTokens/full", std.fmt.comptimePrint(
-        \\{{"textDocument":{{"uri":"{s}"}}}}
-    , .{file_uri}), expected_bytes);
+    try ctx.request(
+        "textDocument/semanticTokens/full",
+        "{\"textDocument\":{\"uri\":\"" ++ file_uri ++ "\"}}",
+        expected_bytes,
+    );
 }

--- a/tests/lsp_features/semantic_tokens.zig
+++ b/tests/lsp_features/semantic_tokens.zig
@@ -22,7 +22,7 @@ test "semantic tokens" {
 }
 
 const file_uri = switch (builtin.os.tag) {
-    .windows => "file:///C:\\test.zig",
+    .windows => "file:///C:\\\\test.zig",
     else => "file:///test.zig",
 };
 


### PR DESCRIPTION
The current method for finding a build file for a given URI involves walking up the filesystem until one is found. This is a problem when a dependency provides the root file for your executable, such as in [microzig](https://github.com/ZigEmbeddedGroup/microzig). [rp2040](https://github.com/ZigEmbeddedGroup/rp2040) is an example of a package that uses it. If I'm editing a path in rp2040, say:

```
rp2040/src/hal/adc.zig
```

with a root file in

```
rp2040/deps/microzig/src/core/microzig.zig
```

what ends up happening is that zls walks upwards and determines the build file to be:

```
rp2040/deps/microzig/build.zig
```

when we want:

```
rp2040/build.zig
```

This is a problem in rp2040 because zls ends up giving completions for an AVR based microcontroller instead of an ARM microcontroller, an artifact from the microzig build file.

### This solution:

Since there does not seem to be a notion of "project root", this patch introduces a new strategy for build.zig discovery where we walk down the filesystem from root towards our file of interest. For each build.zig it encounters, it loads the build configuration and _only associates the build file with the file of interest if that file is imported/used_, otherwise it continues walking. Finally, if no build file is technically associated, zls will used the closest build.zig.

This makes it so that higher build.zig files have precedence for completions, and should be correct in more situations.

