### PR TITLE
Fix Nix build, add Nix to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,9 +4,11 @@ on:
   push:
     paths:
       - "**.zig"
+      - "flake.*"
   pull_request:
     paths:
       - "**.zig"
+      - "flake.*"
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:
@@ -118,3 +120,18 @@ jobs:
           REMOTE_HOST: ${{ secrets.WEBSITE_DEPLOY_HOST }}
           REMOTE_USER: ${{ secrets.WEBSITE_DEPLOY_USER }}
           TARGET: ${{ secrets.WEBSITE_DEPLOY_FOLDER }}
+
+      - name: Install Nix
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        uses: cachix/install-nix-action@v18
+
+      - name: Install Cachix
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        uses: cachix/cachix-action@v12
+        with:
+          name: zigtools
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
+      - name: Build Nix flake package
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: nix build --print-build-logs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
 
           for target in "${targets[@]}"; do
             mkdir -p artifacts/$target
-            echo "Building target ${target}..."   
+            echo "Building target ${target}..."
             if [ "${GITHUB_REF##*/}" == "master" ]; then
               echo "Building safe"
               zig build -Dtarget=${target} -Drelease-safe --prefix artifacts/${target}/

--- a/flake.lock
+++ b/flake.lock
@@ -2,21 +2,6 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
-      "locked": {
         "lastModified": 1659877975,
         "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
@@ -110,7 +95,9 @@
     },
     "zig-overlay": {
       "inputs": {
-        "flake-utils": "flake-utils_2",
+        "flake-utils": [
+          "flake-utils"
+        ],
         "nixpkgs": [
           "nixpkgs"
         ]

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,7 @@
 
     zig-overlay.url = "github:mitchellh/zig-overlay";
     zig-overlay.inputs.nixpkgs.follows = "nixpkgs";
+    zig-overlay.inputs.flake-utils.follows = "flake-utils";
 
     gitignore.url = "github:hercules-ci/gitignore.nix";
     gitignore.inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
### Commit: `Nix: Fix build by updating the Zig version`
  Fix breakage introduced in https://github.com/zigtools/zls/commit/23ef018521714b988cfca6c34a4832358e3e1309.

### Commit: `CI/main: convert line endings from CRLF to LF`
Review this commit like so:
```bash
mkdir -p /tmp/diff
git show master:.github/workflows/main.yml | sed 's|\r$||' > /tmp/diff/master_converted_to_unix
git show --name-only b692e22813
git show b692e22813:.github/workflows/main.yml > /tmp/diff/from_this_pr
# This only shows some removed trailing whitespace
diff -u --color /tmp/diff/{master_converted_to_unix,from_this_pr}
rm -rf /tmp/diff
```

### Commit `CI: Add Nix build`

  This adds a CI Nix step to test that building the Nix package succeeds.
  Currently, this includes the use of [Cachix](https://www.cachix.org/), a Nix cache service that speeds up builds by caching build results.

  We can either:
  - Don't use Cachix (remove step `Install Cachix` in `workflows/main.yml`).
    This very slightly increases build time because the implicit Zig package build isn't cached.

  - Setup Cachix like so:
    1. Sign up and create a binary cache at https://www.cachix.org/
    2. Go to Cache -> Settings -> Auth Token and create a `Write` auth token
    3. ZLS Github repo settings -> Secrets -> Actions -> New repo secret:
       Name: `CACHIX_AUTH_TOKEN`
       Value: See step 2.
    3. Post the name of the binary cache, and I'll update ths PR.