### PR TITLE
fix: avoid finding references in the current file twice

### DIFF
--- a/src/references.zig
+++ b/src/references.zig
@@ -497,6 +497,8 @@ pub fn symbolReferences(
 
             for (dependencies.keys()) |uri| {
                 const handle = store.getHandle(uri) orelse continue;
+                if (std.mem.eql(u8, handle.uri, curr_handle.uri)) continue;
+
                 try symbolReferencesInternal(&builder, 0, handle, true);
             }
         },


### PR DESCRIPTION
This bug is not noticeable in vscode, as either the extension or the editor doesn't show duplicated values on the list. But I catch it using it in neovim, 

Requesting references returns twice each range for the references that are in the same file of the element being requested, this doesn't happen for references in other files.

After doing a small debug, I noticed that the current file is being evaluated as part of the dependencies, therefore sending it to `symbolReferencesInternal` twice. 

This small validation avoids that problem.

Let me know if there is something else that should be validated for this, happy to help!