### PR TITLE
Goto definition works when the cursor is at the start of the identifier

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -163,6 +163,11 @@ pub fn build(b: *std.build.Builder) !void {
     test_step.dependOn(b.getInstallStep());
 
     var tests = b.addTest("tests/tests.zig");
+    tests.setFilter(b.option(
+        []const u8,
+        "test-filter",
+        "Skip tests that do not match filter",
+    ));
 
     if (coverage) {
         const src_dir = b.pathJoin(&.{ b.build_root, "src" });

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -1528,9 +1528,15 @@ fn tokenLocAppend(prev: offsets.Loc, token: std.zig.Token) offsets.Loc {
     };
 }
 
+/// Given a byte index in a document (typically cursor offset), classify what kind of entity is at that index.
+///
+/// Classification is based on the lexical structure -- we fetch the line containin index, tokenize it,
+/// and look at the sequence of tokens just before the cursor. Due to the nice way zig is designed (only line
+/// comments, etc) lexing just a single line is always correct.
 pub fn getPositionContext(allocator: std.mem.Allocator, text: []const u8, doc_index: usize) !PositionContext {
-    const line_loc = offsets.lineLocUntilIndex(text, doc_index);
+    const line_loc = offsets.lineLocAtIndex(text, doc_index);
     const line = offsets.locToSlice(text, line_loc);
+    const prev_char = if (doc_index > 0) text[doc_index - 1] else 0;
 
     const is_comment = std.mem.startsWith(u8, std.mem.trimLeft(u8, line, " \t"), "//");
     if (is_comment) return .comment;
@@ -1551,10 +1557,16 @@ pub fn getPositionContext(allocator: std.mem.Allocator, text: []const u8, doc_in
         while (true) {
             const tok = tokenizer.next();
             // Early exits.
+            if (tok.loc.start > doc_index) break;
+            if (tok.loc.start == doc_index) {
+                // Tie-breaking, the curosr is exactly between two tokens, and
+                // `tok` is the latter of the two.
+                if (tok.tag != .identifier) break;
+            }
             switch (tok.tag) {
                 .invalid => {
                     // Single '@' do not return a builtin token so we check this on our own.
-                    if (line[line.len - 1] == '@') {
+                    if (prev_char == '@') {
                         return PositionContext{
                             .builtin = .{
                                 .start = line_loc.end - 1,
@@ -1660,7 +1672,7 @@ pub fn getPositionContext(allocator: std.mem.Allocator, text: []const u8, doc_in
             .label => |filled| {
                 // We need to check this because the state could be a filled
                 // label if only a space follows it
-                if (!filled or line[line.len - 1] != ' ') {
+                if (!filled or prev_char != ' ') {
                     return state.ctx;
                 }
             },

--- a/tests/lsp_features/definition.zig
+++ b/tests/lsp_features/definition.zig
@@ -28,15 +28,10 @@ test "definition - cursor is at the end of an identifier" {
 }
 
 test "definition - cursor is at the start of an identifier" {
-    testDefinition(
+    try testDefinition(
         \\fn main() void { <>foo(); }
         \\fn <def>foo</def>() void {}
-    ) catch |err| switch (err) {
-        error.UnresolvedDefinition => {
-            // TODO: #891
-        },
-        else => return err,
-    };
+    );
 }
 
 fn testDefinition(source: []const u8) !void {


### PR DESCRIPTION
Before, the code lexed only a prefix of the line up to cursor position.
Now, we lex the entire line, and do look at the token just after the
cursor.

This subtly changes sematncih of `getPostionContext`: now it is becomes
oblivious of the _exact_ position of the cursor and returns the whole
token at cursor's position.

I believe this is semantically right approach -- _most_ of the callsite
should not worry at all about such details. Something like completion
_might_ want to know more, but it's better to make that call site's
problem.

It might be the case that some existing code relies on the past
behavior. It's hard to tell though -- we don't have a lot of tests for
_features_, and changes to unit-tests don't explain if the changes are
meaningful for user-observable behavior or not.

In general, for LSP-shaped thing, I feel that the bulk of testing should
be focused on end-to-end behaviors....


Closes https://github.com/zigtools/zls/issues/891