### PR TITLE
Fix rogue resize, bump minimum version

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -6,7 +6,7 @@ const zls_version = std.builtin.Version{ .major = 0, .minor = 11, .patch = 0 };
 
 pub fn build(b: *std.build.Builder) !void {
     const current_zig = builtin.zig_version;
-    const min_zig = std.SemanticVersion.parse("0.11.0-dev.323+30eb2a175") catch return; // added tuple declaration support
+    const min_zig = std.SemanticVersion.parse("0.11.0-dev.399+44ee1c885") catch return; // whereabouts allocgate 2.0
     if (current_zig.order(min_zig).compare(.lt)) @panic(b.fmt("Your Zig version v{} does not meet the minimum build requirement of v{}", .{ current_zig, min_zig }));
 
     const target = b.standardTargetOptions(.{});

--- a/src/uri.zig
+++ b/src/uri.zig
@@ -101,7 +101,7 @@ pub fn parse(allocator: std.mem.Allocator, str: []const u8) ![]u8 {
     if (str.len < 7 or !std.mem.eql(u8, "file://", str[0..7])) return error.UriBadScheme;
 
     var uri = try allocator.alloc(u8, str.len - (if (std.fs.path.sep == '\\') 8 else 7));
-    errdefer allocator.free(uri);
+    defer allocator.free(uri);
 
     const path = if (std.fs.path.sep == '\\') str[8..] else str[7..];
 
@@ -125,7 +125,5 @@ pub fn parse(allocator: std.mem.Allocator, str: []const u8) ![]u8 {
         i -= 1;
     }
 
-    _ = allocator.resize(uri, i);
-
-    return uri;
+    return try allocator.dupe(u8, uri[0..i]);
 }

--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -269,7 +269,7 @@ test "completion - union" {
 }
 
 test "completion - enum" {
-    // TODO: Fix this test
+    // TODO: Fix
     return error.SkipZigTest;
     // try testCompletion(
     //     \\const E = enum {

--- a/tests/lsp_features/semantic_tokens.zig
+++ b/tests/lsp_features/semantic_tokens.zig
@@ -13,14 +13,11 @@ test "semantic tokens - empty" {
 }
 
 test "semantic tokens" {
-    // TODO: Fix this test
-    return error.SkipZigTest;
-
-    // try testSemanticTokens(
-    //     \\const std = @import("std");
-    // ,
-    //     &.{ 0, 0, 5, 7, 0, 0, 6, 3, 0, 33, 0, 4, 1, 11, 0, 0, 2, 7, 12, 0, 0, 8, 5, 9, 0 },
-    // );
+    try testSemanticTokens(
+        \\const std = @import("std");
+    ,
+        &.{ 0, 0, 5, 7, 0, 0, 6, 3, 0, 33, 0, 4, 1, 11, 0, 0, 2, 7, 12, 0, 0, 8, 5, 9, 0 },
+    );
 
     // TODO more tests
 }


### PR DESCRIPTION
Closes #804
Closes #803

This was a `shrink` before `resize` yet there seem to be behavior differences, thus the double allocation sadly :(