### PR TITLE
make `diff.edits` memory safe

### DIFF
--- a/tests/utility/diff.zig
+++ b/tests/utility/diff.zig
@@ -1,30 +1,37 @@
 const std = @import("std");
 const zls = @import("zls");
 
-const allocator = std.testing.allocator;
-
 fn gen(alloc: std.mem.Allocator, rand: std.rand.Random) ![]const u8 {
-    var buffer = try alloc.alloc(u8, rand.intRangeAtMost(usize, 16, 1024));
-    for (buffer) |*b| b.* = rand.intRangeAtMost(u8, 32, 126);
+    var buffer = try alloc.alloc(u8, rand.intRangeAtMost(usize, 0, 256));
+    for (buffer) |*b| b.* = rand.intRangeAtMost(u8, ' ', '~');
     return buffer;
 }
 
 test "diff - random" {
-    var arena = std.heap.ArenaAllocator.init(allocator);
-    defer arena.deinit();
-
-    var rand = std.rand.DefaultPrng.init(0);
-
-    var index: usize = 0;
-
-    while (index < 100) : (index += 1) {
-        defer _ = arena.reset(.retain_capacity);
-
-        const pre = try gen(arena.allocator(), rand.random());
-        const post = try gen(arena.allocator(), rand.random());
-
-        var edits = try zls.diff.edits(arena.allocator(), pre, post, .@"utf-8");
-        const applied = try zls.diff.applyTextEdits(arena.allocator(), pre, edits.items, .@"utf-8");
-        try std.testing.expectEqualStrings(post, applied);
+    const allocator = std.testing.allocator;
+    try std.testing.checkAllAllocationFailures(allocator, testDiff, .{ 0, .@"utf-8" });
+    for (0..30) |i| {
+        try testDiff(allocator, i, .@"utf-8");
+        try testDiff(allocator, i, .@"utf-16");
+        try testDiff(allocator, i, .@"utf-32");
     }
+}
+
+fn testDiff(allocator: std.mem.Allocator, seed: u64, encoding: zls.offsets.Encoding) !void {
+    var rand = std.rand.DefaultPrng.init(seed);
+    const before = try gen(allocator, rand.random());
+    defer allocator.free(before);
+    const after = try gen(allocator, rand.random());
+    defer allocator.free(after);
+
+    var edits = try zls.diff.edits(allocator, before, after, encoding);
+    defer {
+        for (edits.items) |edit| allocator.free(edit.newText);
+        edits.deinit(allocator);
+    }
+
+    const applied = try zls.diff.applyTextEdits(allocator, before, edits.items, encoding);
+    defer allocator.free(applied);
+
+    try std.testing.expectEqualStrings(after, applied);
 }


### PR DESCRIPTION
`diff.edits` would leak if you haven't used a `ArenaAllocator`.
I've also adjusted the test to be slightly faster by changing the iteration count and file length.
