### PR TITLE
semantic_tokens: Fix handleComments not evaluating the last byte

### DIFF
--- a/src/semantic_tokens.zig
+++ b/src/semantic_tokens.zig
@@ -141,16 +141,16 @@ const Builder = struct {
         const source = self.handle.tree.source;
 
         var i: usize = from;
-        while (i < to - 1) : (i += 1) {
+        while (i < to) : (i += 1) {
             // Skip multi-line string literals
             if (source[i] == '\\' and source[i + 1] == '\\') {
-                while (i < to - 1 and source[i] != '\n') : (i += 1) {}
+                while (i < to and source[i] != '\n') : (i += 1) {}
                 continue;
             }
             // Skip normal string literals
             if (source[i] == '"') {
                 i += 1;
-                while (i < to - 1 and
+                while (i < to and
                     source[i] != '\n' and
                     !(source[i] == '"' and source[i - 1] != '\\')) : (i += 1)
                 {}
@@ -159,7 +159,7 @@ const Builder = struct {
             // Skip char literals
             if (source[i] == '\'') {
                 i += 1;
-                while (i < to - 1 and
+                while (i < to and
                     source[i] != '\n' and
                     !(source[i] == '\'' and source[i - 1] != '\\')) : (i += 1)
                 {}
@@ -174,7 +174,7 @@ const Builder = struct {
             if (i + 2 < to and (source[i + 2] == '!' or source[i + 2] == '/'))
                 mods.documentation = true;
 
-            while (i < to - 1 and source[i] != '\n') : (i += 1) {}
+            while (i < to and source[i] != '\n') : (i += 1) {}
 
             const length = offsets.locLength(self.handle.tree.source, .{ .start = comment_start, .end = i }, self.encoding);
             try self.addDirect(TokenType.comment, mods, comment_start, length);

--- a/tests/lsp_features/semantic_tokens.zig
+++ b/tests/lsp_features/semantic_tokens.zig
@@ -22,6 +22,16 @@ test "semantic tokens" {
     // TODO more tests
 }
 
+test "semantic tokens - comments" {
+    try testSemanticTokens(
+        \\//!─
+    ,
+        &.{ 0, 0, 4, 8, 128 },
+    );
+
+    // TODO more tests
+}
+
 const file_uri = switch (builtin.os.tag) {
     .windows => "file:///C:/test.zig",
     else => "file:///test.zig",


### PR DESCRIPTION
Fixes #842

Does not fix #843, but does fix the last byte of all comments not being included in their semantic tokens.