### PR TITLE
Nix: Improve debugging, support testing

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,11 +36,16 @@
           nativeBuildInputs = [ zig ];
           dontConfigure = true;
           dontInstall = true;
+
+          inherit tres;
+          # Builder var names can't have dashes
+          known_folders = known-folders;
+
           buildPhase = ''
             mkdir -p $out
-            zig build install -Dcpu=baseline -Drelease-safe=true -Ddata_version=master -Dtres=${tres}/tres.zig -Dknown-folders=${known-folders}/known-folders.zig --prefix $out
+            export XDG_CACHE_HOME=$TMP/.cache
+            zig build install -Dcpu=baseline -Drelease-safe=true -Ddata_version=master -Dtres=$tres/tres.zig -Dknown-folders=$known_folders/known-folders.zig --prefix $out
           '';
-          XDG_CACHE_HOME = ".cache";
         };
       }
     );

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -76,7 +76,7 @@ zig_exe_path: ?[]const u8 = null,
 /// Path to the `build_runner.zig` file provided by zls. null is equivalent to `${executable_directory}/build_runner.zig`
 build_runner_path: ?[]const u8 = null,
 
-/// Path to a directroy that will be used as zig's cache. null is equivalent to `${KnownFloders.Cache}/zls`
+/// Path to a directroy that will be used as zig's cache. null is equivalent to `${KnownFolders.Cache}/zls`
 global_cache_path: ?[]const u8 = null,
 
 // DO NOT EDIT

--- a/src/config_gen/config.json
+++ b/src/config_gen/config.json
@@ -146,7 +146,7 @@
         },
         {
             "name": "global_cache_path",
-            "description": "Path to a directroy that will be used as zig's cache. null is equivalent to `${KnownFloders.Cache}/zls`",
+            "description": "Path to a directroy that will be used as zig's cache. null is equivalent to `${KnownFolders.Cache}/zls`",
             "type": "?[]const u8",
             "default": "null"
         }


### PR DESCRIPTION
#### Copy of commit msg
- Export library deps to the nix build environment, so they are easily available inside `nix develop` shells.

- Set `XDG_CACHE_HOME` to an absolute path, because the tests require an absolute path for creating and accessing `build_runner.zig`.
  This allows running `zig build test` inside the dev shell.