### PR TITLE
Separate argument placeholder completions from `enable_snippets` to `enable_argument_placeholders` option [fixes #685]

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ The following options are currently available.
 | Option | Type | Default value | What it Does |
 | --- | --- | --- | --- |
 | `enable_snippets` | `bool` | `false` | Enables snippet completions when the client also supports them. |
+| `enable_argument_placeholders` | `bool` | `false` | Enabes argument placeholder completions, e.g. `@intCast` completes to `@intCast(comptime DestType: type, int: anytype)` instead of `@intCast()`. |
 | `enable_ast_check_diagnostics` | `bool` | `true`| Whether to enable ast-check diagnostics |
 | `enable_autofix` | `bool` | `false`| Whether to automatically fix errors on save. Currently supports adding and removing discards. |
 | `enable_import_embedfile_argument_completions` | `bool` | `false` | Whether to enable import/embedFile argument completions |

--- a/schema.json
+++ b/schema.json
@@ -9,6 +9,9 @@
             "type": "boolean",
             "default": "false"
         },
+        "enable_argument_placeholders": {
+            "description": "Enabes argument placeholder completions, e.g. `@intCast` completes to `@intCast(comptime DestType: type, int: anytype)` instead of `@intCast()`"
+        },
         "enable_ast_check_diagnostics": {
             "description": "Whether to enable ast-check diagnostics",
             "type": "boolean",

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -13,6 +13,9 @@ const logger = std.log.scoped(.config);
 /// Whether to enable snippet completions
 enable_snippets: bool = false,
 
+/// Whether to enable argument placeholder completions
+enable_argument_placeholders: bool = false,
+
 /// Whether to enable ast-check diagnostics
 enable_ast_check_diagnostics: bool = true,
 

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -503,7 +503,8 @@ fn nodeToCompletion(
             const func = ast.fnProto(tree, node, &buf).?;
             if (func.name_token) |name_token| {
                 const use_snippets = server.config.enable_snippets and server.client_capabilities.supports_snippets;
-                const insert_text = if (use_snippets) blk: {
+                const use_placeholders = server.config.enable_argument_placeholders and server.client_capabilities.supports_snippets;
+                const insert_text = if (use_placeholders) blk: {
                     const skip_self_param = !(parent_is_type_val orelse true) and
                         try analysis.hasSelfParam(&server.arena, &server.document_store, handle, func);
                     break :blk try analysis.getFunctionSnippet(server.arena.allocator(), tree, func, skip_self_param);
@@ -2542,7 +2543,7 @@ pub fn init(
     errdefer builtin_completions.deinit();
 
     for (data.builtins) |builtin| {
-        const insert_text = if (config.enable_snippets) builtin.snippet else builtin.name;
+        const insert_text = if (config.enable_argument_placeholders) builtin.snippet else builtin.name;
         builtin_completions.appendAssumeCapacity(.{
             .label = builtin.name,
             .kind = .Function,

--- a/src/setup.zig
+++ b/src/setup.zig
@@ -170,6 +170,7 @@ pub fn wizard(allocator: std.mem.Allocator) !void {
 
     const editor = try askSelectOne("Which code editor do you use?", enum { VSCode, Sublime, Kate, Neovim, Vim8, Emacs, Doom, Spacemacs, Helix, Other });
     const snippets = try askBool("Do you want to enable snippets?");
+    const placeholders = try askBool("Do you want to enable argument placeholders?");
     const ast_check = try askBool("Do you want to enable ast-check diagnostics?");
     const autofix = try askBool("Do you want to zls to automatically try to fix errors on save? (supports adding & removing discards)");
     const ief_apc = try askBool("Do you want to enable @import/@embedFile argument path completion?");
@@ -193,6 +194,7 @@ pub fn wizard(allocator: std.mem.Allocator) !void {
         .@"$schema" = "https://raw.githubusercontent.com/zigtools/zls/master/schema.json",
         .zig_exe_path = zig_exe_path,
         .enable_snippets = snippets,
+        .enable_argument_placeholders = placeholders,
         .enable_ast_check_diagnostics = ast_check,
         .enable_autofix = autofix,
         .enable_import_embedfile_argument_completions = ief_apc,


### PR DESCRIPTION
Separate argument placeholder completions from enable_snippets to enable_argument_placeholders option [fixes #685

_Edit: I have removed my comments about completing `func` to `func()` as it is is out of scope, and would require more nuance._