### PR TITLE
build: add PIE (Position Independent Executable) option

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -26,6 +26,7 @@ pub fn build(b: *std.build.Builder) !void {
     const exe_options = b.addOptions();
     exe.addOptions("build_options", exe_options);
 
+    const pie = b.option(bool, "pie", "Build a Position Independent Executable") orelse false;
     const enable_tracy = b.option(bool, "enable_tracy", "Whether tracy should be enabled.") orelse false;
     const coverage = b.option(bool, "generate_coverage", "Generate coverage data with kcov") orelse false;
     const coverage_output_dir = b.option([]const u8, "coverage_output_dir", "Output directory for coverage data") orelse b.pathJoin(&.{ b.install_prefix, "kcov" });
@@ -154,6 +155,7 @@ pub fn build(b: *std.build.Builder) !void {
         }
     }
 
+    exe.pie = pie;
     exe.install();
 
     const gen_exe = b.addExecutable(.{
@@ -183,7 +185,7 @@ pub fn build(b: *std.build.Builder) !void {
         "test-filter",
         "Skip tests that do not match filter",
     );
-    
+
     var tests = b.addTest(.{
         .root_source_file = .{ .path = "tests/tests.zig" },
         .target = target,

--- a/build.zig
+++ b/build.zig
@@ -26,7 +26,7 @@ pub fn build(b: *std.build.Builder) !void {
     const exe_options = b.addOptions();
     exe.addOptions("build_options", exe_options);
 
-    const pie = b.option(bool, "pie", "Build a Position Independent Executable") orelse false;
+    const pie = b.option(bool, "pie", "Build a Position Independent Executable");
     const enable_tracy = b.option(bool, "enable_tracy", "Whether tracy should be enabled.") orelse false;
     const coverage = b.option(bool, "generate_coverage", "Generate coverage data with kcov") orelse false;
     const coverage_output_dir = b.option([]const u8, "coverage_output_dir", "Output directory for coverage data") orelse b.pathJoin(&.{ b.install_prefix, "kcov" });


### PR DESCRIPTION
This PR adds a `-Dpie=bool` option to `build.zig` for enabling/disabling [PIE](https://en.wikipedia.org/wiki/Position-independent_code) for `zig build` command.
