### PR TITLE
Add CI workflow to check build_runner works with a range of zig versions

### DIFF
--- a/.github/workflows/build_runner.yml
+++ b/.github/workflows/build_runner.yml
@@ -1,0 +1,41 @@
+name: BuildRunner
+
+on:
+  push:
+    paths:
+      - "src/special/build_runner.zig"
+  pull_request:
+    paths:
+      - "src/special/build_runner.zig"
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  check_build_runner:
+    strategy:
+      matrix:
+        zig_version: [0.9.1, 0.10.0, master]
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          submodules: true
+
+      - name: Grab zig
+        uses: goto-bus-stop/setup-zig@v1
+        with:
+          version: ${{ matrix.zig_version }}
+
+      - name: Create temp zig project
+        run: |
+          mkdir $RUNNER_TEMP/TEMP_ZIG_PROJECT
+          cd $RUNNER_TEMP/TEMP_ZIG_PROJECT
+          zig init-exe
+
+      - name: Check build_runner builds
+        run: zig build-exe $GITHUB_WORKSPACE/src/special/build_runner.zig --pkg-begin @build@ $RUNNER_TEMP/TEMP_ZIG_PROJECT/build.zig --pkg-end


### PR DESCRIPTION
This workflow is only run if `build_runner.zig` is modified, should it also have a schedule to catch changes in master?

Currently the versions checked are: 
- 0.9.1 (as the 0.10.0 [release notes](https://ziglang.org/download/0.10.0/release-notes.html#Is-it-time-to-upgrade) have a section about waiting for 0.10.1, I think we should still check 0.9.1)
- 0.10.0
- master