### PR TITLE
Fix crash when getting signature of optional

### DIFF
--- a/src/signature_help.zig
+++ b/src/signature_help.zig
@@ -237,6 +237,7 @@ pub fn getSignatureInfo(document_store: *DocumentStore, arena: *std.heap.ArenaAl
                             .r_paren => state = .{ .in_paren = 1 },
                             .identifier,
                             .period,
+                            .question_mark,
                             .period_asterisk,
                             => {},
                             else => break i + 1,


### PR DESCRIPTION
e.g. typing `foo.?.bar(` crashes zls because it doesn't recognize `?` as a possible token as part of a function expression, and tries to call `getFieldAccessType` with `.bar` instead.

The actual fix is the one line in `src/signature_help.zig`

`getFieldAccessType` was also reworked to be more resilient to this type of thing - the `undefined` value of `current_type.type.data` was being used since it hit the `.period` branch first. This caused the crash.