### PR TITLE
fix: tres not available in a nix environment.

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -92,7 +92,9 @@ pub fn build(b: *std.build.Builder) !void {
     const known_folders_path = b.option([]const u8, "known-folders", "Path to known-folders package (default: " ++ KNOWN_FOLDERS_DEFAULT_PATH ++ ")") orelse KNOWN_FOLDERS_DEFAULT_PATH;
     exe.addPackage(.{ .name = "known-folders", .source = .{ .path = known_folders_path } });
 
-    exe.addPackage(.{ .name = "tres", .source = .{ .path = "src/tres/tres.zig" } });
+    const TRES_DEFAULT_PATH = "src/tres/tres.zig";
+    const tres_path = b.option([]const u8, "tres", "Path to tres package (default: " ++ TRES_DEFAULT_PATH ++ ")") orelse TRES_DEFAULT_PATH;
+    exe.addPackage(.{ .name = "tres", .source = .{ .path = tres_path } });
 
     if (enable_tracy) {
         const client_cpp = "src/tracy/TracyClient.cpp";
@@ -148,7 +150,7 @@ pub fn build(b: *std.build.Builder) !void {
     }
 
     tests.addPackage(.{ .name = "zls", .source = .{ .path = "src/zls.zig" }, .dependencies = exe.packages.items });
-    tests.addPackage(.{ .name = "tres", .source = .{ .path = "src/tres/tres.zig" } });
+    tests.addPackage(.{ .name = "tres", .source = .{ .path = tres_path } });
     tests.setBuildMode(.Debug);
     tests.setTarget(target);
     test_step.dependOn(&tests.step);

--- a/flake.lock
+++ b/flake.lock
@@ -68,11 +68,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1670086663,
-        "narHash": "sha256-hT8C8AQB74tdoCPwz4nlJypLMD7GI2F5q+vn+VE/qQk=",
+        "lastModified": 1672057183,
+        "narHash": "sha256-GN7/10DNNvs1FPj9tlZA2qgNdFuYKKuS3qlHTqAxasQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "813836d64fa57285d108f0dbf2356457ccd304e3",
+        "rev": "b139e44d78c36c69bcbb825b20dbfa51e7738347",
         "type": "github"
       },
       "original": {
@@ -88,7 +88,24 @@
         "gitignore": "gitignore",
         "known-folders": "known-folders",
         "nixpkgs": "nixpkgs",
+        "tres": "tres",
         "zig-overlay": "zig-overlay"
+      }
+    },
+    "tres": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1672008284,
+        "narHash": "sha256-AtM9SV56PEud1MfbKDZMU2FlsNrI46PkcFQh3yMcDX0=",
+        "owner": "ziglibs",
+        "repo": "tres",
+        "rev": "16774b94efa61757a5302a690837dfb8cf750a11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ziglibs",
+        "repo": "tres",
+        "type": "github"
       }
     },
     "zig-overlay": {
@@ -99,11 +116,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670113356,
-        "narHash": "sha256-43aMRMU0OuBin6M2LM+nxVG+whazyHuHnUvu92xoth0=",
+        "lastModified": 1672142864,
+        "narHash": "sha256-uXljuSZK8DP5c4o9u+gcF+Yc3dKYH1wsHmDpWcFBVRQ=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "17352071583eda4be43fa2a312f6e061326374f7",
+        "rev": "16e9191142d2a13d7870c03e500842321a466a74",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -12,9 +12,12 @@
 
     known-folders.url = "github:ziglibs/known-folders";
     known-folders.flake = false;
+
+    tres.url = "github:ziglibs/tres";
+    tres.flake = false;
   };
 
-  outputs = { self, nixpkgs, zig-overlay, gitignore, flake-utils, known-folders }:
+  outputs = { self, nixpkgs, zig-overlay, gitignore, flake-utils, known-folders, tres }:
     let
       systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
       inherit (gitignore.lib) gitignoreSource;
@@ -35,7 +38,7 @@
           dontInstall = true;
           buildPhase = ''
             mkdir -p $out
-            zig build install -Dcpu=baseline -Drelease-safe=true -Ddata_version=master -Dknown-folders=${known-folders}/known-folders.zig --prefix $out
+            zig build install -Dcpu=baseline -Drelease-safe=true -Ddata_version=master -Dtres=${tres}/tres.zig -Dknown-folders=${known-folders}/known-folders.zig --prefix $out
           '';
           XDG_CACHE_HOME = ".cache";
         };

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -24,7 +24,7 @@ const ComptimeInterpreter = @import("ComptimeInterpreter.zig");
 const data = @import("data/data.zig");
 const snipped_data = @import("data/snippets.zig");
 
-const tres = @import("tres/tres.zig");
+const tres = @import("tres");
 
 const log = std.log.scoped(.server);
 
@@ -188,7 +188,7 @@ fn generateDiagnostics(server: *Server, handle: DocumentStore.Handle) !types.Pub
     defer tracy_zone.end();
 
     std.debug.assert(server.client_capabilities.supports_publish_diagnostics);
-    
+
     const tree = handle.tree;
 
     var allocator = server.arena.allocator();
@@ -1885,7 +1885,7 @@ fn openDocumentHandler(server: *Server, notification: types.DidOpenTextDocumentP
     defer tracy_zone.end();
 
     const handle = try server.document_store.openDocument(notification.textDocument.uri, notification.textDocument.text);
-    
+
     if (server.client_capabilities.supports_publish_diagnostics) {
         const diagnostics = try server.generateDiagnostics(handle);
         server.sendNotification("textDocument/publishDiagnostics", diagnostics);
@@ -2128,7 +2128,6 @@ fn hoverHandler(server: *Server, request: types.HoverParams) !?types.Hover {
         else => null,
     };
 
-    
     // TODO: Figure out a better solution for comptime interpreter diags
     if (server.client_capabilities.supports_publish_diagnostics) {
         const diagnostics = try server.generateDiagnostics(handle.*);


### PR DESCRIPTION
The last commit added tres as a depency, but did so in a way that broke the nix environment. 

This pull-request fixes that by:

- Adding a `tres` option to the build, the same way we have a `known-folders` option.
- Changing the `flake.nix` file to pull `tres` and pass the correct path through the new option.
- Changing the `Server.zig` file to use the correct import statement.

With those changes I now have both `zig build` and `nix build` working.