### PR TITLE
remove types.TextDocument

### DIFF
--- a/src/DocumentStore.zig
+++ b/src/DocumentStore.zig
@@ -77,10 +77,6 @@ pub const Handle = struct {
 
     associated_build_file: ?*BuildFile,
     is_build_file: ?*BuildFile,
-
-    pub fn uri(handle: Handle) []const u8 {
-        return handle.document.uri;
-    }
 };
 
 pub const UriToHandleMap = std.StringHashMapUnmanaged(*Handle);

--- a/src/code_actions.zig
+++ b/src/code_actions.zig
@@ -70,7 +70,7 @@ pub const Builder = struct {
 };
 
 fn handleNonCamelcaseFunction(builder: *Builder, actions: *std.ArrayListUnmanaged(types.CodeAction), loc: offsets.Loc) !void {
-    const identifier_name = offsets.locToSlice(builder.text(), loc);
+    const identifier_name = offsets.locToSlice(builder.handle.text, loc);
 
     if (std.mem.allEqual(u8, identifier_name, '_')) return;
 

--- a/src/inlay_hints.zig
+++ b/src/inlay_hints.zig
@@ -211,14 +211,12 @@ fn writeCallNodeHint(builder: *Builder, arena: *std.heap.ArenaAllocator, store: 
             const start = offsets.tokenToIndex(tree, lhsToken);
             const rhs_loc = offsets.tokenToLoc(tree, rhsToken);
 
-            var held_range = handle.document.borrowNullTerminatedSlice(start, rhs_loc.end);
-            var tokenizer = std.zig.Tokenizer.init(held_range.data());
+            var held_range = try arena.allocator().dupeZ(u8, handle.text[start..rhs_loc.end]);
+            var tokenizer = std.zig.Tokenizer.init(held_range);
 
             // note: we have the ast node, traversing it would probably yield better results
             // than trying to re-tokenize and re-parse it
-            errdefer held_range.release();
             if (try analysis.getFieldAccessType(store, arena, handle, rhs_loc.end, &tokenizer)) |result| {
-                held_range.release();
                 const container_handle = result.unwrapped orelse result.original;
                 switch (container_handle.type.data) {
                     .other => |container_handle_node| {

--- a/src/references.zig
+++ b/src/references.zig
@@ -29,7 +29,7 @@ pub fn labelReferences(
     if (include_decl) {
         // The first token is always going to be the label
         try locations.append(allocator, .{
-            .uri = handle.uri(),
+            .uri = handle.uri,
             .range = offsets.tokenToRange(handle.tree, first_tok, encoding),
         });
     }
@@ -45,7 +45,7 @@ pub fn labelReferences(
         if (!std.mem.eql(u8, tree.tokenSlice(curr_tok + 2), tree.tokenSlice(first_tok))) continue;
 
         try locations.append(allocator, .{
-            .uri = handle.uri(),
+            .uri = handle.uri,
             .range = offsets.tokenToRange(handle.tree, curr_tok + 2, encoding),
         });
     }
@@ -72,7 +72,7 @@ const Builder = struct {
 
     pub fn add(self: *Builder, handle: *DocumentStore.Handle, token_index: Ast.TokenIndex) !void {
         try self.locations.append(self.arena.allocator(), .{
-            .uri = handle.uri(),
+            .uri = handle.uri,
             .range = offsets.tokenToRange(handle.tree, token_index, self.encoding),
         });
     }

--- a/src/requests.zig
+++ b/src/requests.zig
@@ -204,8 +204,13 @@ const TextDocumentIdentifier = struct {
 pub const ChangeDocument = struct {
     params: struct {
         textDocument: TextDocumentIdentifier,
-        contentChanges: std.json.Value,
+        contentChanges: []TextDocumentContentChangeEvent,
     },
+};
+
+pub const TextDocumentContentChangeEvent = struct {
+    range: ?types.Range,
+    text: []const u8,
 };
 
 const TextDocumentIdentifierRequest = struct {

--- a/src/signature_help.zig
+++ b/src/signature_help.zig
@@ -251,11 +251,10 @@ pub fn getSignatureInfo(document_store: *DocumentStore, arena: *std.heap.ArenaAl
                 const last_token_slice = tree.tokenSlice(expr_last_token);
                 const expr_end = token_starts[expr_last_token] + last_token_slice.len;
 
-                var held_expr = handle.document.borrowNullTerminatedSlice(expr_start, expr_end);
-                defer held_expr.release();
+                var held_expr = try alloc.dupeZ(u8, handle.text[expr_start..expr_end]);
 
                 // Resolve the expression.
-                var tokenizer = std.zig.Tokenizer.init(held_expr.data());
+                var tokenizer = std.zig.Tokenizer.init(held_expr);
                 if (try analysis.getFieldAccessType(
                     document_store,
                     arena,

--- a/src/types.zig
+++ b/src/types.zig
@@ -124,41 +124,6 @@ pub const Diagnostic = struct {
     relatedInformation: ?[]const DiagnosticRelatedInformation = null,
 };
 
-pub const TextDocument = struct {
-    uri: string,
-    // This is a substring of mem starting at 0
-    text: [:0]const u8,
-    // This holds the memory that we have actually allocated.
-    mem: []u8,
-
-    const Held = struct {
-        document: *const TextDocument,
-        popped: u8,
-        start_index: usize,
-        end_index: usize,
-
-        pub fn data(self: @This()) [:0]const u8 {
-            return self.document.mem[self.start_index..self.end_index :0];
-        }
-
-        pub fn release(self: *@This()) void {
-            self.document.mem[self.end_index] = self.popped;
-        }
-    };
-
-    pub fn borrowNullTerminatedSlice(self: *const @This(), start_idx: usize, end_idx: usize) Held {
-        std.debug.assert(end_idx >= start_idx);
-        const popped_char = self.mem[end_idx];
-        self.mem[end_idx] = 0;
-        return .{
-            .document = self,
-            .popped = popped_char,
-            .start_index = start_idx,
-            .end_index = end_idx,
-        };
-    }
-};
-
 pub const WorkspaceEdit = struct {
     changes: std.StringHashMapUnmanaged(std.ArrayListUnmanaged(TextEdit)),
 

--- a/tests/utility/position_context.zig
+++ b/tests/utility/position_context.zig
@@ -233,38 +233,19 @@ test "position context - empty" {
     );
 }
 
-fn makeDocument(uri: []const u8, text: []const u8) !types.TextDocument {
-    const mem = try allocator.alloc(u8, text.len + 1);
-    std.mem.copy(u8, mem, text);
-    mem[text.len] = 0;
+fn testContext(line: []const u8, tag: std.meta.Tag(analysis.PositionContext), maybe_range: ?[]const u8) !void {
+    const cursor_idx = std.mem.indexOf(u8, line, "<cursor>").?;
+    const final_line = try std.mem.concat(allocator, u8, &.{ line[0..cursor_idx], line[cursor_idx + "<cursor>".len ..] });
+    defer allocator.free(final_line);
 
-    return types.TextDocument{
-        .uri = uri,
-        .mem = mem,
-        .text = mem[0..text.len :0],
-    };
-}
-
-fn freeDocument(doc: types.TextDocument) void {
-    allocator.free(doc.text);
-}
-
-
-fn testContext(comptime line: []const u8, comptime tag: std.meta.Tag(analysis.PositionContext), comptime maybe_range: ?[]const u8) !void {
-    const cursor_idx = comptime std.mem.indexOf(u8, line, "<cursor>").?;
-    const final_line = line[0..cursor_idx] ++ line[cursor_idx + "<cursor>".len ..];
-
-    const doc = try makeDocument("", line);
-    defer freeDocument(doc);
-
-    const ctx = try analysis.getPositionContext(allocator, doc, cursor_idx);
+    const ctx = try analysis.getPositionContext(allocator, line, cursor_idx);
 
     if (std.meta.activeTag(ctx) != tag) {
         std.debug.print("Expected tag `{s}`, got `{s}`\n", .{ @tagName(tag), @tagName(std.meta.activeTag(ctx)) });
         return error.DifferentTag;
     }
 
-    const actual_loc = ctx.loc() orelse if(maybe_range) |expected_range| {
+    const actual_loc = ctx.loc() orelse if (maybe_range) |expected_range| {
         std.debug.print("Expected `{s}`, got null range\n", .{
             expected_range,
         });
@@ -273,18 +254,18 @@ fn testContext(comptime line: []const u8, comptime tag: std.meta.Tag(analysis.Po
 
     const expected_range = maybe_range orelse {
         std.debug.print("Expected null range, got `{s}`\n", .{
-            doc.text[actual_loc.start..actual_loc.end],
+            line[actual_loc.start..actual_loc.end],
         });
         return error.DifferentRange;
     };
-    
-    const expected_range_start = comptime std.mem.indexOf(u8, final_line, expected_range).?;
+
+    const expected_range_start = std.mem.indexOf(u8, final_line, expected_range).?;
     const expected_range_end = expected_range_start + expected_range.len;
 
     if (expected_range_start != actual_loc.start or expected_range_end != actual_loc.end) {
         std.debug.print("Expected range `{s}` ({}..{}), got `{s}` ({}..{})\n", .{
-            doc.text[expected_range_start..expected_range_end], expected_range_start, expected_range_end,
-            doc.text[actual_loc.start..actual_loc.end], actual_loc.start, actual_loc.end,
+            line[expected_range_start..expected_range_end], expected_range_start, expected_range_end,
+            line[actual_loc.start..actual_loc.end],         actual_loc.start,     actual_loc.end,
         });
         return error.DifferentRange;
     }


### PR DESCRIPTION
The main reason for this change is getting rid of `borrowNullTerminatedSlice`, because it temporarily modifies the source text. This may not seem like a big problem but it is one of the thinks that needs to change before the possibility of processing request in parallel becomes possible.

I've also replaced `applyChanges` with a cleaner implementation. We may consider setting [TextDocumentSyncKind](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocumentSyncKind) to `.Incremental` which should be especially helpful if you are dealing with very large files.
https://github.com/zigtools/zls/blob/3c4535a32111fc995d805c015f8f89b9b608e01d/src/Server.zig#L1487