### PR TITLE
Update the main CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: true
@@ -38,7 +38,7 @@ jobs:
       - name: Build artifacts
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
-          declare -a targets=("x86_64-windows" "x86_64-linux" "x86_64-macos" "i386-windows" "i386-linux" "aarch64-macos")
+          declare -a targets=("x86_64-windows" "x86_64-linux" "x86_64-macos" "x86-windows" "x86-linux" "aarch64-macos")
           mkdir -p "artifacts/"
 
           for target in "${targets[@]}"; do


### PR DESCRIPTION
targets i386-* -> x86-*
use actions/checkout@v3 (v2 uses Node.js 12 which is about to be deprecated)