### PR TITLE
update flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -68,11 +68,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1667292599,
-        "narHash": "sha256-7ISOUI1aj6UKMPIL+wwthENL22L3+A9V+jS8Is3QsRo=",
+        "lastModified": 1670086663,
+        "narHash": "sha256-hT8C8AQB74tdoCPwz4nlJypLMD7GI2F5q+vn+VE/qQk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ef2f213d9659a274985778bff4ca322f3ef3ac68",
+        "rev": "813836d64fa57285d108f0dbf2356457ccd304e3",
         "type": "github"
       },
       "original": {
@@ -99,11 +99,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667477360,
-        "narHash": "sha256-EE1UMXQr4FkQFGoOHDslqi3Q7V2BUkLMrOBeV/UJYoE=",
+        "lastModified": 1670113356,
+        "narHash": "sha256-43aMRMU0OuBin6M2LM+nxVG+whazyHuHnUvu92xoth0=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "c8900204fcd5c09ab0c9b7bb7f4d04dacab3c462",
+        "rev": "17352071583eda4be43fa2a312f6e061326374f7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Current one is too old:

[matklad@Ishmael:~/p/tb/zls]$ zig build
thread 5181 panic: Your Zig version v0.11.0-dev.38+b40fc7018 does not meet the minimum build requirement of v0.11.0-dev.323+30eb2a175