### PR TITLE
fix crashes found through fuzzing

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -2485,14 +2485,14 @@ fn foldingRangeHandler(server: *Server, request: types.FoldingRangeParams) !?[]t
             .@"if", .if_simple => {
                 const if_full = ast.ifFull(handle.tree, node);
 
-                const start_tok_1 = handle.tree.lastToken(if_full.ast.cond_expr);
-                const end_tok_1 = handle.tree.lastToken(if_full.ast.then_expr);
+                const start_tok_1 = ast.lastToken(handle.tree, if_full.ast.cond_expr);
+                const end_tok_1 = ast.lastToken(handle.tree, if_full.ast.then_expr);
                 _ = try helper.maybeAddTokRange(&ranges, handle.tree, start_tok_1, end_tok_1, .inclusive, server.offset_encoding);
 
                 if (if_full.ast.else_expr == 0) continue;
 
                 const start_tok_2 = if_full.else_token;
-                const end_tok_2 = handle.tree.lastToken(if_full.ast.else_expr);
+                const end_tok_2 = ast.lastToken(handle.tree, if_full.ast.else_expr);
 
                 _ = try helper.maybeAddTokRange(&ranges, handle.tree, start_tok_2, end_tok_2, .inclusive, server.offset_encoding);
             },
@@ -2506,14 +2506,14 @@ fn foldingRangeHandler(server: *Server, request: types.FoldingRangeParams) !?[]t
             => {
                 const loop_full = ast.whileAst(handle.tree, node).?;
 
-                const start_tok_1 = handle.tree.lastToken(loop_full.ast.cond_expr);
-                const end_tok_1 = handle.tree.lastToken(loop_full.ast.then_expr);
+                const start_tok_1 = ast.lastToken(handle.tree, loop_full.ast.cond_expr);
+                const end_tok_1 = ast.lastToken(handle.tree, loop_full.ast.then_expr);
                 _ = try helper.maybeAddTokRange(&ranges, handle.tree, start_tok_1, end_tok_1, .inclusive, server.offset_encoding);
 
                 if (loop_full.ast.else_expr == 0) continue;
 
                 const start_tok_2 = loop_full.else_token;
-                const end_tok_2 = handle.tree.lastToken(loop_full.ast.else_expr);
+                const end_tok_2 = ast.lastToken(handle.tree, loop_full.ast.else_expr);
                 _ = try helper.maybeAddTokRange(&ranges, handle.tree, start_tok_2, end_tok_2, .inclusive, server.offset_encoding);
             },
 
@@ -2551,7 +2551,7 @@ fn foldingRangeHandler(server: *Server, request: types.FoldingRangeParams) !?[]t
                     break :decl_node_blk;
 
                 const list_start_tok: Ast.TokenIndex = fn_proto.lparen;
-                const list_end_tok: Ast.TokenIndex = handle.tree.lastToken(fn_proto.ast.proto_node);
+                const list_end_tok: Ast.TokenIndex = ast.lastToken(handle.tree, fn_proto.ast.proto_node);
 
                 if (handle.tree.tokensOnSameLine(list_start_tok, list_end_tok)) break :decl_node_blk;
                 try ranges.ensureUnusedCapacity(1 + fn_proto.ast.params.len); // best guess, doesn't include anytype params
@@ -2578,7 +2578,7 @@ fn foldingRangeHandler(server: *Server, request: types.FoldingRangeParams) !?[]t
             // .grouped_expression,
             => {
                 const start_tok = handle.tree.firstToken(node);
-                const end_tok = handle.tree.lastToken(node);
+                const end_tok = ast.lastToken(handle.tree, node);
                 _ = try helper.maybeAddTokRange(&ranges, handle.tree, start_tok, end_tok, .inclusive, server.offset_encoding);
             },
 
@@ -2625,7 +2625,7 @@ fn foldingRangeHandler(server: *Server, request: types.FoldingRangeParams) !?[]t
                 }
 
                 const start_tok = handle.tree.firstToken(node);
-                const end_tok = handle.tree.lastToken(node);
+                const end_tok = ast.lastToken(handle.tree, node);
                 _ = try helper.maybeAddTokRange(&ranges, handle.tree, start_tok, end_tok, .exclusive, server.offset_encoding);
             },
         }

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -1466,6 +1466,8 @@ pub fn getImportStr(tree: Ast, node: Ast.Node.Index, source_index: usize) ?[]con
 
     if (params.len != 1) return null;
 
+    if(node_tags[params[0]] != .string_literal) return null;
+
     const import_str = tree.tokenSlice(tree.nodes.items(.main_token)[params[0]]);
     return import_str[1 .. import_str.len - 1];
 }

--- a/src/ast.zig
+++ b/src/ast.zig
@@ -539,10 +539,15 @@ pub fn lastToken(tree: Ast, node: Ast.Node.Index) Ast.TokenIndex {
         .container_decl_arg_trailing,
         .switch_comma,
         => {
-            const members = tree.extraData(datas[n].rhs, Node.SubRange);
-            std.debug.assert(members.end - members.start > 0);
-            end_offset += 2; // for the comma + rbrace
-            n = tree.extra_data[members.end - 1]; // last parameter
+            if(datas[n].rhs != 0) {
+                const members = tree.extraData(datas[n].rhs, Node.SubRange);
+                std.debug.assert(members.end - members.start > 0);
+                end_offset += 2; // for the comma + rbrace
+                n = tree.extra_data[members.end - 1]; // last parameter
+            } else {
+                end_offset += 1;
+                n = datas[n].lhs;
+            }
         },
         .array_init_dot,
         .struct_init_dot,

--- a/src/inlay_hints.zig
+++ b/src/inlay_hints.zig
@@ -22,7 +22,7 @@ pub const inlay_hints_max_inline_children = 12;
 
 /// checks whether node is inside the range
 fn isNodeInRange(tree: Ast, node: Ast.Node.Index, range: types.Range) bool {
-    const endLocation = tree.tokenLocation(0, tree.lastToken(node));
+    const endLocation = tree.tokenLocation(0, ast.lastToken(tree, node));
     if (endLocation.line < range.start.line) return false;
 
     const beginLocation = tree.tokenLocation(0, tree.firstToken(node));

--- a/src/semantic_tokens.zig
+++ b/src/semantic_tokens.zig
@@ -289,7 +289,7 @@ fn writeNodeTokens(builder: *Builder, maybe_node: ?Ast.Node.Index) WriteTokensEr
     const token_tags = tree.tokens.items(.tag);
     const node_data = tree.nodes.items(.data);
     const main_tokens = tree.nodes.items(.main_token);
-    if (node == 0 or node > node_data.len) return;
+    if (node == 0 or node >= node_data.len) return;
 
     var allocator = builder.arena.allocator();
 

--- a/tests/lsp_features/folding_range.zig
+++ b/tests/lsp_features/folding_range.zig
@@ -34,7 +34,7 @@ test "foldingRange - #801" {
         \\    };
         \\}
     ,
-        \\[]
+        \\[{"startLine":1,"endLine":4},{"startLine":0,"endLine":5}]
     );
 }
 


### PR DESCRIPTION
fixes  #849
```zig
foo = enum(i2) {
  var bar == 1);
}
```
---
fixes:
```zig
st = mem.tokenizer, token: *?Token, tokens, false);
const NSIG = if (out.len != 0) continue :start_over;
    const x29 = (@as(u64, x46), x61);
               result[@enumToInt(permissionDenied,
         0x16, 0x17, 0x13,
    }
```
---
fixes:
```zig
const std = @import("std" {});
//                   ^^^ goto definition here
```