### PR TITLE
Only run CI workflow if a zig file changed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,13 @@ name: CI
 
 on:
   push:
+    paths:
+      - "**.zig"
   pull_request:
+    paths:
+      - "**.zig"
   schedule:
-    - cron: '0 0 * * *'
+    - cron: "0 0 * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
There is no reason to run the CI workflow if the only file changed is README.md