### PR TITLE
fix ast-check with single error

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -453,6 +453,12 @@ fn getAstCheckDiagnostics(
             };
         }
     }
+
+    if (last_diagnostic) |*diagnostic| {
+        diagnostic.relatedInformation = try last_related_diagnostics.toOwnedSlice(allocator);
+        try diagnostics.append(allocator, diagnostic.*);
+        last_diagnostic = null;
+    }
 }
 
 /// caller owns returned memory.


### PR DESCRIPTION
fixes an ast-check issue that was caused in 61c0981294c52820d185afe41a0965a722c3e314

i believed that this will f i x  #856 but based on what is being said in the comments that issue is also caused in older version.
I did a `git bisect` between 44b6c4dae4ace789c5a3ebf9fdbeb65db8f1cf30 and c6d74dbca565105b49655e50c062758e6af99127. 61c0981294c52820d185afe41a0965a722c3e314 was the resulting turning point.