### PR TITLE
CI: Add Nix build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
 
           for target in "${targets[@]}"; do
             mkdir -p artifacts/$target
-            echo "Building target ${target}..."   
+            echo "Building target ${target}..."
             if [ "${GITHUB_REF##*/}" == "master" ]; then
               echo "Building safe"
               zig build -Dtarget=${target} -Drelease-safe --prefix artifacts/${target}/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,9 +4,11 @@ on:
   push:
     paths:
       - "**.zig"
+      - "flake.*"
   pull_request:
     paths:
       - "**.zig"
+      - "flake.*"
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:
@@ -118,3 +120,11 @@ jobs:
           REMOTE_HOST: ${{ secrets.WEBSITE_DEPLOY_HOST }}
           REMOTE_USER: ${{ secrets.WEBSITE_DEPLOY_USER }}
           TARGET: ${{ secrets.WEBSITE_DEPLOY_FOLDER }}
+
+      - name: Install Nix
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        uses: cachix/install-nix-action@v18
+
+      - name: Build Nix flake package
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: nix build --print-build-logs

--- a/flake.lock
+++ b/flake.lock
@@ -2,21 +2,6 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
-      "locked": {
         "lastModified": 1659877975,
         "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
@@ -110,7 +95,9 @@
     },
     "zig-overlay": {
       "inputs": {
-        "flake-utils": "flake-utils_2",
+        "flake-utils": [
+          "flake-utils"
+        ],
         "nixpkgs": [
           "nixpkgs"
         ]

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,7 @@
 
     zig-overlay.url = "github:mitchellh/zig-overlay";
     zig-overlay.inputs.nixpkgs.follows = "nixpkgs";
+    zig-overlay.inputs.flake-utils.follows = "flake-utils";
 
     gitignore.url = "github:hercules-ci/gitignore.nix";
     gitignore.inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
### Commit: `CI/main: convert line endings from CRLF to LF`

Review this commit like so:
```bash
mkdir -p /tmp/diff
git show master:.github/workflows/main.yml | sed 's|\r$||' > /tmp/diff/master_converted_to_unix
git show --name-only 8ee1c6e
git show 8ee1c6e:.github/workflows/main.yml > /tmp/diff/from_this_pr
# This only shows some removed trailing whitespace
diff -u --color /tmp/diff/{master_converted_to_unix,from_this_pr}
rm -rf /tmp/diff
```

### Commit `CI: Add Nix build`

This adds a CI Nix step to test that building the Nix package succeeds.

Let's do this without Cachix for now.
The resulting slowdown is insignificant, because caching would only affect the zig build (from zig-overlay) which internally is [just a copy operation](https://github.com/mitchellh/zig-overlay/blob/ef9d5253e1a990a49e761854f51c71d75f15579d/default.nix#L22) anyway.

### Meta
@SuperAuguste, can you try to avoid squashing all commits for PRs that have a clean commit structure?
This helps reviewing changes and also allows for finer-grained reverts.