### PR TITLE
Optimize analysis backend

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -2418,9 +2418,7 @@ pub fn makeDocumentScope(allocator: std.mem.Allocator, tree: Ast) !DocumentScope
     };
     errdefer document_scope.deinit(allocator);
 
-    // pass root node index ('0')
-    had_root = false;
-    try makeScopeInternal(allocator, .{
+    try makeInnerScope(allocator, .{
         .scopes = &document_scope.scopes,
         .errors = &document_scope.error_completions,
         .enums = &document_scope.enum_completions,
@@ -2490,9 +2488,9 @@ fn makeInnerScope(allocator: std.mem.Allocator, context: ScopeContext, node_idx:
     }
 }
 
-// Whether we have already visited the root node.
-var had_root = true;
 fn makeScopeInternal(allocator: std.mem.Allocator, context: ScopeContext, node_idx: Ast.Node.Index) error{OutOfMemory}!void {
+    if (node_idx == 0) return;
+
     const scopes = context.scopes;
     const tree = context.tree;
     const tags = tree.nodes.items(.tag);
@@ -2501,14 +2499,8 @@ fn makeScopeInternal(allocator: std.mem.Allocator, context: ScopeContext, node_i
     const main_tokens = tree.nodes.items(.main_token);
     const node_tag = tags[node_idx];
 
-    if (node_idx == 0) {
-        if (had_root)
-            return
-        else
-            had_root = true;
-    }
-
     switch (node_tag) {
+        .root => unreachable,
         .container_decl,
         .container_decl_trailing,
         .container_decl_arg,
@@ -2521,7 +2513,6 @@ fn makeScopeInternal(allocator: std.mem.Allocator, context: ScopeContext, node_i
         .tagged_union_two_trailing,
         .tagged_union_enum_tag,
         .tagged_union_enum_tag_trailing,
-        .root,
         => {
             try makeInnerScope(allocator, context, node_idx);
         },

--- a/src/code_actions.zig
+++ b/src/code_actions.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const Ast = std.zig.Ast;
 
 const DocumentStore = @import("DocumentStore.zig");
-const analysis = @import("analysis.zig");
+const Analyser = @import("analysis.zig");
 const ast = @import("ast.zig");
 
 const types = @import("lsp.zig");
@@ -10,7 +10,7 @@ const offsets = @import("offsets.zig");
 
 pub const Builder = struct {
     arena: std.mem.Allocator,
-    document_store: *DocumentStore,
+    analyser: *Analyser,
     handle: *const DocumentStore.Handle,
     offset_encoding: offsets.Encoding,
 
@@ -88,9 +88,7 @@ fn handleUnusedFunctionParameter(builder: *Builder, actions: *std.ArrayListUnman
 
     const token_starts = tree.tokens.items(.start);
 
-    const decl = (try analysis.lookupSymbolGlobal(
-        builder.arena,
-        builder.document_store,
+    const decl = (try builder.analyser.lookupSymbolGlobal(
         builder.handle,
         identifier_name,
         loc.start,
@@ -134,9 +132,7 @@ fn handleUnusedVariableOrConstant(builder: *Builder, actions: *std.ArrayListUnma
     const token_tags = tree.tokens.items(.tag);
     const token_starts = tree.tokens.items(.start);
 
-    const decl = (try analysis.lookupSymbolGlobal(
-        builder.arena,
-        builder.document_store,
+    const decl = (try builder.analyser.lookupSymbolGlobal(
         builder.handle,
         identifier_name,
         loc.start,

--- a/src/zls.zig
+++ b/src/zls.zig
@@ -2,7 +2,7 @@
 //! zigbot9001 to take advantage of zls' tools
 
 pub const ast = @import("ast.zig");
-pub const analysis = @import("analysis.zig");
+pub const Analyser = @import("analysis.zig");
 pub const Header = @import("Header.zig");
 pub const debug = @import("debug.zig");
 pub const offsets = @import("offsets.zig");

--- a/tests/utility/position_context.zig
+++ b/tests/utility/position_context.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const zls = @import("zls");
 
-const analysis = zls.analysis;
+const Analyser = zls.Analyser;
 const types = zls.types;
 const offsets = zls.offsets;
 
@@ -510,12 +510,12 @@ test "position context - empty" {
     );
 }
 
-fn testContext(line: []const u8, tag: std.meta.Tag(analysis.PositionContext), maybe_range: ?[]const u8) !void {
+fn testContext(line: []const u8, tag: std.meta.Tag(Analyser.PositionContext), maybe_range: ?[]const u8) !void {
     const cursor_idx = std.mem.indexOf(u8, line, "<cursor>").?;
     const final_line = try std.mem.concat(allocator, u8, &.{ line[0..cursor_idx], line[cursor_idx + "<cursor>".len ..] });
     defer allocator.free(final_line);
 
-    const ctx = try analysis.getPositionContext(allocator, final_line, cursor_idx, true);
+    const ctx = try Analyser.getPositionContext(allocator, final_line, cursor_idx, true);
 
     if (std.meta.activeTag(ctx) != tag) {
         std.debug.print("Expected tag `{s}`, got `{s}`\n", .{ @tagName(tag), @tagName(std.meta.activeTag(ctx)) });


### PR DESCRIPTION
based on top of #1057
fixes  #536

I've benchmarked the total time required to generate semantic tokens for Sema.zig 20 times in a row.
| Command | Mean [s] | Min [s] | Max [s] | Relative | per request | speedup :rocket: |
|:---|---:|---:|---:|---:|:--:|:--:|
| `./bench-new-debug` | 8.273 ± 0.012 | 8.257 | 8.291 | 6.07 ± 0.08 | 413.65ms | 16.7x |
| `./bench-new-fast` | 1.364 ± 0.017 | 1.346 | 1.383 | 1.00 | 68.2ms | 21.6x |
| `./bench-new-safe` | 1.554 ± 0.012 | 1.537 | 1.569 | 1.14 ± 0.02 | 77.7ms | 21.1x |
| `./bench-new-small` | 1.964 ± 0.008 | 1.954 | 1.975 | 1.44 ± 0.02 | 98.2ms | 17.8x |
| `./bench-old-debug` | 138.830 ± 0.898 | 137.611 | 139.700 | 101.81 ± 1.43 | 6941.5ms | |
| `./bench-old-fast` | 29.566 ± 0.937 | 28.677 | 30.757 | 21.68 ± 0.74 | 1478.3ms | |
| `./bench-old-safe` | 32.906 ± 1.089 | 31.477 | 34.024 | 24.13 ± 0.85 | 1645.3ms | |
| `./bench-old-small` | 35.037 ± 0.845 | 34.158 | 35.969 | 25.69 ± 0.70 | 1751.8ms | |

The actual changes that improved performance are relatively small:
- Calls to `resolveTypeOfNode` are now cached so they never have to be recomputed
- scopes in DocumentScope now stores their parent and child scopes so that variable lookup becomes faster 