### PR TITLE
Optimize inlay hints

### DIFF
--- a/src/ast.zig
+++ b/src/ast.zig
@@ -1254,11 +1254,6 @@ pub fn iterateChildren(
         .async_call_one,
         .async_call_one_comma,
         .switch_range,
-        .while_simple,
-        .for_simple,
-        .if_simple,
-        .fn_proto_simple,
-        .fn_decl,
         .builtin_call_two,
         .builtin_call_two_comma,
         .container_decl_two,
@@ -1299,7 +1294,7 @@ pub fn iterateChildren(
         .simple_var_decl,
         .aligned_var_decl,
         => {
-            const var_decl = tree.fullVarDecl(node).?.ast; // TODO order
+            const var_decl = tree.fullVarDecl(node).?.ast;
             try callback(context, var_decl.type_node);
             try callback(context, var_decl.align_node);
             try callback(context, var_decl.addrspace_node);
@@ -1320,11 +1315,11 @@ pub fn iterateChildren(
         .ptr_type_bit_range,
         => {
             const ptr_type = fullPtrType(tree, node).?.ast;
-            try callback(context, ptr_type.align_node);
-            try callback(context, ptr_type.addrspace_node);
             try callback(context, ptr_type.sentinel);
+            try callback(context, ptr_type.align_node);
             try callback(context, ptr_type.bit_range_start);
             try callback(context, ptr_type.bit_range_end);
+            try callback(context, ptr_type.addrspace_node);
             try callback(context, ptr_type.child_type);
         },
 
@@ -1395,8 +1390,10 @@ pub fn iterateChildren(
             try callback(context, switch_case.target_expr);
         },
 
+        .while_simple,
         .while_cont,
         .@"while",
+        .for_simple,
         .@"for",
         => {
             const while_ast = fullWhile(tree, node).?.ast;
@@ -1406,29 +1403,32 @@ pub fn iterateChildren(
             try callback(context, while_ast.else_expr);
         },
 
-        .@"if" => {
+        .@"if",
+        .if_simple,
+        => {
             const if_ast = ifFull(tree, node).ast;
             try callback(context, if_ast.cond_expr);
             try callback(context, if_ast.then_expr);
             try callback(context, if_ast.else_expr);
         },
 
+        .fn_proto_simple,
         .fn_proto_multi,
         .fn_proto_one,
         .fn_proto,
+        .fn_decl,
         => {
             var buffer: [1]Node.Index = undefined;
-            const fn_proto = tree.fullFnProto(&buffer, node).?; // TODO order
-
-            try callback(context, fn_proto.ast.return_type);
-            try callback(context, fn_proto.ast.align_expr);
-            try callback(context, fn_proto.ast.addrspace_expr);
-            try callback(context, fn_proto.ast.section_expr);
-            try callback(context, fn_proto.ast.callconv_expr);
+            const fn_proto = tree.fullFnProto(&buffer, node).?;
 
             for (fn_proto.ast.params) |child| {
                 try callback(context, child);
             }
+            try callback(context, fn_proto.ast.align_expr);
+            try callback(context, fn_proto.ast.addrspace_expr);
+            try callback(context, fn_proto.ast.section_expr);
+            try callback(context, fn_proto.ast.callconv_expr);
+            try callback(context, fn_proto.ast.return_type);
         },
 
         .container_decl_arg,

--- a/src/offsets.zig
+++ b/src/offsets.zig
@@ -240,6 +240,29 @@ pub fn convertRangeEncoding(text: []const u8, range: types.Range, from_encoding:
     };
 }
 
+// returns true if a and b intersect
+pub fn locIntersect(a: Loc, b: Loc) bool {
+    std.debug.assert(a.start <= a.end and b.start <= b.end);
+    const a_start_in_b = b.start <= a.start and a.start <= b.end;
+    const a_end_in_b = b.start <= a.end and a.end <= b.end;
+    return a_start_in_b or a_end_in_b;
+}
+
+// returns true if a is inside b
+pub fn locInside(inner: Loc, outer: Loc) bool {
+    std.debug.assert(inner.start <= inner.end and outer.start <= outer.end);
+    return outer.start <= inner.start and inner.end <= outer.end;
+}
+
+// returns the union of a and b
+pub fn locMerge(a: Loc, b: Loc) Loc {
+    std.debug.assert(a.start <= a.end and b.start <= b.end);
+    return .{
+        .start = @min(a.start, b.start),
+        .end = @max(a.end, b.end),
+    };
+}
+
 // Helper functions
 
 /// advance `position` which starts at `from_index` to `to_index` accounting for line breaks

--- a/src/zls.zig
+++ b/src/zls.zig
@@ -1,6 +1,7 @@
 // Used by tests as a package, can be used by tools such as
 // zigbot9001 to take advantage of zls' tools
 
+pub const ast = @import("ast.zig");
 pub const analysis = @import("analysis.zig");
 pub const Header = @import("Header.zig");
 pub const debug = @import("debug.zig");

--- a/tests/tests.zig
+++ b/tests/tests.zig
@@ -1,6 +1,7 @@
 comptime {
     _ = @import("helper.zig");
 
+    _ = @import("utility/ast.zig");
     _ = @import("utility/offsets.zig");
     _ = @import("utility/position_context.zig");
     _ = @import("utility/uri.zig");

--- a/tests/utility/ast.zig
+++ b/tests/utility/ast.zig
@@ -1,0 +1,76 @@
+const std = @import("std");
+const zls = @import("zls");
+
+const helper = @import("../helper.zig");
+const Context = @import("../context.zig").Context;
+const ErrorBuilder = @import("../ErrorBuilder.zig");
+
+const types = zls.types;
+const offsets = zls.offsets;
+const ast = zls.ast;
+
+const allocator = std.testing.allocator;
+
+test "nodesAtLoc" {
+    try testNodesAtLoc(
+        \\<outer>const<inner> foo<inner> = 5<outer>;
+    );
+    try testNodesAtLoc(
+        \\<outer>const f<inner>oo = 5;
+        \\var bar = <inner>2<outer>;
+    );
+    try testNodesAtLoc(
+        \\const foo = <outer>5<inner> +<inner> 2<outer>;
+    );
+    try testNodesAtLoc(
+        \\<outer><inner>fn foo(alpha: u32) void {}
+        \\const _ = foo(5);<inner><outer>
+    );
+}
+
+fn testNodesAtLoc(source: []const u8) !void {
+    var ccp = try helper.collectClearPlaceholders(allocator, source);
+    defer ccp.deinit(allocator);
+
+    const old_locs = ccp.locations.items(.old);
+    const locs = ccp.locations.items(.new);
+
+    std.debug.assert(ccp.locations.len == 4);
+    std.debug.assert(std.mem.eql(u8, offsets.locToSlice(source, old_locs[0]), "<outer>"));
+    std.debug.assert(std.mem.eql(u8, offsets.locToSlice(source, old_locs[1]), "<inner>"));
+    std.debug.assert(std.mem.eql(u8, offsets.locToSlice(source, old_locs[2]), "<inner>"));
+    std.debug.assert(std.mem.eql(u8, offsets.locToSlice(source, old_locs[3]), "<outer>"));
+
+    const inner_loc = offsets.Loc{ .start = locs[1].start, .end = locs[2].start };
+    const outer_loc = offsets.Loc{ .start = locs[0].start, .end = locs[3].end };
+
+    const new_source = try allocator.dupeZ(u8, ccp.new_source);
+    defer allocator.free(new_source);
+
+    var tree = try std.zig.parse(allocator, new_source);
+    defer tree.deinit(allocator);
+
+    const nodes = try ast.nodesAtLoc(allocator, tree, inner_loc);
+    defer allocator.free(nodes);
+
+    const actual_loc = offsets.Loc{
+        .start = offsets.nodeToLoc(tree, nodes[0]).start,
+        .end = offsets.nodeToLoc(tree, nodes[nodes.len - 1]).end,
+    };
+
+    var error_builder = ErrorBuilder.init(allocator, new_source);
+    defer error_builder.deinit();
+    errdefer error_builder.writeDebug();
+
+    if (outer_loc.start != actual_loc.start) {
+        try error_builder.msgAtIndex("actual start here", actual_loc.start, .err, .{});
+        try error_builder.msgAtIndex("expected start here", outer_loc.start, .err, .{});
+        return error.LocStartMismatch;
+    }
+
+    if (outer_loc.end != actual_loc.end) {
+        try error_builder.msgAtIndex("actual end here", actual_loc.end, .err, .{});
+        try error_builder.msgAtIndex("expected end here", outer_loc.end, .err, .{});
+        return error.LocEndMismatch;
+    }
+}


### PR DESCRIPTION

This data has been produced by sending 66 inlay hint requests across `AstGen.zig`.

|                | total time | time per request  | speedup compared to master :rocket: |
|----------------|------------|-------------------|------------------------------|
| debug-master |    41730ms |      632ms        |               -              |
| debug-pr      |      582ms |        9.82ms     |             71.7x            |
| safe-master  |     5221ms |       79ms        |               -              |
| safe-pr       |      105ms |        1.59ms     |             49.7x            |
| small-master |     7581ms |      115ms        |               -              |
| small-pr      |      124ms |        1.88ms     |             61.1x            |
| fast-master  |     3452ms |       52ms        |               -              |
| fast-pr       |       95ms |        1.44ms     |             36.3x            |

I've also added some helper function in `Ast.zig` for iterating over node children and finding nodes that contain a certain source range. This could be useful for implementing ranged semantic tokens.
