### PR TITLE
analysis.zig getPositionContext() - check for null

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -1612,6 +1612,7 @@ pub fn getPositionContext(allocator: std.mem.Allocator, text: []const u8, doc_in
                     .field_access => {},
                     .other => {},
                     .global_error_set => {},
+                    .label => {},
                     else => curr_ctx.ctx = .{
                         .field_access = tokenLocAppend(curr_ctx.ctx.loc().?, tok),
                     },


### PR DESCRIPTION
closes #754

this pr just adds `.label => {}` to the switch as suggested by
@nullptrdevs, thereby preventing the null unwrap.  i checked that zls no
longer crashes when positioning the cursor on Server.zig:2287:41 which
is this line:
```zig
break :blk .{ .WorkspaceEdit = edits };
//                         ^ cursor here previously crashed zls
```