### PR TITLE
panic when setting configuration

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -2644,6 +2644,7 @@ pub fn processJsonRpc(server: *Server, writer: anytype, json: []const u8) !void 
         // Yes, String ids are officially supported by LSP
         // but not sure how standard this "standard" really is
 
+        if (tree.root.Object.get("error")) |_| return;
         const result = tree.root.Object.get("result").?.Array;
 
         inline for (std.meta.fields(Config)) |field, index| {
@@ -2661,8 +2662,7 @@ pub fn processJsonRpc(server: *Server, writer: anytype, json: []const u8) !void 
                             if (s.len == 0) {
                                 if (field.field_type == ?[]const u8) {
                                     break :blk null;
-                                }
-                                else {
+                                } else {
                                     break :blk s;
                                 }
                             }


### PR DESCRIPTION
### Zig Version

0.10.0

### Zig Language Server Version

0.10.0-dev.364+88d1693

### Steps to Reproduce

Using Emacs' eglot client to connect to zls, I started getting `zls` panics after each start in every file nowadays.

This was after upgrading Emacs+eglot, but I still need to check what has changed there.  In any case, `zls` should surely not panic like that..  Attached is eglot's log for one whole initialization run and the final panic.

[zls-after-eglot-update.txt](https://github.com/zigtools/zls/files/9995169/zls-after-eglot-update.txt)


### Expected Behavior

`zls` starts and is configured as before my Emacs/eglot update.

### Actual Behavior

`zls` panics (and is restarted several times by the LSP client, repeating the cycle..)