### PR TITLE
Nix: Pass `-Dcpu=baseline` to `zig build`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,6 @@
-{ pkgs ? import <nixpkgs> {},
-  system ? builtins.currentSystem }:
+{ pkgs ? import <nixpkgs> { }
+, system ? builtins.currentSystem
+}:
 
 let
   zig-overlay = pkgs.fetchFromGitHub {
@@ -26,7 +27,7 @@ pkgs.stdenvNoCC.mkDerivation {
   dontInstall = true;
   buildPhase = ''
     mkdir -p $out
-    zig build install -Drelease-safe=true -Ddata_version=master --prefix $out
+    zig build install -Dcpu=baseline -Drelease-safe=true -Ddata_version=master --prefix $out
   '';
   XDG_CACHE_HOME = ".cache";
 }

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
         "type": "github"
       },
       "original": {
@@ -68,11 +68,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1665695307,
-        "narHash": "sha256-Nt0ZBvRjQaZFVcYH5kwnCO6EUnSbL5zTf12NIIfHDeA=",
+        "lastModified": 1667292599,
+        "narHash": "sha256-7ISOUI1aj6UKMPIL+wwthENL22L3+A9V+jS8Is3QsRo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e858db900443414fd8dd2f78c3ecb47df3febc44",
+        "rev": "ef2f213d9659a274985778bff4ca322f3ef3ac68",
         "type": "github"
       },
       "original": {
@@ -99,11 +99,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1665663057,
-        "narHash": "sha256-k42CNjlArnr64st2EBlDiZzo0jBzCs6eta7zeb2KH6w=",
+        "lastModified": 1667477360,
+        "narHash": "sha256-EE1UMXQr4FkQFGoOHDslqi3Q7V2BUkLMrOBeV/UJYoE=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "049f82ae9bc43f9ced8e3aa52f936b186c09c85f",
+        "rev": "c8900204fcd5c09ab0c9b7bb7f4d04dacab3c462",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -13,16 +13,18 @@
     known-folders.url = "github:ziglibs/known-folders";
     known-folders.flake = false;
   };
-  
-  outputs = {self, nixpkgs, zig-overlay, gitignore, flake-utils, known-folders }:
+
+  outputs = { self, nixpkgs, zig-overlay, gitignore, flake-utils, known-folders }:
     let
       systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
       inherit (gitignore.lib) gitignoreSource;
-    in flake-utils.lib.eachSystem systems (system:
+    in
+    flake-utils.lib.eachSystem systems (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
         zig = zig-overlay.packages.${system}.master;
-      in rec {
+      in
+      rec {
         packages.default = packages.zls;
         packages.zls = pkgs.stdenvNoCC.mkDerivation {
           name = "zls";
@@ -33,10 +35,10 @@
           dontInstall = true;
           buildPhase = ''
             mkdir -p $out
-            zig build install -Drelease-safe=true -Ddata_version=master -Dknown-folders=${known-folders}/known-folders.zig --prefix $out
+            zig build install -Dcpu=baseline -Drelease-safe=true -Ddata_version=master -Dknown-folders=${known-folders}/known-folders.zig --prefix $out
           '';
           XDG_CACHE_HOME = ".cache";
         };
       }
-  );
+    );
 }


### PR DESCRIPTION
Closes #738 and depends on #737 for successful compilation.

Also, formatted some code with `nixpkgs-fmt`.