### PR TITLE
improve behavior if zig_exe_path is not set

### DIFF
--- a/src/DocumentStore.zig
+++ b/src/DocumentStore.zig
@@ -854,10 +854,7 @@ pub fn resolveCImport(self: *DocumentStore, handle: Handle, node: Ast.Node.Index
 /// caller owns the returned memory
 pub fn uriFromImportStr(self: *const DocumentStore, allocator: std.mem.Allocator, handle: Handle, import_str: []const u8) error{OutOfMemory}!?Uri {
     if (std.mem.eql(u8, import_str, "std")) {
-        const zig_lib_path = self.config.zig_lib_path orelse {
-            log.debug("Cannot resolve std library import, path is null.", .{});
-            return null;
-        };
+        const zig_lib_path = self.config.zig_lib_path orelse return null;
 
         const std_path = std.fs.path.resolve(allocator, &[_][]const u8{ zig_lib_path, "./std/std.zig" }) catch |err| switch (err) {
             error.OutOfMemory => return error.OutOfMemory,

--- a/src/translate_c.zig
+++ b/src/translate_c.zig
@@ -162,11 +162,11 @@ pub fn translate(allocator: std.mem.Allocator, config: Config, include_dirs: []c
     };
 
     const base_args = &[_][]const u8{
-        config.zig_exe_path.?,
+        config.zig_exe_path orelse return null,
         "translate-c",
         "--enable-cache",
         "--zig-lib-dir",
-        config.zig_lib_path.?,
+        config.zig_lib_path orelse return null,
         "--cache-dir",
         config.global_cache_path.?,
         "-lc",


### PR DESCRIPTION
zls will now not crash if `zig_exe_path` is not set and will show a popup message to the user (if supported).
 fixes #820