### PR TITLE
inlay_hints: implement ability to remove redundant hints

### DIFF
--- a/src/Config.zig
+++ b/src/Config.zig
@@ -52,6 +52,14 @@ inlay_hints_show_builtin: bool = true,
 /// don't show inlay hints for single argument calls
 inlay_hints_exclude_single_argument: bool = true,
 
+/// don't show inlay hints when parameter name matches the identifier
+/// for example: `foo: foo`
+inlay_hints_hide_redundant_param_names: bool = false,
+
+/// don't show inlay hints when parameter names matches the last
+/// for example: `foo: bar.foo`, `foo: &foo`
+inlay_hints_hide_redundant_param_names_last_token: bool = false,
+
 /// Whether to enable `*` and `?` operators in completion lists
 operator_completions: bool = true,
 
@@ -69,8 +77,6 @@ skip_std_references: bool = false,
 builtin_path: ?[]const u8 = null,
 
 pub fn loadFromFile(allocator: std.mem.Allocator, file_path: []const u8) ?Config {
-    @setEvalBranchQuota(5000);
-
     const tracy_zone = tracy.trace(@src());
     defer tracy_zone.end();
 
@@ -84,7 +90,7 @@ pub fn loadFromFile(allocator: std.mem.Allocator, file_path: []const u8) ?Config
 
     const file_buf = file.readToEndAlloc(allocator, 0x1000000) catch return null;
     defer allocator.free(file_buf);
-    @setEvalBranchQuota(3000);
+    @setEvalBranchQuota(7000);
     const parse_options = std.json.ParseOptions{ .allocator = allocator, .ignore_unknown_fields = true };
     // TODO: Better errors? Doesn't seem like std.json can provide us positions or context.
     var config = std.json.parse(Config, &std.json.TokenStream.init(file_buf), parse_options) catch |err| {

--- a/src/requests.zig
+++ b/src/requests.zig
@@ -300,6 +300,8 @@ pub const Configuration = struct {
             enable_inlay_hints: ?bool,
             inlay_hints_show_builtin: ?bool,
             inlay_hints_exclude_single_argument: ?bool,
+            inlay_hints_hide_redundant_param_names: ?bool,
+            inlay_hints_hide_redundant_param_names_last_token: ?bool,
             operator_completions: ?bool,
             include_at_in_builtins: ?bool,
             max_detail_length: ?usize,


### PR DESCRIPTION
This adds a way to disable inlay hints when they are redundant, for example: `foo: foo`, `foo: &foo`, `foo: bar.foo`

Some screenshots:
inlay hints without this feature:
![image](https://user-images.githubusercontent.com/1974995/193045940-7007b057-60d6-4676-8528-a4b9c25f48e2.png)
with inlay_hints_hide_redundant_param_names:
![image](https://user-images.githubusercontent.com/1974995/193046150-63f699ff-44cc-48f0-912a-d74fb9517c22.png)
with inlay_hints_hide_redundant_param_names_last_token:
![image](https://user-images.githubusercontent.com/1974995/193046367-d6cb17c8-f5ab-4910-a09f-b2a2e6f4d8b2.png)
with both enabled:
![image](https://user-images.githubusercontent.com/1974995/193047168-94669b0a-299a-4a9d-8f5e-10fb58f40ac4.png)
