### PR TITLE
use textDocument/willSaveWaitUntil for autofix

### DIFF
--- a/src/requests.zig
+++ b/src/requests.zig
@@ -154,6 +154,11 @@ pub const Initialize = struct {
             workspaceFolders: Default(bool, false),
         },
         textDocument: ?struct {
+            synchronization: ?struct {
+                willSave: Default(bool, false),
+                willSaveWaitUntil: Default(bool, false),
+                didSave: Default(bool, false),
+            },
             semanticTokens: Exists,
             inlayHint: Exists,
             hover: ?struct {
@@ -230,6 +235,19 @@ const TextDocumentIdentifierPositionRequest = struct {
     },
 };
 
+pub const SaveReason = enum(u32) {
+    Manual = 1,
+    AfterDelay = 2,
+    FocusOut = 3,
+};
+
+pub const WillSave = struct {
+    params: struct {
+        textDocument: TextDocumentIdentifier,
+        reason: SaveReason,
+    },
+};
+
 pub const SignatureHelp = struct {
     params: struct {
         textDocument: TextDocumentIdentifier,
@@ -291,6 +309,6 @@ pub const CodeAction = struct {
 
 pub const FoldingRange = struct {
     params: struct {
-        textDocument: TextDocumentIdentifier,  
+        textDocument: TextDocumentIdentifier,
     },
 };

--- a/src/types.zig
+++ b/src/types.zig
@@ -441,6 +441,8 @@ const InitializeResult = struct {
         textDocumentSync: struct {
             openClose: bool,
             change: TextDocumentSyncKind,
+            willSave: bool,
+            willSaveWaitUntil: bool,
             save: bool,
         },
         renameProvider: bool,


### PR DESCRIPTION
I've tested this on VSCode and Helix.
Helix doesn't seem to work because it does not support `willSaveWaitUntil`.
@nullptrdevs thank you for suggesting this. I didn't even knew this request existed.
fixes #779