### PR TITLE
Ignore common editor file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ zig-*
 debug
 release
 *.zlsreplay
+
+# Editor-specific ignores
+.vscode


### PR DESCRIPTION
In theory, this is everyone's own business, and they should add personal excludes to `.git/info/exclude` or to global gitignore. In practice, it's just simpler to add this stuff directly to project's .gitignore