### PR TITLE
Label details should not be enabled if client doesn't support it

### DIFF
--- a/src/requests.zig
+++ b/src/requests.zig
@@ -162,7 +162,7 @@ pub const Initialize = struct {
             completion: ?struct {
                 completionItem: ?struct {
                     snippetSupport: Default(bool, false),
-                    labelDetailsSupport: Default(bool, true),
+                    labelDetailsSupport: Default(bool, false),
                     documentationFormat: MaybeStringArray,
                 },
             },


### PR DESCRIPTION
Fixes #608