### PR TITLE
Fix handling of invalid tokens in getPositionContext

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -1576,8 +1576,9 @@ pub fn getPositionContext(
                             },
                         };
                     }
-                    const q = std.mem.lastIndexOf(u8, held_line, "\"") orelse return .other;
-                    if (held_line[q -| 1] == '@') {
+                    const s = held_line[tok.loc.start..tok.loc.end];
+                    const q = std.mem.indexOf(u8, s, "\"") orelse return .other;
+                    if (s[q -| 1] == '@') {
                         tok.tag = .identifier;
                     } else {
                         tok.tag = .string_literal;


### PR DESCRIPTION
Fuzz this a few times for good measure .. or/and test with the known principal/`pub const a = @import(""\<request completion here>);`

Cheers,