### PR TITLE
Detect comment position context

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -1469,6 +1469,9 @@ pub fn getPositionContext(allocator: std.mem.Allocator, text: []const u8, doc_in
     const line_loc = offsets.lineLocUntilIndex(text, doc_index);
     const line = offsets.locToSlice(text, line_loc);
 
+    const is_comment = std.mem.startsWith(u8, std.mem.trimLeft(u8, line, " \t"), "//");
+    if (is_comment) return .comment;
+
     var stack = try std.ArrayListUnmanaged(StackState).initCapacity(allocator, 8);
     defer stack.deinit(allocator);
 

--- a/tests/utility/position_context.zig
+++ b/tests/utility/position_context.zig
@@ -103,19 +103,18 @@ test "position context - builtin" {
 }
 
 test "position context - comment" {
-    // TODO fix failing test!
-    // try testContext(
-    //     \\// i am<cursor> a test
-    // ,
-    //     .comment,
-    //     "// i am",
-    // );
-    // try testContext(
-    //     \\/// i am<cursor> a test
-    // ,
-    //     .comment,
-    //     "/// i am",
-    // );
+    try testContext(
+        \\// i am<cursor> a test
+    ,
+        .comment,
+        null, // report "// i am a test"
+    );
+    try testContext(
+        \\/// i am<cursor> a test
+    ,
+        .comment,
+        null, // report /// i am a test
+    );
 }
 
 test "position context - import/embedfile string literal" {


### PR DESCRIPTION
there will be no more completions provided when inside comments.
NOTE: your editor may still provide text based completions

this should fix #753