### PR TITLE
pass correct zig-cache path

### DIFF
--- a/src/DocumentStore.zig
+++ b/src/DocumentStore.zig
@@ -387,7 +387,7 @@ fn loadBuildConfiguration(
     const directory_path = try std.fs.path.resolve(arena_allocator, &.{ build_file_path, "../" });
 
     // TODO extract this option from `BuildAssociatedConfig.BuildOption`
-    const zig_cache_root: []const u8 = "zig-cache";
+    const zig_cache_root: []const u8 = try std.fs.path.join(arena_allocator, &.{ directory_path, "zig-cache" });
     // Since we don't compile anything and no packages should put their
     // files there this path can be ignored
     const zig_global_cache_root: []const u8 = "ZLS_DONT_CARE";


### PR DESCRIPTION
I'm not sure why this change is required now but without it zig tries to use a cache path of `/zig-cache`

In [`std.build`](https://github.com/ziglang/zig/blob/52e1be9c68aba87c1c530461c794b9c87c8a2016/lib/std/build.zig#L181)  a build root of `/path/to/my/project` with a cache_root of `zig-cache` resolves to `../../../../zig-cache` which results in zig using a cache path of `/zig-cache`.

Then if the users build.zig has an `OptionsStep` we try to [generate](https://github.com/zigtools/zls/blob/56a65f42bf950f4ad47a7c365ec445a57f6ca0ba/src/special/build_runner.zig#L128) the options file inside the `/zig-cache` directory which will probably not exist resulting in:
```
$ zig run /home/lee/.cache/zls/build_runner.zig --cache-dir /home/lee/.cache/zls --pkg-begin @build@ /home/lee/src/ztos/build.zig --pkg-end -- /home/lee/bin/zig /home/lee/src/ztos zig-cache ZLS_DONT_CARE
error: AccessDenied
/home/lee/zig/0.11.0-dev.324+f61c5f3f5/files/lib/std/os.zig:2803:19: 0x327d7b in mkdiratZ (build_runner)
        .ACCES => return error.AccessDenied,
                  ^
/home/lee/zig/0.11.0-dev.324+f61c5f3f5/files/lib/std/os.zig:2767:9: 0x30aa5f in mkdirat (build_runner)
        return mkdiratZ(dir_fd, &sub_dir_path_c, mode);
        ^
/home/lee/zig/0.11.0-dev.324+f61c5f3f5/files/lib/std/fs.zig:1426:9: 0x30a93b in makeDir (build_runner)
        try os.mkdirat(self.fd, sub_path, default_new_dir_mode);
        ^
/home/lee/zig/0.11.0-dev.324+f61c5f3f5/files/lib/std/fs.zig:1460:25: 0x30ab57 in makePath (build_runner)
                else => return err,
                        ^
/home/lee/zig/0.11.0-dev.324+f61c5f3f5/files/lib/std/build/OptionsStep.zig:239:5: 0x305829 in make (build_runner)
    try fs.cwd().makePath(options_directory);
    ^
/home/lee/zig/0.11.0-dev.324+f61c5f3f5/files/lib/std/build.zig:3660:9: 0x285ba7 in make (build_runner)
        try self.makeFn(self);
        ^
/home/lee/.cache/zls/build_runner.zig:128:13: 0x274de8 in reifyOptions (build_runner)
            try option.step.make();
            ^
/home/lee/.cache/zls/build_runner.zig:133:9: 0x274e6e in reifyOptions (build_runner)
        try reifyOptions(unknown_step);
        ^
/home/lee/.cache/zls/build_runner.zig:133:9: 0x274e6e in reifyOptions (build_runner)
        try reifyOptions(unknown_step);
        ^
/home/lee/.cache/zls/build_runner.zig:98:13: 0x273b1c in main (build_runner)
            try reifyOptions(step);
            ^
```