### PR TITLE
Fix undefined memory access

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -1332,6 +1332,10 @@ fn completeBuiltin(server: *Server) error{OutOfMemory}!?[]types.CompletionItem {
         for (completions.items) |*item| {
             try formatDetailledLabel(item, allocator);
         }
+    } else {
+        for (builtin_completions.items) |item, i| {
+            completions[i] = item;
+        }
     }
 
     return completions.items;


### PR DESCRIPTION
Builtin label completions weren't being initialised if labels were disabled, resulting in a crash whenever you tried to complete a builtin.