### PR TITLE
Remove unused capacity from Ast and DocumentStore

### DIFF
--- a/src/DocumentStore.zig
+++ b/src/DocumentStore.zig
@@ -622,8 +622,18 @@ fn createDocument(self: *DocumentStore, uri: Uri, text: [:0]u8, open: bool) erro
         var tree = try std.zig.parse(self.allocator, text);
         errdefer tree.deinit(self.allocator);
 
+        var nodes = tree.nodes.toMultiArrayList();
+        try nodes.setCapacity(self.allocator, nodes.len);
+        tree.nodes = nodes.slice();
+
+        var tokens = tree.tokens.toMultiArrayList();
+        try tokens.setCapacity(self.allocator, tokens.len);
+        tree.tokens = tokens.slice();
+
         var document_scope = try analysis.makeDocumentScope(self.allocator, tree);
         errdefer document_scope.deinit(self.allocator);
+
+        try document_scope.scopes.setCapacity(self.allocator, document_scope.scopes.len);
 
         break :blk Handle{
             .open = open,


### PR DESCRIPTION
We can save some memory by removing unused storage from Ast nodes, tokens and DocumentStore scopes.

| Action                             | Master   |    PR    | Memory savings |
|------------------------------------|----------|----------|----------------|
| completions on `win32.everything`  | 520.29MB | 462.01MB |     11.2%      |
| 8 largest files in zig src folder  | 47.54MB  | 38.71MB  |     18.5%      |
| 20 largest files in zig src folder | 54.65MB  | 48.06MB  |     12.0%      |
| 6 largest files in zls src folder  | 13.82MB  | 12.24MB  |     11.5%      |
| every zls file in src folder       | 21.09MB  | 18.86MB  |     10.6%      |