### PR TITLE
track builtin API changes from zig/master

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -6,7 +6,7 @@ const zls_version = std.builtin.Version{ .major = 0, .minor = 11, .patch = 0 };
 
 pub fn build(b: *std.build.Builder) !void {
     const current_zig = builtin.zig_version;
-    const min_zig = std.SemanticVersion.parse("0.11.0-dev.780+6378644d4") catch return; // Changes to @call
+    const min_zig = std.SemanticVersion.parse("0.11.0-dev.874+40ed6ae84") catch return; // Changes to builtin.Type API
     if (current_zig.order(min_zig).compare(.lt)) @panic(b.fmt("Your Zig version v{} does not meet the minimum build requirement of v{}", .{ current_zig, min_zig }));
 
     const target = b.standardTargetOptions(.{});

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -2752,18 +2752,18 @@ pub fn processJsonRpc(server: *Server, writer: anytype, json: []const u8) !void 
 
         inline for (std.meta.fields(Config)) |field, index| {
             const value = result.items[index];
-            const ft = if (@typeInfo(field.field_type) == .Optional)
-                @typeInfo(field.field_type).Optional.child
+            const ft = if (@typeInfo(field.type) == .Optional)
+                @typeInfo(field.type).Optional.child
             else
-                field.field_type;
+                field.type;
             const ti = @typeInfo(ft);
 
             if (value != .Null) {
-                const new_value: field.field_type = switch (ft) {
+                const new_value: field.type = switch (ft) {
                     []const u8 => switch (value) {
                         .String => |s| blk: {
                             if (s.len == 0) {
-                                if (field.field_type == ?[]const u8) {
+                                if (field.type == ?[]const u8) {
                                     break :blk null;
                                 } else {
                                     break :blk s;

--- a/src/configuration.zig
+++ b/src/configuration.zig
@@ -198,9 +198,9 @@ fn getConfigurationType() type {
     var fields: [config_info.Struct.fields.len]std.builtin.Type.StructField = undefined;
     for (config_info.Struct.fields) |field, i| {
         fields[i] = field;
-        if (@typeInfo(field.field_type) != .Optional) {
-            fields[i].field_type = @Type(std.builtin.Type{
-                .Optional = .{ .child = field.field_type },
+        if (@typeInfo(field.type) != .Optional) {
+            fields[i].type = @Type(std.builtin.Type{
+                .Optional = .{ .child = field.type },
             });
         }
     }

--- a/src/requests.zig
+++ b/src/requests.zig
@@ -45,10 +45,10 @@ fn fromDynamicTreeInternal(arena: *std.heap.ArenaAllocator, value: std.json.Valu
 
         var err = false;
         inline for (std.meta.fields(T)) |field| {
-            const is_exists = field.field_type == Exists;
+            const is_exists = field.type == Exists;
 
-            const is_optional = comptime std.meta.trait.is(.Optional)(field.field_type);
-            const actual_type = if (is_optional) std.meta.Child(field.field_type) else field.field_type;
+            const is_optional = comptime std.meta.trait.is(.Optional)(field.type);
+            const actual_type = if (is_optional) std.meta.Child(field.type) else field.type;
 
             const is_struct = comptime std.meta.trait.is(.Struct)(actual_type);
             const is_default = comptime if (is_struct) std.meta.trait.hasDecls(actual_type, .{ "default", "value_type" }) else false;
@@ -107,9 +107,6 @@ fn fromDynamicTreeInternal(arena: *std.heap.ArenaAllocator, value: std.json.Valu
         out.* = value;
     } else if (comptime std.meta.trait.is(.Enum)(T)) {
         const info = @typeInfo(T).Enum;
-        if (info.layout != .Auto)
-            @compileError("Only auto layout enums are allowed");
-
         const TagType = info.tag_type;
         if (value != .Integer) return error.MalformedJson;
         out.* = std.meta.intToEnum(


### PR DESCRIPTION
**Context**
I was getting set up to use zls for the first time, building from zig master - I came across some compile errors. I tracked it down to a very recent API change in zig.

https://github.com/ziglang/zig/pull/13930

In this PR, std.builtin.Type.field_type is renamed to type And there is discussion that all Enum layouts are .Auto.