### PR TITLE
fix use after free

### DIFF
--- a/src/DocumentStore.zig
+++ b/src/DocumentStore.zig
@@ -694,7 +694,7 @@ fn createDocument(self: *DocumentStore, uri: Uri, text: [:0]u8, open: bool) erro
                 handle.associated_build_file = gop.key_ptr.*;
                 break;
             } else if (handle.associated_build_file == null) {
-                handle.associated_build_file = build_file_uri;
+                handle.associated_build_file = gop.key_ptr.*;
             }
         }
     }


### PR DESCRIPTION
We free build_file_uri at https://github.com/zigtools/zls/compare/master...matklad:zls:fix-uaf?expand=1#diff-9cb2be04fa3f02d77f8aa62f4254392953ec06c5a1c4063db610575ab78a3343L690


I am not entirely sure whhat I am doing heer, but it gets me rid of a crash when working with zls iteslf.