### PR TITLE
DocumentStore refactor

### DIFF
--- a/src/DocumentStore.zig
+++ b/src/DocumentStore.zig
@@ -302,6 +302,9 @@ fn garbageCollectionCImports(self: *DocumentStore) error{OutOfMemory}!void {
 }
 
 fn garbageCollectionBuildFiles(self: *DocumentStore) error{OutOfMemory}!void {
+    const tracy_zone = tracy.trace(@src());
+    defer tracy_zone.end();
+
     var reachable_build_files = std.StringHashMapUnmanaged(void){};
     defer reachable_build_files.deinit(self.allocator);
 
@@ -521,6 +524,9 @@ fn uriAssociatedWithBuild(
     build_file: BuildFile,
     uri: Uri,
 ) error{OutOfMemory}!bool {
+    const tracy_zone = tracy.trace(@src());
+    defer tracy_zone.end();
+
     var checked_uris = std.StringHashMap(void).init(self.allocator);
     defer {
         var it = checked_uris.iterator();
@@ -750,6 +756,9 @@ pub fn collectDependencies(
     handle: Handle,
     dependencies: *std.ArrayListUnmanaged(Uri),
 ) error{OutOfMemory}!void {
+    const tracy_zone = tracy.trace(@src());
+    defer tracy_zone.end();
+
     try dependencies.ensureUnusedCapacity(allocator, handle.import_uris.items.len);
     for (handle.import_uris.items) |uri| {
         dependencies.appendAssumeCapacity(try allocator.dupe(u8, uri));

--- a/src/DocumentStore.zig
+++ b/src/DocumentStore.zig
@@ -871,8 +871,11 @@ pub fn uriFromImportStr(self: *const DocumentStore, allocator: std.mem.Allocator
         defer allocator.free(std_path);
         return try URI.fromPath(allocator, std_path);
     } else if (std.mem.eql(u8, import_str, "builtin")) {
-        if (handle.associated_build_file) |builtin_uri| {
-            return try allocator.dupe(u8, builtin_uri);
+        if (handle.associated_build_file) |build_file_uri| {
+            const build_file = self.build_files.get(build_file_uri).?;
+            if (build_file.builtin_uri) |builtin_uri| {
+                return try allocator.dupe(u8, builtin_uri);
+            }
         }
         if (self.config.builtin_path) |_| {
             return try URI.fromPath(allocator, self.config.builtin_path.?);

--- a/src/DocumentStore.zig
+++ b/src/DocumentStore.zig
@@ -866,13 +866,13 @@ fn tagStoreCompletionItems(self: DocumentStore, arena: std.mem.Allocator, handle
     defer tracy_zone.end();
 
     var dependencies = std.ArrayListUnmanaged(Uri){};
-    try dependencies.append(self.allocator, handle);
-    try collectDependencies(self.allocator, self, handle, dependencies);
+    try dependencies.append(self.allocator, handle.uri);
+    try collectDependencies(self.allocator, &self, handle, &dependencies);
 
     // TODO Better solution for deciding what tags to include
     var result_set = analysis.CompletionSet{};
 
-    for (dependencies) |uri| {
+    for (dependencies.items) |uri| {
         // not every dependency is loaded which results in incomplete completion
         const hdl = self.handles.get(uri) orelse continue;
         const curr_set = @field(hdl.document_scope, name);

--- a/src/DocumentStore.zig
+++ b/src/DocumentStore.zig
@@ -258,7 +258,7 @@ fn garbageCollectionImports(self: *DocumentStore) error{OutOfMemory}!void {
 
         try reachable_handles.put(self.allocator, handle.uri, {});
 
-        try collectDependencies(self.allocator, self, handle.*, &queue);
+        try self.collectDependencies(self.allocator, handle.*, &queue);
     }
 
     while (queue.popOrNull()) |uri| {
@@ -268,7 +268,7 @@ fn garbageCollectionImports(self: *DocumentStore) error{OutOfMemory}!void {
 
         const handle = self.handles.get(uri) orelse continue;
 
-        try collectDependencies(self.allocator, self, handle.*, &queue);
+        try self.collectDependencies(self.allocator, handle.*, &queue);
     }
 
     var i: usize = 0;
@@ -763,8 +763,8 @@ fn collectCIncludes(self: *const DocumentStore, handle: Handle) error{OutOfMemor
 /// collects every file uri the given handle depends on
 /// includes imports, cimports & packages
 pub fn collectDependencies(
-    allocator: std.mem.Allocator,
     store: *const DocumentStore,
+    allocator: std.mem.Allocator,
     handle: Handle,
     dependencies: *std.ArrayListUnmanaged(Uri),
 ) error{OutOfMemory}!void {
@@ -879,7 +879,7 @@ fn tagStoreCompletionItems(self: DocumentStore, arena: std.mem.Allocator, handle
 
     var dependencies = std.ArrayListUnmanaged(Uri){};
     try dependencies.append(self.allocator, handle.uri);
-    try collectDependencies(self.allocator, &self, handle, &dependencies);
+    try self.collectDependencies(self.allocator, handle, &dependencies);
 
     // TODO Better solution for deciding what tags to include
     var result_set = analysis.CompletionSet{};

--- a/src/DocumentStore.zig
+++ b/src/DocumentStore.zig
@@ -553,9 +553,7 @@ fn createBuildFile(self: *const DocumentStore, uri: Uri) error{OutOfMemory}!Buil
 
         if (config.relative_builtin_path) |relative_builtin_path| blk: {
             const build_file_path = URI.parse(self.allocator, build_file.uri) catch break :blk;
-            const directory_path = std.fs.path.resolve(self.allocator, &.{ build_file_path, "../build.zig" }) catch break :blk;
-            defer self.allocator.free(directory_path);
-            var absolute_builtin_path = try std.mem.concat(self.allocator, u8, &.{ directory_path, relative_builtin_path });
+            const absolute_builtin_path = std.fs.path.resolve(self.allocator, &.{ build_file_path, "../", relative_builtin_path }) catch break :blk;
             defer self.allocator.free(absolute_builtin_path);
             build_file.builtin_uri = try URI.fromPath(self.allocator, absolute_builtin_path);
         }

--- a/src/DocumentStore.zig
+++ b/src/DocumentStore.zig
@@ -100,7 +100,7 @@ pub fn deinit(self: *DocumentStore) void {
 }
 
 /// returns a handle to the given document
-pub fn getHandle(self: *DocumentStore, uri: Uri) ?*Handle {
+pub fn getHandle(self: *const DocumentStore, uri: Uri) ?*Handle {
     const handle = self.handles.getPtr(uri) orelse {
         log.warn("Trying to open non existent document {s}", .{uri});
         return null;

--- a/src/DocumentStore.zig
+++ b/src/DocumentStore.zig
@@ -682,13 +682,13 @@ fn createDocumentFromURI(self: *DocumentStore, uri: Uri, open: bool) error{OutOf
     const tracy_zone = tracy.trace(@src());
     defer tracy_zone.end();
 
-    const file_path = URI.parse(self.allocator, uri) catch unreachable;
+    const file_path = URI.parse(self.allocator, uri) catch return null;
     defer self.allocator.free(file_path);
 
-    var file = std.fs.openFileAbsolute(file_path, .{}) catch unreachable;
+    var file = std.fs.openFileAbsolute(file_path, .{}) catch return null;
     defer file.close();
 
-    const file_contents = file.readToEndAllocOptions(self.allocator, std.math.maxInt(usize), null, @alignOf(u8), 0) catch unreachable;
+    const file_contents = file.readToEndAllocOptions(self.allocator, std.math.maxInt(usize), null, @alignOf(u8), 0) catch return null;
 
     return try self.createDocument(uri, file_contents, open);
 }

--- a/src/DocumentStore.zig
+++ b/src/DocumentStore.zig
@@ -654,7 +654,7 @@ fn createDocument(self: *DocumentStore, uri: Uri, text: [:0]u8, open: bool) erro
         } else |err| {
             log.debug("Failed to load build file {s}: (error: {})", .{ uri, err });
         }
-    } else if (self.config.zig_exe_path != null and std.mem.endsWith(u8, uri, "/builtin.zig") and !in_std) blk: {
+    } else if (self.config.zig_exe_path != null and !std.mem.endsWith(u8, uri, "/builtin.zig") and !in_std) blk: {
         log.debug("Going to walk down the tree towards: {s}", .{uri});
         // walk down the tree towards the uri. When we hit build.zig files
         // determine if the uri we're interested in is involved with the build.

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -151,7 +151,7 @@ fn showMessage(server: *Server, writer: anytype, message_type: types.MessageType
     });
 }
 
-fn publishDiagnostics(server: *Server, writer: anytype, handle: *DocumentStore.Handle) !void {
+fn publishDiagnostics(server: *Server, writer: anytype, handle: DocumentStore.Handle) !void {
     const tracy_zone = tracy.trace(@src());
     defer tracy_zone.end();
 
@@ -252,17 +252,19 @@ fn publishDiagnostics(server: *Server, writer: anytype, handle: *DocumentStore.H
         }
     }
 
-    for (handle.cimports) |cimport| {
-        if (cimport.result != .failure) continue;
-        const stderr = std.mem.trim(u8, cimport.result.failure, " ");
+    for (handle.cimports.items(.hash)) |hash, i| {
+        const result = server.document_store.cimports.get(hash) orelse continue;
+        if (result != .failure) continue;
+        const stderr = std.mem.trim(u8, result.failure, " ");
 
         var pos_and_diag_iterator = std.mem.split(u8, stderr, ":");
         _ = pos_and_diag_iterator.next(); // skip file path
         _ = pos_and_diag_iterator.next(); // skip line
         _ = pos_and_diag_iterator.next(); // skip character
 
+        const node = handle.cimports.items(.node)[i];
         try diagnostics.append(allocator, .{
-            .range = offsets.nodeToRange(handle.tree, cimport.node, server.offset_encoding),
+            .range = offsets.nodeToRange(handle.tree, node, server.offset_encoding),
             .severity = .Error,
             .code = "cImport",
             .source = "zls",
@@ -283,7 +285,7 @@ fn publishDiagnostics(server: *Server, writer: anytype, handle: *DocumentStore.H
 
 fn getAstCheckDiagnostics(
     server: *Server,
-    handle: *DocumentStore.Handle,
+    handle: DocumentStore.Handle,
     diagnostics: *std.ArrayListUnmanaged(types.Diagnostic),
 ) !void {
     var allocator = server.arena.allocator();
@@ -966,10 +968,7 @@ fn gotoDefinitionString(
     defer tracy_zone.end();
 
     const import_str = analysis.getImportStr(handle.tree, 0, pos_index) orelse return null;
-    const uri = server.document_store.uriFromImportStr(server.arena.allocator(), handle.*, import_str) catch |err| switch (err) {
-        error.UriBadScheme => return null,
-        error.OutOfMemory => |e| return e,
-    };
+    const uri = try server.document_store.uriFromImportStr(server.arena.allocator(), handle.*, import_str);
 
     return types.Location{
         .uri = uri orelse return null,
@@ -1327,7 +1326,7 @@ fn completeError(server: *Server, handle: *DocumentStore.Handle) ![]types.Comple
     const tracy_zone = tracy.trace(@src());
     defer tracy_zone.end();
 
-    return try server.document_store.errorCompletionItems(&server.arena, handle);
+    return try server.document_store.errorCompletionItems(server.arena.allocator(), handle.*);
 }
 
 fn kindToSortScore(kind: types.CompletionItem.Kind) ?[]const u8 {
@@ -1362,12 +1361,12 @@ fn completeDot(server: *Server, handle: *DocumentStore.Handle) ![]types.Completi
     const tracy_zone = tracy.trace(@src());
     defer tracy_zone.end();
 
-    var completions = try server.document_store.enumCompletionItems(&server.arena, handle);
+    var completions = try server.document_store.enumCompletionItems(server.arena.allocator(), handle.*);
 
     return completions;
 }
 
-fn completeFileSystemStringLiteral(allocator: std.mem.Allocator, handle: *DocumentStore.Handle, completing: []const u8, is_import: bool) ![]types.CompletionItem {
+fn completeFileSystemStringLiteral(allocator: std.mem.Allocator, store: *const DocumentStore, handle: *DocumentStore.Handle, completing: []const u8, is_import: bool) ![]types.CompletionItem {
     var subpath_present = false;
     var completions = std.ArrayListUnmanaged(types.CompletionItem){};
 
@@ -1407,10 +1406,11 @@ fn completeFileSystemStringLiteral(allocator: std.mem.Allocator, handle: *Docume
     }
 
     if (!subpath_present and is_import) {
-        if (handle.associated_build_file) |bf| {
-            try completions.ensureUnusedCapacity(allocator, bf.config.packages.len);
+        if (handle.associated_build_file) |uri| {
+            const build_file = store.build_files.get(uri).?;
+            try completions.ensureUnusedCapacity(allocator, build_file.config.packages.len);
 
-            for (bf.config.packages) |pkg| {
+            for (build_file.config.packages) |pkg| {
                 completions.appendAssumeCapacity(.{
                     .label = pkg.name,
                     .kind = .Module,
@@ -1704,13 +1704,14 @@ fn changeDocumentHandler(server: *Server, writer: anytype, id: types.RequestId, 
 
     _ = id;
 
-    const handle = server.document_store.getHandle(req.params.textDocument.uri) orelse {
-        log.debug("Trying to change non existent document {s}", .{req.params.textDocument.uri});
-        return;
-    };
+    const handle = server.document_store.getHandle(req.params.textDocument.uri) orelse return;
 
-    try server.document_store.applyChanges(handle, req.params.contentChanges, server.offset_encoding);
-    try server.publishDiagnostics(writer, handle);
+    const new_text = try diff.applyTextEdits(server.allocator, handle.text, req.params.contentChanges, server.offset_encoding);
+    server.allocator.free(handle.text);
+    handle.text = new_text;
+
+    try server.document_store.refreshDocument(handle);
+    try server.publishDiagnostics(writer, handle.*);
 }
 
 fn saveDocumentHandler(server: *Server, writer: anytype, id: types.RequestId, req: requests.SaveDocument) !void {
@@ -1721,10 +1722,7 @@ fn saveDocumentHandler(server: *Server, writer: anytype, id: types.RequestId, re
     const allocator = server.arena.allocator();
     const uri = req.params.textDocument.uri;
 
-    const handle = server.document_store.getHandle(uri) orelse {
-        log.warn("Trying to save non existent document {s}", .{uri});
-        return;
-    };
+    const handle = server.document_store.getHandle(uri) orelse return;
     try server.document_store.applySave(handle);
 
     if (handle.tree.errors.len != 0) return;
@@ -1732,7 +1730,7 @@ fn saveDocumentHandler(server: *Server, writer: anytype, id: types.RequestId, re
     if (!server.config.enable_autofix) return;
 
     var diagnostics = std.ArrayListUnmanaged(types.Diagnostic){};
-    try getAstCheckDiagnostics(server, handle, &diagnostics);
+    try getAstCheckDiagnostics(server, handle.*, &diagnostics);
 
     var builder = code_actions.Builder{
         .arena = &server.arena,
@@ -1790,7 +1788,6 @@ fn semanticTokensFullHandler(server: *Server, writer: anytype, id: types.Request
     if (!server.config.enable_semantic_tokens) return try respondGeneric(writer, id, no_semantic_tokens_response);
 
     const handle = server.document_store.getHandle(req.params.textDocument.uri) orelse {
-        log.warn("Trying to get semantic tokens of non existent document {s}", .{req.params.textDocument.uri});
         return try respondGeneric(writer, id, no_semantic_tokens_response);
     };
 
@@ -1807,7 +1804,6 @@ fn completionHandler(server: *Server, writer: anytype, id: types.RequestId, req:
     defer tracy_zone.end();
 
     const handle = server.document_store.getHandle(req.params.textDocument.uri) orelse {
-        log.warn("Trying to complete in non existent document {s}", .{req.params.textDocument.uri});
         return try respondGeneric(writer, id, no_completions_response);
     };
 
@@ -1838,7 +1834,7 @@ fn completionHandler(server: *Server, writer: anytype, id: types.RequestId, req:
 
             const completing = offsets.locToSlice(handle.tree.source, loc);
             const is_import = pos_context == .import_string_literal;
-            break :blk try completeFileSystemStringLiteral(server.arena.allocator(), handle, completing, is_import);
+            break :blk try completeFileSystemStringLiteral(server.arena.allocator(), &server.document_store, handle, completing, is_import);
         },
         else => null,
     };
@@ -1878,7 +1874,6 @@ fn signatureHelpHandler(server: *Server, writer: anytype, id: types.RequestId, r
 
     const getSignatureInfo = @import("signature_help.zig").getSignatureInfo;
     const handle = server.document_store.getHandle(req.params.textDocument.uri) orelse {
-        log.warn("Trying to get signature help in non existent document {s}", .{req.params.textDocument.uri});
         return try respondGeneric(writer, id, no_signatures_response);
     };
 
@@ -1912,7 +1907,6 @@ fn gotoHandler(server: *Server, writer: anytype, id: types.RequestId, req: reque
     defer tracy_zone.end();
 
     const handle = server.document_store.getHandle(req.params.textDocument.uri) orelse {
-        log.warn("Trying to go to definition in non existent document {s}", .{req.params.textDocument.uri});
         return try respondGeneric(writer, id, null_result_response);
     };
 
@@ -1956,7 +1950,6 @@ fn hoverHandler(server: *Server, writer: anytype, id: types.RequestId, req: requ
     defer tracy_zone.end();
 
     const handle = server.document_store.getHandle(req.params.textDocument.uri) orelse {
-        log.warn("Trying to get hover in non existent document {s}", .{req.params.textDocument.uri});
         return try respondGeneric(writer, id, null_result_response);
     };
 
@@ -1986,7 +1979,6 @@ fn documentSymbolsHandler(server: *Server, writer: anytype, id: types.RequestId,
     defer tracy_zone.end();
 
     const handle = server.document_store.getHandle(req.params.textDocument.uri) orelse {
-        log.warn("Trying to get document symbols in non existent document {s}", .{req.params.textDocument.uri});
         return try respondGeneric(writer, id, null_result_response);
     };
     try server.documentSymbol(writer, id, handle);
@@ -1998,7 +1990,6 @@ fn formattingHandler(server: *Server, writer: anytype, id: types.RequestId, req:
 
     if (server.config.zig_exe_path) |zig_exe_path| {
         const handle = server.document_store.getHandle(req.params.textDocument.uri) orelse {
-            log.warn("Trying to got to definition in non existent document {s}", .{req.params.textDocument.uri});
             return try respondGeneric(writer, id, null_result_response);
         };
 
@@ -2124,14 +2115,6 @@ const GeneralReferencesRequest = union(enum) {
             .highlight => |highlight| highlight.params.position,
         };
     }
-
-    pub fn name(self: @This()) []const u8 {
-        return switch (self) {
-            .rename => "rename",
-            .references => "references",
-            .highlight => "highlight references",
-        };
-    }
 };
 
 fn generalReferencesHandler(server: *Server, writer: anytype, id: types.RequestId, req: GeneralReferencesRequest) !void {
@@ -2141,7 +2124,6 @@ fn generalReferencesHandler(server: *Server, writer: anytype, id: types.RequestI
     const allocator = server.arena.allocator();
 
     const handle = server.document_store.getHandle(req.uri()) orelse {
-        log.warn("Trying to get {s} in non existent document {s}", .{ req.name(), req.uri() });
         return try respondGeneric(writer, id, null_result_response);
     };
 
@@ -2223,7 +2205,6 @@ fn inlayHintHandler(server: *Server, writer: anytype, id: types.RequestId, req: 
     if (!server.config.enable_inlay_hints) return try respondGeneric(writer, id, null_result_response);
 
     const handle = server.document_store.getHandle(req.params.textDocument.uri) orelse {
-        log.warn("Trying to get inlay hint of non existent document {s}", .{req.params.textDocument.uri});
         return try respondGeneric(writer, id, null_result_response);
     };
 
@@ -2272,7 +2253,6 @@ fn inlayHintHandler(server: *Server, writer: anytype, id: types.RequestId, req: 
 
 fn codeActionHandler(server: *Server, writer: anytype, id: types.RequestId, req: requests.CodeAction) !void {
     const handle = server.document_store.getHandle(req.params.textDocument.uri) orelse {
-        log.warn("Trying to get code actions of non existent document {s}", .{req.params.textDocument.uri});
         return try respondGeneric(writer, id, null_result_response);
     };
 
@@ -2402,12 +2382,12 @@ pub fn processJsonRpc(server: *Server, writer: anytype, json: []const u8) !void 
         .shutdown => return try sendErrorResponse(writer, server.arena.allocator(), .InvalidRequest, "server received a request after shutdown!"),
     }
 
-    const start_time = std.time.milliTimestamp();
+    // const start_time = std.time.milliTimestamp();
     defer {
         // makes `zig build test` look nice
         if (!zig_builtin.is_test and !std.mem.eql(u8, method, "shutdown")) {
-            const end_time = std.time.milliTimestamp();
-            log.debug("Took {}ms to process method {s}", .{ end_time - start_time, method });
+            // const end_time = std.time.milliTimestamp();
+            // log.debug("Took {}ms to process method {s}", .{ end_time - start_time, method });
         }
     }
 
@@ -2535,7 +2515,10 @@ pub fn init(
 
     try config.configChanged(allocator, config_path);
 
-    var document_store = try DocumentStore.init(allocator, config);
+    var document_store = DocumentStore{
+        .allocator = allocator,
+        .config = config,
+    };
     errdefer document_store.deinit();
 
     var builtin_completions = try std.ArrayListUnmanaged(types.CompletionItem).initCapacity(allocator, data.builtins.len);

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -1756,10 +1756,8 @@ fn changeDocumentHandler(server: *Server, writer: anytype, id: types.RequestId, 
     const handle = server.document_store.getHandle(req.params.textDocument.uri) orelse return;
 
     const new_text = try diff.applyTextEdits(server.allocator, handle.text, req.params.contentChanges, server.offset_encoding);
-    server.allocator.free(handle.text);
-    handle.text = new_text;
 
-    try server.document_store.refreshDocument(handle);
+    try server.document_store.refreshDocument(handle.uri, new_text);
     try server.publishDiagnostics(writer, handle.*);
 }
 

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -379,7 +379,7 @@ fn typeToCompletion(
     server: *Server,
     list: *std.ArrayListUnmanaged(types.CompletionItem),
     field_access: analysis.FieldAccessReturn,
-    orig_handle: *DocumentStore.Handle,
+    orig_handle: *const DocumentStore.Handle,
 ) error{OutOfMemory}!void {
     var allocator = server.arena.allocator();
 
@@ -441,7 +441,7 @@ fn nodeToCompletion(
     list: *std.ArrayListUnmanaged(types.CompletionItem),
     node_handle: analysis.NodeWithHandle,
     unwrapped: ?analysis.TypeWithHandle,
-    orig_handle: *DocumentStore.Handle,
+    orig_handle: *const DocumentStore.Handle,
     is_type_val: bool,
     parent_is_type_val: ?bool,
 ) error{OutOfMemory}!void {
@@ -811,7 +811,7 @@ fn hoverSymbol(server: *Server, decl_handle: analysis.DeclWithHandle) error{OutO
     };
 }
 
-fn getLabelGlobal(pos_index: usize, handle: *DocumentStore.Handle) error{OutOfMemory}!?analysis.DeclWithHandle {
+fn getLabelGlobal(pos_index: usize, handle: *const DocumentStore.Handle) error{OutOfMemory}!?analysis.DeclWithHandle {
     const tracy_zone = tracy.trace(@src());
     defer tracy_zone.end();
 
@@ -824,7 +824,7 @@ fn getLabelGlobal(pos_index: usize, handle: *DocumentStore.Handle) error{OutOfMe
 fn getSymbolGlobal(
     server: *Server,
     pos_index: usize,
-    handle: *DocumentStore.Handle,
+    handle: *const DocumentStore.Handle,
 ) error{OutOfMemory}!?analysis.DeclWithHandle {
     const tracy_zone = tracy.trace(@src());
     defer tracy_zone.end();
@@ -838,7 +838,7 @@ fn getSymbolGlobal(
 fn gotoDefinitionLabel(
     server: *Server,
     pos_index: usize,
-    handle: *DocumentStore.Handle,
+    handle: *const DocumentStore.Handle,
 ) error{OutOfMemory}!?types.Location {
     const tracy_zone = tracy.trace(@src());
     defer tracy_zone.end();
@@ -850,7 +850,7 @@ fn gotoDefinitionLabel(
 fn gotoDefinitionGlobal(
     server: *Server,
     pos_index: usize,
-    handle: *DocumentStore.Handle,
+    handle: *const DocumentStore.Handle,
     resolve_alias: bool,
 ) error{OutOfMemory}!?types.Location {
     const tracy_zone = tracy.trace(@src());
@@ -860,7 +860,7 @@ fn gotoDefinitionGlobal(
     return try server.gotoDefinitionSymbol(decl, resolve_alias);
 }
 
-fn hoverDefinitionLabel(server: *Server, pos_index: usize, handle: *DocumentStore.Handle) error{OutOfMemory}!?types.Hover {
+fn hoverDefinitionLabel(server: *Server, pos_index: usize, handle: *const DocumentStore.Handle) error{OutOfMemory}!?types.Hover {
     const tracy_zone = tracy.trace(@src());
     defer tracy_zone.end();
 
@@ -868,7 +868,7 @@ fn hoverDefinitionLabel(server: *Server, pos_index: usize, handle: *DocumentStor
     return try server.hoverSymbol(decl);
 }
 
-fn hoverDefinitionBuiltin(server: *Server, pos_index: usize, handle: *DocumentStore.Handle) error{OutOfMemory}!?types.Hover {
+fn hoverDefinitionBuiltin(server: *Server, pos_index: usize, handle: *const DocumentStore.Handle) error{OutOfMemory}!?types.Hover {
     const tracy_zone = tracy.trace(@src());
     defer tracy_zone.end();
 
@@ -892,7 +892,7 @@ fn hoverDefinitionBuiltin(server: *Server, pos_index: usize, handle: *DocumentSt
     return null;
 }
 
-fn hoverDefinitionGlobal(server: *Server, pos_index: usize, handle: *DocumentStore.Handle) error{OutOfMemory}!?types.Hover {
+fn hoverDefinitionGlobal(server: *Server, pos_index: usize, handle: *const DocumentStore.Handle) error{OutOfMemory}!?types.Hover {
     const tracy_zone = tracy.trace(@src());
     defer tracy_zone.end();
 
@@ -902,7 +902,7 @@ fn hoverDefinitionGlobal(server: *Server, pos_index: usize, handle: *DocumentSto
 
 fn getSymbolFieldAccess(
     server: *Server,
-    handle: *DocumentStore.Handle,
+    handle: *const DocumentStore.Handle,
     source_index: usize,
     loc: offsets.Loc,
 ) !?analysis.DeclWithHandle {
@@ -934,7 +934,7 @@ fn getSymbolFieldAccess(
 
 fn gotoDefinitionFieldAccess(
     server: *Server,
-    handle: *DocumentStore.Handle,
+    handle: *const DocumentStore.Handle,
     source_index: usize,
     loc: offsets.Loc,
     resolve_alias: bool,
@@ -948,7 +948,7 @@ fn gotoDefinitionFieldAccess(
 
 fn hoverDefinitionFieldAccess(
     server: *Server,
-    handle: *DocumentStore.Handle,
+    handle: *const DocumentStore.Handle,
     source_index: usize,
     loc: offsets.Loc,
 ) error{OutOfMemory}!?types.Hover {
@@ -962,7 +962,7 @@ fn hoverDefinitionFieldAccess(
 fn gotoDefinitionString(
     server: *Server,
     pos_index: usize,
-    handle: *DocumentStore.Handle,
+    handle: *const DocumentStore.Handle,
 ) error{OutOfMemory}!?types.Location {
     const tracy_zone = tracy.trace(@src());
     defer tracy_zone.end();
@@ -982,7 +982,7 @@ fn gotoDefinitionString(
 const DeclToCompletionContext = struct {
     server: *Server,
     completions: *std.ArrayListUnmanaged(types.CompletionItem),
-    orig_handle: *DocumentStore.Handle,
+    orig_handle: *const DocumentStore.Handle,
     parent_is_type_val: ?bool = null,
 };
 
@@ -1071,7 +1071,7 @@ fn declToCompletion(context: DeclToCompletionContext, decl_handle: analysis.Decl
 fn completeLabel(
     server: *Server,
     pos_index: usize,
-    handle: *DocumentStore.Handle,
+    handle: *const DocumentStore.Handle,
 ) ![]types.CompletionItem {
     const tracy_zone = tracy.trace(@src());
     defer tracy_zone.end();
@@ -1112,7 +1112,7 @@ fn populateSnippedCompletions(
     }
 }
 
-fn completeGlobal(server: *Server, pos_index: usize, handle: *DocumentStore.Handle) ![]types.CompletionItem {
+fn completeGlobal(server: *Server, pos_index: usize, handle: *const DocumentStore.Handle) ![]types.CompletionItem {
     const tracy_zone = tracy.trace(@src());
     defer tracy_zone.end();
 
@@ -1135,7 +1135,7 @@ fn completeGlobal(server: *Server, pos_index: usize, handle: *DocumentStore.Hand
     return completions.toOwnedSlice(server.arena.allocator());
 }
 
-fn completeFieldAccess(server: *Server, handle: *DocumentStore.Handle, source_index: usize, loc: offsets.Loc) !?[]types.CompletionItem {
+fn completeFieldAccess(server: *Server, handle: *const DocumentStore.Handle, source_index: usize, loc: offsets.Loc) !?[]types.CompletionItem {
     const tracy_zone = tracy.trace(@src());
     defer tracy_zone.end();
 
@@ -1322,7 +1322,7 @@ fn formatDetailledLabel(item: *types.CompletionItem, alloc: std.mem.Allocator) !
     //     logger.info("labelDetails: {s}  ::  {s}", .{item.labelDetails.?.detail, item.labelDetails.?.description});
 }
 
-fn completeError(server: *Server, handle: *DocumentStore.Handle) ![]types.CompletionItem {
+fn completeError(server: *Server, handle: *const DocumentStore.Handle) ![]types.CompletionItem {
     const tracy_zone = tracy.trace(@src());
     defer tracy_zone.end();
 
@@ -1357,7 +1357,7 @@ fn kindToSortScore(kind: types.CompletionItem.Kind) ?[]const u8 {
     };
 }
 
-fn completeDot(server: *Server, handle: *DocumentStore.Handle) ![]types.CompletionItem {
+fn completeDot(server: *Server, handle: *const DocumentStore.Handle) ![]types.CompletionItem {
     const tracy_zone = tracy.trace(@src());
     defer tracy_zone.end();
 
@@ -1366,7 +1366,7 @@ fn completeDot(server: *Server, handle: *DocumentStore.Handle) ![]types.Completi
     return completions;
 }
 
-fn completeFileSystemStringLiteral(allocator: std.mem.Allocator, store: *const DocumentStore, handle: *DocumentStore.Handle, completing: []const u8, is_import: bool) ![]types.CompletionItem {
+fn completeFileSystemStringLiteral(allocator: std.mem.Allocator, store: *const DocumentStore, handle: *const DocumentStore.Handle, completing: []const u8, is_import: bool) ![]types.CompletionItem {
     var subpath_present = false;
     var completions = std.ArrayListUnmanaged(types.CompletionItem){};
 
@@ -1422,7 +1422,7 @@ fn completeFileSystemStringLiteral(allocator: std.mem.Allocator, store: *const D
     return completions.toOwnedSlice(allocator);
 }
 
-fn documentSymbol(server: *Server, writer: anytype, id: types.RequestId, handle: *DocumentStore.Handle) !void {
+fn documentSymbol(server: *Server, writer: anytype, id: types.RequestId, handle: *const DocumentStore.Handle) !void {
     const tracy_zone = tracy.trace(@src());
     defer tracy_zone.end();
 

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -2382,12 +2382,12 @@ pub fn processJsonRpc(server: *Server, writer: anytype, json: []const u8) !void 
         .shutdown => return try sendErrorResponse(writer, server.arena.allocator(), .InvalidRequest, "server received a request after shutdown!"),
     }
 
-    // const start_time = std.time.milliTimestamp();
+    const start_time = std.time.milliTimestamp();
     defer {
         // makes `zig build test` look nice
         if (!zig_builtin.is_test and !std.mem.eql(u8, method, "shutdown")) {
-            // const end_time = std.time.milliTimestamp();
-            // log.debug("Took {}ms to process method {s}", .{ end_time - start_time, method });
+            const end_time = std.time.milliTimestamp();
+            log.debug("Took {}ms to process method {s}", .{ end_time - start_time, method });
         }
     }
 

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -181,7 +181,7 @@ pub fn getFunctionSnippet(allocator: std.mem.Allocator, tree: Ast, func: Ast.ful
     return buffer.toOwnedSlice(allocator);
 }
 
-pub fn hasSelfParam(arena: *std.heap.ArenaAllocator, document_store: *const DocumentStore, handle: *const DocumentStore.Handle, func: Ast.full.FnProto) !bool {
+pub fn hasSelfParam(arena: *std.heap.ArenaAllocator, document_store: *DocumentStore, handle: *const DocumentStore.Handle, func: Ast.full.FnProto) !bool {
     // Non-decl prototypes cannot have a self parameter.
     if (func.name_token == null) return false;
     if (func.ast.params.len == 0) return false;
@@ -314,7 +314,7 @@ fn getDeclName(tree: Ast, node: Ast.Node.Index) ?[]const u8 {
     };
 }
 
-fn resolveVarDeclAliasInternal(store: *const DocumentStore, arena: *std.heap.ArenaAllocator, node_handle: NodeWithHandle, root: bool) error{OutOfMemory}!?DeclWithHandle {
+fn resolveVarDeclAliasInternal(store: *DocumentStore, arena: *std.heap.ArenaAllocator, node_handle: NodeWithHandle, root: bool) error{OutOfMemory}!?DeclWithHandle {
     _ = root;
     const handle = node_handle.handle;
     const tree = handle.tree;
@@ -367,7 +367,7 @@ fn resolveVarDeclAliasInternal(store: *const DocumentStore, arena: *std.heap.Are
 /// const decl = @import("decl-file.zig").decl;
 /// const other = decl.middle.other;
 ///```
-pub fn resolveVarDeclAlias(store: *const DocumentStore, arena: *std.heap.ArenaAllocator, decl_handle: NodeWithHandle) !?DeclWithHandle {
+pub fn resolveVarDeclAlias(store: *DocumentStore, arena: *std.heap.ArenaAllocator, decl_handle: NodeWithHandle) !?DeclWithHandle {
     const decl = decl_handle.node;
     const handle = decl_handle.handle;
     const tree = handle.tree;
@@ -431,7 +431,7 @@ fn findReturnStatement(tree: Ast, fn_decl: Ast.full.FnProto, body: Ast.Node.Inde
     return findReturnStatementInternal(tree, fn_decl, body, &already_found);
 }
 
-pub fn resolveReturnType(store: *const DocumentStore, arena: *std.heap.ArenaAllocator, fn_decl: Ast.full.FnProto, handle: *const DocumentStore.Handle, bound_type_params: *BoundTypeParams, fn_body: ?Ast.Node.Index) !?TypeWithHandle {
+pub fn resolveReturnType(store: *DocumentStore, arena: *std.heap.ArenaAllocator, fn_decl: Ast.full.FnProto, handle: *const DocumentStore.Handle, bound_type_params: *BoundTypeParams, fn_body: ?Ast.Node.Index) !?TypeWithHandle {
     const tree = handle.tree;
     if (isTypeFunction(tree, fn_decl) and fn_body != null) {
         // If this is a type function and it only contains a single return statement that returns
@@ -468,7 +468,7 @@ pub fn resolveReturnType(store: *const DocumentStore, arena: *std.heap.ArenaAllo
 }
 
 /// Resolves the child type of an optional type
-fn resolveUnwrapOptionalType(store: *const DocumentStore, arena: *std.heap.ArenaAllocator, opt: TypeWithHandle, bound_type_params: *BoundTypeParams) !?TypeWithHandle {
+fn resolveUnwrapOptionalType(store: *DocumentStore, arena: *std.heap.ArenaAllocator, opt: TypeWithHandle, bound_type_params: *BoundTypeParams) !?TypeWithHandle {
     const opt_node = switch (opt.type.data) {
         .other => |n| n,
         else => return null,
@@ -484,7 +484,7 @@ fn resolveUnwrapOptionalType(store: *const DocumentStore, arena: *std.heap.Arena
     return null;
 }
 
-fn resolveUnwrapErrorType(store: *const DocumentStore, arena: *std.heap.ArenaAllocator, rhs: TypeWithHandle, bound_type_params: *BoundTypeParams) !?TypeWithHandle {
+fn resolveUnwrapErrorType(store: *DocumentStore, arena: *std.heap.ArenaAllocator, rhs: TypeWithHandle, bound_type_params: *BoundTypeParams) !?TypeWithHandle {
     const rhs_node = switch (rhs.type.data) {
         .other => |n| n,
         .error_union => |n| return TypeWithHandle{
@@ -505,7 +505,7 @@ fn resolveUnwrapErrorType(store: *const DocumentStore, arena: *std.heap.ArenaAll
 }
 
 /// Resolves the child type of a deref type
-fn resolveDerefType(store: *const DocumentStore, arena: *std.heap.ArenaAllocator, deref: TypeWithHandle, bound_type_params: *BoundTypeParams) !?TypeWithHandle {
+fn resolveDerefType(store: *DocumentStore, arena: *std.heap.ArenaAllocator, deref: TypeWithHandle, bound_type_params: *BoundTypeParams) !?TypeWithHandle {
     const deref_node = switch (deref.type.data) {
         .other => |n| n,
         .pointer => |n| return TypeWithHandle{
@@ -538,7 +538,7 @@ fn resolveDerefType(store: *const DocumentStore, arena: *std.heap.ArenaAllocator
 }
 
 /// Resolves slicing and array access
-fn resolveBracketAccessType(store: *const DocumentStore, arena: *std.heap.ArenaAllocator, lhs: TypeWithHandle, rhs: enum { Single, Range }, bound_type_params: *BoundTypeParams) !?TypeWithHandle {
+fn resolveBracketAccessType(store: *DocumentStore, arena: *std.heap.ArenaAllocator, lhs: TypeWithHandle, rhs: enum { Single, Range }, bound_type_params: *BoundTypeParams) !?TypeWithHandle {
     const lhs_node = switch (lhs.type.data) {
         .other => |n| n,
         else => return null,
@@ -575,7 +575,7 @@ fn resolveBracketAccessType(store: *const DocumentStore, arena: *std.heap.ArenaA
 }
 
 /// Called to remove one level of pointerness before a field access
-pub fn resolveFieldAccessLhsType(store: *const DocumentStore, arena: *std.heap.ArenaAllocator, lhs: TypeWithHandle, bound_type_params: *BoundTypeParams) !TypeWithHandle {
+pub fn resolveFieldAccessLhsType(store: *DocumentStore, arena: *std.heap.ArenaAllocator, lhs: TypeWithHandle, bound_type_params: *BoundTypeParams) !TypeWithHandle {
     return (try resolveDerefType(store, arena, lhs, bound_type_params)) orelse lhs;
 }
 
@@ -614,7 +614,7 @@ pub fn isTypeIdent(text: []const u8) bool {
 }
 
 /// Resolves the type of a node
-pub fn resolveTypeOfNodeInternal(store: *const DocumentStore, arena: *std.heap.ArenaAllocator, node_handle: NodeWithHandle, bound_type_params: *BoundTypeParams) error{OutOfMemory}!?TypeWithHandle {
+pub fn resolveTypeOfNodeInternal(store: *DocumentStore, arena: *std.heap.ArenaAllocator, node_handle: NodeWithHandle, bound_type_params: *BoundTypeParams) error{OutOfMemory}!?TypeWithHandle {
     // If we were asked to resolve this node before,
     // it is self-referential and we cannot resolve it.
     for (resolve_trail.items) |i| {
@@ -1080,7 +1080,7 @@ pub const TypeWithHandle = struct {
     }
 };
 
-pub fn resolveTypeOfNode(store: *const DocumentStore, arena: *std.heap.ArenaAllocator, node_handle: NodeWithHandle) error{OutOfMemory}!?TypeWithHandle {
+pub fn resolveTypeOfNode(store: *DocumentStore, arena: *std.heap.ArenaAllocator, node_handle: NodeWithHandle) error{OutOfMemory}!?TypeWithHandle {
     var bound_type_params = BoundTypeParams{};
     return resolveTypeOfNodeInternal(store, arena, node_handle, &bound_type_params);
 }
@@ -1153,7 +1153,7 @@ pub const FieldAccessReturn = struct {
     unwrapped: ?TypeWithHandle = null,
 };
 
-pub fn getFieldAccessType(store: *const DocumentStore, arena: *std.heap.ArenaAllocator, handle: *const DocumentStore.Handle, source_index: usize, tokenizer: *std.zig.Tokenizer) !?FieldAccessReturn {
+pub fn getFieldAccessType(store: *DocumentStore, arena: *std.heap.ArenaAllocator, handle: *const DocumentStore.Handle, source_index: usize, tokenizer: *std.zig.Tokenizer) !?FieldAccessReturn {
     var current_type = TypeWithHandle.typeVal(.{
         .node = undefined,
         .handle = handle,
@@ -1887,7 +1887,7 @@ pub const DeclWithHandle = struct {
         };
     }
 
-    pub fn resolveType(self: DeclWithHandle, store: *const DocumentStore, arena: *std.heap.ArenaAllocator, bound_type_params: *BoundTypeParams) !?TypeWithHandle {
+    pub fn resolveType(self: DeclWithHandle, store: *DocumentStore, arena: *std.heap.ArenaAllocator, bound_type_params: *BoundTypeParams) !?TypeWithHandle {
         const tree = self.handle.tree;
         const node_tags = tree.nodes.items(.tag);
         const main_tokens = tree.nodes.items(.main_token);
@@ -1997,7 +1997,7 @@ fn findContainerScope(container_handle: NodeWithHandle) ?*Scope {
     } else null;
 }
 
-fn iterateSymbolsContainerInternal(store: *const DocumentStore, arena: *std.heap.ArenaAllocator, container_handle: NodeWithHandle, orig_handle: *const DocumentStore.Handle, comptime callback: anytype, context: anytype, instance_access: bool, use_trail: *std.ArrayList(Ast.Node.Index)) error{OutOfMemory}!void {
+fn iterateSymbolsContainerInternal(store: *DocumentStore, arena: *std.heap.ArenaAllocator, container_handle: NodeWithHandle, orig_handle: *const DocumentStore.Handle, comptime callback: anytype, context: anytype, instance_access: bool, use_trail: *std.ArrayList(Ast.Node.Index)) error{OutOfMemory}!void {
     const container = container_handle.node;
     const handle = container_handle.handle;
 
@@ -2064,7 +2064,7 @@ fn iterateSymbolsContainerInternal(store: *const DocumentStore, arena: *std.heap
     }
 }
 
-pub fn iterateSymbolsContainer(store: *const DocumentStore, arena: *std.heap.ArenaAllocator, container_handle: NodeWithHandle, orig_handle: *const DocumentStore.Handle, comptime callback: anytype, context: anytype, instance_access: bool) error{OutOfMemory}!void {
+pub fn iterateSymbolsContainer(store: *DocumentStore, arena: *std.heap.ArenaAllocator, container_handle: NodeWithHandle, orig_handle: *const DocumentStore.Handle, comptime callback: anytype, context: anytype, instance_access: bool) error{OutOfMemory}!void {
     var use_trail = std.ArrayList(Ast.Node.Index).init(arena.allocator());
     return try iterateSymbolsContainerInternal(store, arena, container_handle, orig_handle, callback, context, instance_access, &use_trail);
 }
@@ -2085,7 +2085,7 @@ pub fn iterateLabels(handle: *const DocumentStore.Handle, source_index: usize, c
     }
 }
 
-fn iterateSymbolsGlobalInternal(store: *const DocumentStore, arena: *std.heap.ArenaAllocator, handle: *const DocumentStore.Handle, source_index: usize, comptime callback: anytype, context: anytype, use_trail: *std.ArrayList(Ast.Node.Index)) error{OutOfMemory}!void {
+fn iterateSymbolsGlobalInternal(store: *DocumentStore, arena: *std.heap.ArenaAllocator, handle: *const DocumentStore.Handle, source_index: usize, comptime callback: anytype, context: anytype, use_trail: *std.ArrayList(Ast.Node.Index)) error{OutOfMemory}!void {
     for (handle.document_scope.scopes.items) |scope| {
         if (source_index >= scope.loc.start and source_index <= scope.loc.end) {
             var decl_it = scope.decls.iterator();
@@ -2126,7 +2126,7 @@ fn iterateSymbolsGlobalInternal(store: *const DocumentStore, arena: *std.heap.Ar
     }
 }
 
-pub fn iterateSymbolsGlobal(store: *const DocumentStore, arena: *std.heap.ArenaAllocator, handle: *const DocumentStore.Handle, source_index: usize, comptime callback: anytype, context: anytype) error{OutOfMemory}!void {
+pub fn iterateSymbolsGlobal(store: *DocumentStore, arena: *std.heap.ArenaAllocator, handle: *const DocumentStore.Handle, source_index: usize, comptime callback: anytype, context: anytype) error{OutOfMemory}!void {
     var use_trail = std.ArrayList(Ast.Node.Index).init(arena.allocator());
     return try iterateSymbolsGlobalInternal(store, arena, handle, source_index, callback, context, &use_trail);
 }
@@ -2167,7 +2167,7 @@ pub fn innermostContainer(handle: *const DocumentStore.Handle, source_index: usi
     return TypeWithHandle.typeVal(.{ .node = current, .handle = handle });
 }
 
-fn resolveUse(store: *const DocumentStore, arena: *std.heap.ArenaAllocator, uses: []const Ast.Node.Index, symbol: []const u8, handle: *const DocumentStore.Handle) error{OutOfMemory}!?DeclWithHandle {
+fn resolveUse(store: *DocumentStore, arena: *std.heap.ArenaAllocator, uses: []const Ast.Node.Index, symbol: []const u8, handle: *const DocumentStore.Handle) error{OutOfMemory}!?DeclWithHandle {
     // If we were asked to resolve this symbol before,
     // it is self-referential and we cannot resolve it.
     if (std.mem.indexOfScalar([*]const u8, using_trail.items, symbol.ptr) != null)
@@ -2218,7 +2218,7 @@ pub fn lookupLabel(handle: *const DocumentStore.Handle, symbol: []const u8, sour
     return null;
 }
 
-pub fn lookupSymbolGlobal(store: *const DocumentStore, arena: *std.heap.ArenaAllocator, handle: *const DocumentStore.Handle, symbol: []const u8, source_index: usize) error{OutOfMemory}!?DeclWithHandle {
+pub fn lookupSymbolGlobal(store: *DocumentStore, arena: *std.heap.ArenaAllocator, handle: *const DocumentStore.Handle, symbol: []const u8, source_index: usize) error{OutOfMemory}!?DeclWithHandle {
     const innermost_scope_idx = innermostBlockScopeIndex(handle.*, source_index);
 
     var curr = innermost_scope_idx;
@@ -2246,7 +2246,7 @@ pub fn lookupSymbolGlobal(store: *const DocumentStore, arena: *std.heap.ArenaAll
 }
 
 pub fn lookupSymbolContainer(
-    store: *const DocumentStore,
+    store: *DocumentStore,
     arena: *std.heap.ArenaAllocator,
     container_handle: NodeWithHandle,
     symbol: []const u8,

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -914,14 +914,14 @@ pub fn resolveTypeOfNodeInternal(store: *DocumentStore, arena: *std.heap.ArenaAl
                 const import_str = tree.tokenSlice(main_tokens[import_param]);
                 const import_uri = (try store.uriFromImportStr(arena.allocator(), handle.*, import_str[1 .. import_str.len - 1])) orelse return null;
 
-                const new_handle = store.getHandle(import_uri) orelse return null;
+                const new_handle = store.getOrLoadHandle(import_uri) orelse return null;
 
                 // reference to node '0' which is root
                 return TypeWithHandle.typeVal(.{ .node = 0, .handle = new_handle });
             } else if (std.mem.eql(u8, call_name, "@cImport")) {
                 const cimport_uri = (try store.resolveCImport(handle.*, node)) orelse return null;
 
-                const new_handle = store.getHandle(cimport_uri) orelse return null;
+                const new_handle = store.getOrLoadHandle(cimport_uri) orelse return null;
 
                 // reference to node '0' which is root
                 return TypeWithHandle.typeVal(.{ .node = 0, .handle = new_handle });

--- a/src/code_actions.zig
+++ b/src/code_actions.zig
@@ -11,8 +11,8 @@ const offsets = @import("offsets.zig");
 
 pub const Builder = struct {
     arena: *std.heap.ArenaAllocator,
-    document_store: *DocumentStore,
-    handle: *DocumentStore.Handle,
+    document_store: *const DocumentStore,
+    handle: *const DocumentStore.Handle,
     offset_encoding: offsets.Encoding,
 
     pub fn generateCodeAction(

--- a/src/code_actions.zig
+++ b/src/code_actions.zig
@@ -11,7 +11,7 @@ const offsets = @import("offsets.zig");
 
 pub const Builder = struct {
     arena: *std.heap.ArenaAllocator,
-    document_store: *const DocumentStore,
+    document_store: *DocumentStore,
     handle: *const DocumentStore.Handle,
     offset_encoding: offsets.Encoding,
 

--- a/src/diff.zig
+++ b/src/diff.zig
@@ -1,5 +1,7 @@
 const std = @import("std");
 const types = @import("types.zig");
+const requests = @import("requests.zig");
+const offsets = @import("offsets.zig");
 
 pub const Error = error{ OutOfMemory, InvalidRange };
 
@@ -349,4 +351,38 @@ fn char_pos_to_range(
         .start = result_start_pos.?,
         .end = result_end_pos.?,
     };
+}
+
+// Caller owns returned memory.
+pub fn applyTextEdits(
+    allocator: std.mem.Allocator,
+    text: []const u8,
+    content_changes: []const requests.TextDocumentContentChangeEvent,
+    encoding: offsets.Encoding,
+) ![:0]const u8 {
+    var last_full_text_change: ?usize = null;
+    var i: usize = content_changes.len;
+    while (i > 0) {
+        i -= 1;
+        if (content_changes[i].range == null) {
+            last_full_text_change = i;
+        }
+    }
+
+    var text_array = std.ArrayListUnmanaged(u8){};
+    errdefer text_array.deinit(allocator);
+
+    try text_array.appendSlice(allocator, if (last_full_text_change) |index| content_changes[index].text else text);
+
+    // don't even bother applying changes before a full text change
+    const changes = content_changes[if (last_full_text_change) |index| index + 1 else 0..];
+
+    for (changes) |item| {
+        const range = item.range.?; // every element is guaranteed to have `range` set
+
+        const loc = offsets.rangeToLoc(text_array.items, range, encoding);
+        try text_array.replaceRange(allocator, loc.start, loc.end - loc.start, item.text);
+    }
+
+    return try text_array.toOwnedSliceSentinel(allocator, 0);
 }

--- a/src/inlay_hints.zig
+++ b/src/inlay_hints.zig
@@ -81,7 +81,7 @@ const Builder = struct {
 /// `call` is the function call
 /// `decl_handle` should be a function protototype
 /// writes parameter hints into `builder.hints`
-fn writeCallHint(builder: *Builder, arena: *std.heap.ArenaAllocator, store: *const DocumentStore, call: Ast.full.Call, decl_handle: analysis.DeclWithHandle) !void {
+fn writeCallHint(builder: *Builder, arena: *std.heap.ArenaAllocator, store: *DocumentStore, call: Ast.full.Call, decl_handle: analysis.DeclWithHandle) !void {
     const handle = builder.handle;
     const tree = handle.tree;
 
@@ -181,7 +181,7 @@ fn writeBuiltinHint(builder: *Builder, parameters: []const Ast.Node.Index, argum
 }
 
 /// takes a Ast.full.Call (a function call), analysis its function expression, finds its declaration and writes parameter hints into `builder.hints`
-fn writeCallNodeHint(builder: *Builder, arena: *std.heap.ArenaAllocator, store: *const DocumentStore, call: Ast.full.Call) !void {
+fn writeCallNodeHint(builder: *Builder, arena: *std.heap.ArenaAllocator, store: *DocumentStore, call: Ast.full.Call) !void {
     if (call.ast.params.len == 0) return;
     if (builder.config.inlay_hints_exclude_single_argument and call.ast.params.len == 1) return;
 
@@ -257,7 +257,7 @@ fn callWriteNodeInlayHint(allocator: std.mem.Allocator, args: anytype) error{Out
 
 /// iterates over the ast and writes parameter hints into `builder.hints` for every function call and builtin call
 /// nodes outside the given range are excluded
-fn writeNodeInlayHint(builder: *Builder, arena: *std.heap.ArenaAllocator, store: *const DocumentStore, maybe_node: ?Ast.Node.Index, range: types.Range) error{OutOfMemory}!void {
+fn writeNodeInlayHint(builder: *Builder, arena: *std.heap.ArenaAllocator, store: *DocumentStore, maybe_node: ?Ast.Node.Index, range: types.Range) error{OutOfMemory}!void {
     const node = maybe_node orelse return;
 
     const handle = builder.handle;
@@ -690,7 +690,7 @@ fn writeNodeInlayHint(builder: *Builder, arena: *std.heap.ArenaAllocator, store:
 pub fn writeRangeInlayHint(
     arena: *std.heap.ArenaAllocator,
     config: Config,
-    store: *const DocumentStore,
+    store: *DocumentStore,
     handle: *const DocumentStore.Handle,
     range: types.Range,
     hover_kind: types.MarkupContent.Kind,

--- a/src/inlay_hints.zig
+++ b/src/inlay_hints.zig
@@ -34,7 +34,7 @@ fn isNodeInRange(tree: Ast, node: Ast.Node.Index, range: types.Range) bool {
 const Builder = struct {
     allocator: std.mem.Allocator,
     config: *const Config,
-    handle: *DocumentStore.Handle,
+    handle: *const DocumentStore.Handle,
     hints: std.ArrayListUnmanaged(types.InlayHint),
     hover_kind: types.MarkupContent.Kind,
     encoding: offsets.Encoding,
@@ -81,7 +81,7 @@ const Builder = struct {
 /// `call` is the function call
 /// `decl_handle` should be a function protototype
 /// writes parameter hints into `builder.hints`
-fn writeCallHint(builder: *Builder, arena: *std.heap.ArenaAllocator, store: *DocumentStore, call: Ast.full.Call, decl_handle: analysis.DeclWithHandle) !void {
+fn writeCallHint(builder: *Builder, arena: *std.heap.ArenaAllocator, store: *const DocumentStore, call: Ast.full.Call, decl_handle: analysis.DeclWithHandle) !void {
     const handle = builder.handle;
     const tree = handle.tree;
 
@@ -181,7 +181,7 @@ fn writeBuiltinHint(builder: *Builder, parameters: []const Ast.Node.Index, argum
 }
 
 /// takes a Ast.full.Call (a function call), analysis its function expression, finds its declaration and writes parameter hints into `builder.hints`
-fn writeCallNodeHint(builder: *Builder, arena: *std.heap.ArenaAllocator, store: *DocumentStore, call: Ast.full.Call) !void {
+fn writeCallNodeHint(builder: *Builder, arena: *std.heap.ArenaAllocator, store: *const DocumentStore, call: Ast.full.Call) !void {
     if (call.ast.params.len == 0) return;
     if (builder.config.inlay_hints_exclude_single_argument and call.ast.params.len == 1) return;
 
@@ -257,7 +257,7 @@ fn callWriteNodeInlayHint(allocator: std.mem.Allocator, args: anytype) error{Out
 
 /// iterates over the ast and writes parameter hints into `builder.hints` for every function call and builtin call
 /// nodes outside the given range are excluded
-fn writeNodeInlayHint(builder: *Builder, arena: *std.heap.ArenaAllocator, store: *DocumentStore, maybe_node: ?Ast.Node.Index, range: types.Range) error{OutOfMemory}!void {
+fn writeNodeInlayHint(builder: *Builder, arena: *std.heap.ArenaAllocator, store: *const DocumentStore, maybe_node: ?Ast.Node.Index, range: types.Range) error{OutOfMemory}!void {
     const node = maybe_node orelse return;
 
     const handle = builder.handle;
@@ -688,8 +688,8 @@ fn writeNodeInlayHint(builder: *Builder, arena: *std.heap.ArenaAllocator, store:
 pub fn writeRangeInlayHint(
     arena: *std.heap.ArenaAllocator,
     config: Config,
-    store: *DocumentStore,
-    handle: *DocumentStore.Handle,
+    store: *const DocumentStore,
+    handle: *const DocumentStore.Handle,
     range: types.Range,
     hover_kind: types.MarkupContent.Kind,
     encoding: offsets.Encoding,

--- a/src/references.zig
+++ b/src/references.zig
@@ -56,11 +56,11 @@ pub fn labelReferences(
 const Builder = struct {
     arena: *std.heap.ArenaAllocator,
     locations: std.ArrayListUnmanaged(types.Location),
-    store: *DocumentStore,
+    store: *const DocumentStore,
     decl: analysis.DeclWithHandle,
     encoding: offsets.Encoding,
 
-    pub fn init(arena: *std.heap.ArenaAllocator, store: *DocumentStore, decl: analysis.DeclWithHandle, encoding: offsets.Encoding) Builder {
+    pub fn init(arena: *std.heap.ArenaAllocator, store: *const DocumentStore, decl: analysis.DeclWithHandle, encoding: offsets.Encoding) Builder {
         return Builder{
             .arena = arena,
             .locations = .{},
@@ -70,7 +70,7 @@ const Builder = struct {
         };
     }
 
-    pub fn add(self: *Builder, handle: *DocumentStore.Handle, token_index: Ast.TokenIndex) !void {
+    pub fn add(self: *Builder, handle: *const DocumentStore.Handle, token_index: Ast.TokenIndex) !void {
         try self.locations.append(self.arena.allocator(), .{
             .uri = handle.uri,
             .range = offsets.tokenToRange(handle.tree, token_index, self.encoding),
@@ -81,7 +81,7 @@ const Builder = struct {
 fn symbolReferencesInternal(
     builder: *Builder,
     node: Ast.Node.Index,
-    handle: *DocumentStore.Handle,
+    handle: *const DocumentStore.Handle,
 ) error{OutOfMemory}!void {
     const tree = handle.tree;
 
@@ -453,7 +453,7 @@ fn symbolReferencesInternal(
 
 pub fn symbolReferences(
     arena: *std.heap.ArenaAllocator,
-    store: *DocumentStore,
+    store: *const DocumentStore,
     decl_handle: analysis.DeclWithHandle,
     encoding: offsets.Encoding,
     include_decl: bool,

--- a/src/references.zig
+++ b/src/references.zig
@@ -485,7 +485,7 @@ pub fn symbolReferences(
 
             var imports = std.ArrayListUnmanaged(*const DocumentStore.Handle){};
 
-            for (store.handles.values()) |*handle| {
+            for (store.handles.values()) |handle| {
                 if (skip_std_references and std.mem.indexOf(u8, handle.uri, "std") != null) {
                     if (!include_decl or !std.mem.eql(u8, handle.uri, curr_handle.uri))
                         continue;

--- a/src/references.zig
+++ b/src/references.zig
@@ -56,11 +56,11 @@ pub fn labelReferences(
 const Builder = struct {
     arena: *std.heap.ArenaAllocator,
     locations: std.ArrayListUnmanaged(types.Location),
-    store: *const DocumentStore,
+    store: *DocumentStore,
     decl: analysis.DeclWithHandle,
     encoding: offsets.Encoding,
 
-    pub fn init(arena: *std.heap.ArenaAllocator, store: *const DocumentStore, decl: analysis.DeclWithHandle, encoding: offsets.Encoding) Builder {
+    pub fn init(arena: *std.heap.ArenaAllocator, store: *DocumentStore, decl: analysis.DeclWithHandle, encoding: offsets.Encoding) Builder {
         return Builder{
             .arena = arena,
             .locations = .{},
@@ -457,7 +457,7 @@ fn symbolReferencesInternal(
 
 pub fn symbolReferences(
     arena: *std.heap.ArenaAllocator,
-    store: *const DocumentStore,
+    store: *DocumentStore,
     decl_handle: analysis.DeclWithHandle,
     encoding: offsets.Encoding,
     include_decl: bool,

--- a/src/semantic_tokens.zig
+++ b/src/semantic_tokens.zig
@@ -52,14 +52,14 @@ pub const TokenModifiers = packed struct {
 
 const Builder = struct {
     arena: *std.heap.ArenaAllocator,
-    store: *const DocumentStore,
+    store: *DocumentStore,
     handle: *const DocumentStore.Handle,
     previous_position: usize = 0,
     previous_token: ?Ast.TokenIndex = null,
     arr: std.ArrayListUnmanaged(u32),
     encoding: offsets.Encoding,
 
-    fn init(arena: *std.heap.ArenaAllocator, store: *const DocumentStore, handle: *const DocumentStore.Handle, encoding: offsets.Encoding) Builder {
+    fn init(arena: *std.heap.ArenaAllocator, store: *DocumentStore, handle: *const DocumentStore.Handle, encoding: offsets.Encoding) Builder {
         return Builder{
             .arena = arena,
             .store = store,
@@ -1025,7 +1025,7 @@ fn writeContainerField(builder: *Builder, node: Ast.Node.Index, field_token_type
 // TODO Range version, edit version.
 pub fn writeAllSemanticTokens(
     arena: *std.heap.ArenaAllocator,
-    store: *const DocumentStore,
+    store: *DocumentStore,
     handle: *const DocumentStore.Handle,
     encoding: offsets.Encoding,
 ) ![]u32 {

--- a/src/semantic_tokens.zig
+++ b/src/semantic_tokens.zig
@@ -52,14 +52,14 @@ pub const TokenModifiers = packed struct {
 
 const Builder = struct {
     arena: *std.heap.ArenaAllocator,
-    store: *DocumentStore,
-    handle: *DocumentStore.Handle,
+    store: *const DocumentStore,
+    handle: *const DocumentStore.Handle,
     previous_position: usize = 0,
     previous_token: ?Ast.TokenIndex = null,
     arr: std.ArrayListUnmanaged(u32),
     encoding: offsets.Encoding,
 
-    fn init(arena: *std.heap.ArenaAllocator, store: *DocumentStore, handle: *DocumentStore.Handle, encoding: offsets.Encoding) Builder {
+    fn init(arena: *std.heap.ArenaAllocator, store: *const DocumentStore, handle: *const DocumentStore.Handle, encoding: offsets.Encoding) Builder {
         return Builder{
             .arena = arena,
             .store = store,
@@ -223,7 +223,7 @@ fn writeDocComments(builder: *Builder, tree: Ast, doc: Ast.TokenIndex) !void {
     }
 }
 
-fn fieldTokenType(container_decl: Ast.Node.Index, handle: *DocumentStore.Handle) ?TokenType {
+fn fieldTokenType(container_decl: Ast.Node.Index, handle: *const DocumentStore.Handle) ?TokenType {
     const main_token = handle.tree.nodes.items(.main_token)[container_decl];
     if (main_token > handle.tree.tokens.len) return null;
     return @as(?TokenType, switch (handle.tree.tokens.items(.tag)[main_token]) {
@@ -1018,7 +1018,12 @@ fn writeContainerField(builder: *Builder, node: Ast.Node.Index, field_token_type
 }
 
 // TODO Range version, edit version.
-pub fn writeAllSemanticTokens(arena: *std.heap.ArenaAllocator, store: *DocumentStore, handle: *DocumentStore.Handle, encoding: offsets.Encoding) ![]u32 {
+pub fn writeAllSemanticTokens(
+    arena: *std.heap.ArenaAllocator,
+    store: *const DocumentStore,
+    handle: *const DocumentStore.Handle,
+    encoding: offsets.Encoding,
+) ![]u32 {
     var builder = Builder.init(arena, store, handle, encoding);
 
     // reverse the ast from the root declarations

--- a/src/signature_help.zig
+++ b/src/signature_help.zig
@@ -8,7 +8,7 @@ const Token = std.zig.Token;
 const identifierFromPosition = @import("Server.zig").identifierFromPosition;
 const ast = @import("ast.zig");
 
-fn fnProtoToSignatureInfo(document_store: *const DocumentStore, arena: *std.heap.ArenaAllocator, commas: u32, skip_self_param: bool, handle: *const DocumentStore.Handle, fn_node: Ast.Node.Index, proto: Ast.full.FnProto) !types.SignatureInformation {
+fn fnProtoToSignatureInfo(document_store: *DocumentStore, arena: *std.heap.ArenaAllocator, commas: u32, skip_self_param: bool, handle: *const DocumentStore.Handle, fn_node: Ast.Node.Index, proto: Ast.full.FnProto) !types.SignatureInformation {
     const ParameterInformation = types.SignatureInformation.ParameterInformation;
 
     const tree = handle.tree;
@@ -67,7 +67,7 @@ fn fnProtoToSignatureInfo(document_store: *const DocumentStore, arena: *std.heap
     };
 }
 
-pub fn getSignatureInfo(document_store: *const DocumentStore, arena: *std.heap.ArenaAllocator, handle: *const DocumentStore.Handle, absolute_index: usize, comptime data: type) !?types.SignatureInformation {
+pub fn getSignatureInfo(document_store: *DocumentStore, arena: *std.heap.ArenaAllocator, handle: *const DocumentStore.Handle, absolute_index: usize, comptime data: type) !?types.SignatureInformation {
     const innermost_block = analysis.innermostBlockScope(handle.*, absolute_index);
     const tree = handle.tree;
     const token_tags = tree.tokens.items(.tag);

--- a/src/signature_help.zig
+++ b/src/signature_help.zig
@@ -8,7 +8,7 @@ const Token = std.zig.Token;
 const identifierFromPosition = @import("Server.zig").identifierFromPosition;
 const ast = @import("ast.zig");
 
-fn fnProtoToSignatureInfo(document_store: *DocumentStore, arena: *std.heap.ArenaAllocator, commas: u32, skip_self_param: bool, handle: *DocumentStore.Handle, fn_node: Ast.Node.Index, proto: Ast.full.FnProto) !types.SignatureInformation {
+fn fnProtoToSignatureInfo(document_store: *const DocumentStore, arena: *std.heap.ArenaAllocator, commas: u32, skip_self_param: bool, handle: *const DocumentStore.Handle, fn_node: Ast.Node.Index, proto: Ast.full.FnProto) !types.SignatureInformation {
     const ParameterInformation = types.SignatureInformation.ParameterInformation;
 
     const tree = handle.tree;
@@ -67,7 +67,7 @@ fn fnProtoToSignatureInfo(document_store: *DocumentStore, arena: *std.heap.Arena
     };
 }
 
-pub fn getSignatureInfo(document_store: *DocumentStore, arena: *std.heap.ArenaAllocator, handle: *DocumentStore.Handle, absolute_index: usize, comptime data: type) !?types.SignatureInformation {
+pub fn getSignatureInfo(document_store: *const DocumentStore, arena: *std.heap.ArenaAllocator, handle: *const DocumentStore.Handle, absolute_index: usize, comptime data: type) !?types.SignatureInformation {
     const innermost_block = analysis.innermostBlockScope(handle.*, absolute_index);
     const tree = handle.tree;
     const token_tags = tree.tokens.items(.tag);


### PR DESCRIPTION
Previously DocumentStore used a reference counting like approach for cleaning up unused document. This approach is unfitting because of cyclic dependencies.
As an example if `A.zig` imports `B.zig` and `B.zig` imports `A.zig` they will never be closed.
This new approach should collect all unneeded documents for cleanup.

CImports also received some care and are now managed globally instead of per document.
