### PR TITLE
show better zig/zls version mismatch messages

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -1744,8 +1744,9 @@ fn initializeHandler(server: *Server, request: types.InitializeParams) Error!typ
 
         switch (zig_version_simple.order(zls_version_simple)) {
             .lt => {
-                // ZLS should be backwards compatible with older Zig version which is why we only log
-                log.info("Zig {} is older than ZLS {}", .{ zig_version_simple, zls_version_simple });
+                server.showMessage(.Warning,
+                    \\Zig {} is older than ZLS {}. Update Zig to avoid unexpected behavior.
+                , .{ zig_version_simple, zls_version_simple });
             },
             .eq => {},
             .gt => {

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -1734,25 +1734,25 @@ fn initializeHandler(server: *Server, request: types.InitializeParams) Error!typ
         const zig_version_simple = std.SemanticVersion{
             .major = zig_version.major,
             .minor = zig_version.minor,
-            .patch = zig_version.patch,
+            .patch = 0,
         };
         const zls_version_simple = std.SemanticVersion{
             .major = zls_version.major,
             .minor = zls_version.minor,
-            .patch = zls_version.patch,
+            .patch = 0,
         };
 
         switch (zig_version_simple.order(zls_version_simple)) {
             .lt => {
                 server.showMessage(.Warning,
-                    \\Zig {} is older than ZLS {}. Update Zig to avoid unexpected behavior.
-                , .{ zig_version_simple, zls_version_simple });
+                    \\Zig `{}` is older than ZLS `{}`. Update Zig to avoid unexpected behavior.
+                , .{ zig_version, zls_version });
             },
             .eq => {},
             .gt => {
                 server.showMessage(.Warning,
-                    \\Zig {} is newer than ZLS {}. Update ZLS to avoid unexpected behavior.
-                , .{ zig_version_simple, zls_version_simple });
+                    \\Zig `{}` is newer than ZLS `{}`. Update ZLS to avoid unexpected behavior.
+                , .{ zig_version, zls_version });
             },
         }
     } else {


### PR DESCRIPTION
Previously ZLS would show a warning if zls was build using an old zig version. 
Instead there should be a warning if the zig version doesn't match the ZLS version (only major and minor version matter).

| Zig     | ZLS     |  Result |
|---------|---------|-----------|
| 0.9.0   | 0.10.0  | "Zig `0.9.0` is older than ZLS `0.10.0`. Update Zig to avoid unexpected behavior."    |
| 0.11.3  | 0.10.1  | "Zig `0.11.3` is newer than ZLS `0.10.1`. Update ZLS to avoid unexpected behavior."    |
| 0.10.0  | 0.10.0  |   no warning   |
| 0.10.0  | 0.10.1  |   no warning   |
| 0.10.1  | 0.10.0  |   no warning   |

fixes #838