### PR TITLE
Improve Zig version mismatch error

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -1634,10 +1634,8 @@ fn initializeHandler(server: *Server, writer: anytype, id: types.RequestId, req:
     const zig_exe_version = std.SemanticVersion.parse(env.version) catch return;
 
     if (zig_builtin.zig_version.order(zig_exe_version) == .gt) {
-        try server.showMessage(writer, .Warning,
-            \\ZLS has been build with a newer version than you are using!
-            \\This may cause unexpected issues.
-        );
+        const version_mismatch_message = try std.fmt.allocPrint(server.arena.allocator(), "ZLS was built with Zig {}, but your Zig version is {s}. Update Zig to avoid unexpected behavior.", .{ zig_builtin.zig_version, env.version });
+        try server.showMessage(writer, .Warning, version_mismatch_message);
     }
 }
 


### PR DESCRIPTION
Improves the server message we send if the system Zig version is older than the Zig version that ZLS was built with:

- Correct typo (“build with” → “built with”).
- Show versions so users know which one they need to update beyond.
- Suggest step needed to fix the error (“Update Zig…”).

Example of messages in VS Code:

| Before | After |
| - | - |
| <img width="537" alt="Screenshot 2022-11-08 at 18 18 49" src="https://user-images.githubusercontent.com/647669/200632822-1ac17133-8db8-4397-b927-e1e362a53140.png"> | <img width="477" alt="Screenshot 2022-11-08 at 18 10 59" src="https://user-images.githubusercontent.com/647669/200632875-6fb26423-4309-4150-a9b5-9dcc96606c7d.png"> |
