### PR TITLE
fix memory lifetime issues

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -1148,12 +1148,7 @@ pub fn resolveTypeOfNode(store: *DocumentStore, arena: *std.heap.ArenaAllocator,
 /// Collects all `@import`'s we can find into a slice of import paths (without quotes).
 pub fn collectImports(allocator: std.mem.Allocator, tree: Ast) error{OutOfMemory}!std.ArrayListUnmanaged([]const u8) {
     var imports = std.ArrayListUnmanaged([]const u8){};
-    errdefer {
-        for (imports.items) |imp| {
-            allocator.free(imp);
-        }
-        imports.deinit(allocator);
-    }
+    errdefer imports.deinit(allocator);
 
     const tags = tree.tokens.items(.tag);
 

--- a/src/references.zig
+++ b/src/references.zig
@@ -488,7 +488,7 @@ pub fn symbolReferences(
                 }
 
                 var handle_dependencies = std.ArrayListUnmanaged([]const u8){};
-                try store.collectDependencies(store.allocator, handle.*, &handle_dependencies);
+                try store.collectDependencies(arena.allocator(), handle.*, &handle_dependencies);
 
                 for (handle_dependencies.items) |uri| {
                     try dependencies.put(arena.allocator(), uri, {});


### PR DESCRIPTION
I've inserted a randomly failing allocator similar to `std.testing.FailingAllocator` into zls to find some leaks when `error.OutOfMemory` occured.
Once #850 is merged i could try to integrate this into zls so that it can be used with [sus](https://github.com/zigtools/sus) to find even more issues.