### PR TITLE
add cross-file references test infrastructure

### DIFF
--- a/tests/ErrorBuilder.zig
+++ b/tests/ErrorBuilder.zig
@@ -7,78 +7,146 @@ const offsets = zls.offsets;
 const ErrorBuilder = @This();
 
 allocator: std.mem.Allocator,
-items: std.ArrayListUnmanaged(MsgItem) = .{},
-source: []const u8,
+files: std.StringArrayHashMapUnmanaged(File) = .{},
+message_count: usize = 0,
 
-pub fn init(allocator: std.mem.Allocator, source: []const u8) ErrorBuilder {
-    return ErrorBuilder{
-        .allocator = allocator,
-        .source = source,
-    };
+pub fn init(allocator: std.mem.Allocator) ErrorBuilder {
+    return ErrorBuilder{ .allocator = allocator };
 }
 
 pub fn deinit(builder: *ErrorBuilder) void {
-    for (builder.items.items) |item| {
-        builder.allocator.free(item.message);
+    for (builder.files.values()) |*file| {
+        for (file.messages.items) |item| {
+            builder.allocator.free(item.message);
+        }
+        file.messages.deinit(builder.allocator);
     }
-    builder.items.deinit(builder.allocator);
+    builder.files.deinit(builder.allocator);
 }
 
-pub fn msgAtLoc(builder: *ErrorBuilder, comptime fmt: []const u8, loc: offsets.Loc, level: std.log.Level, args: anytype) !void {
-    try builder.items.append(builder.allocator, .{
+/// assumes `name` and `source` outlives the `ErrorBuilder`
+pub fn addFile(builder: *ErrorBuilder, name: []const u8, source: []const u8) error{OutOfMemory}!void {
+    const gop = try builder.files.getOrPutValue(builder.allocator, name, .{ .source = source });
+    if (gop.found_existing)
+        std.debug.panic("file '{s}' already exists", .{name});
+}
+
+pub fn removeFile(builder: *ErrorBuilder, name: []const u8) error{OutOfMemory}!void {
+    const found = builder.files.remove(name);
+    if (!found)
+        std.debug.panic("file '{s}' doesn't exist", .{name});
+    builder.message_count -= found.messages.items.len;
+}
+
+pub fn msgAtLoc(
+    builder: *ErrorBuilder,
+    comptime fmt: []const u8,
+    file_name: []const u8,
+    loc: offsets.Loc,
+    level: std.log.Level,
+    args: anytype,
+) error{OutOfMemory}!void {
+    if (loc.start > loc.end)
+        std.debug.panic("invalid source location {}", .{loc});
+    const file = builder.files.getPtr(file_name) orelse
+        std.debug.panic("file '{s}' doesn't exist", .{file_name});
+    if (loc.end > file.source.len)
+        std.debug.panic("source location {} is outside file source (len: {d})", .{ loc, file.source.len });
+    const message = try std.fmt.allocPrint(builder.allocator, fmt, args);
+    errdefer builder.allocator.free(message);
+
+    try file.messages.append(builder.allocator, .{
         .loc = loc,
         .level = level,
-        .message = try std.fmt.allocPrint(builder.allocator, fmt, args),
+        .message = message,
     });
+    builder.message_count += 1;
 }
 
-pub fn msgAtIndex(builder: *ErrorBuilder, comptime fmt: []const u8, index: usize, level: std.log.Level, args: anytype) !void {
-    return msgAtLoc(builder, fmt, .{ .start = index, .end = index }, level, args);
+pub fn msgAtIndex(
+    builder: *ErrorBuilder,
+    comptime fmt: []const u8,
+    file: []const u8,
+    source_index: usize,
+    level: std.log.Level,
+    args: anytype,
+) error{OutOfMemory}!void {
+    return msgAtLoc(builder, fmt, file, .{ .start = source_index, .end = source_index }, level, args);
 }
 
 pub fn hasMessages(builder: *ErrorBuilder) bool {
-    return builder.items.items.len != 0;
+    return builder.message_count != 0;
 }
 
-pub fn write(builder: *ErrorBuilder, writer: anytype) !void {
-    if (!builder.hasMessages()) return;
-
-    std.sort.sort(MsgItem, builder.items.items, builder, ErrorBuilder.lessThan);
-
-    try writer.writeByte('\n');
-
-    var start: usize = 0;
-    for (builder.items.items) |item| {
-        const line = offsets.lineLocAtIndex(builder.source, item.loc.start);
-        defer start = line.end;
-
-        try writer.writeAll(builder.source[start..line.end]);
-        try writer.writeByte('\n');
-        {
-            var i: usize = line.start;
-            while (i < item.loc.start) : (i += 1) try writer.writeByte(' ');
-            while (i < item.loc.end) : (i += 1) try writer.writeByte('^');
-            if (item.loc.start == item.loc.end) try writer.writeByte('^');
+pub fn clearMessages(builder: *ErrorBuilder) void {
+    for (builder.files.values()) |*file| {
+        for (file.messages.items) |item| {
+            builder.allocator.free(item.message);
         }
-        const level_txt: []const u8 = switch (item.level) {
-            .err => "error",
-            .warn => "warning",
-            .info => "info",
-            .debug => "debug",
-        };
-        try writer.print(" {s}: {s}", .{ level_txt, item.message });
+        file.messages.clearAndFree(builder.allocator);
     }
+    builder.message_count = 0;
+}
 
-    try writer.writeAll(builder.source[start..builder.source.len]);
-    try writer.writeByte('\n');
+pub fn write(builder: *ErrorBuilder, writer: anytype, tty_config: std.debug.TTY.Config) !void {
+    for (builder.files.keys(), builder.files.values()) |file_name, file| {
+        if (file.messages.items.len == 0) continue;
+
+        std.sort.sort(MsgItem, file.messages.items, file.source, ErrorBuilder.lessThan);
+
+        try writer.writeByte('\n');
+        if (builder.files.count() > 1) {
+            try writer.print("{s}:\n", .{file_name});
+        }
+
+        var start: usize = 0;
+        for (file.messages.items) |item| {
+            const line = offsets.lineLocAtIndex(file.source, item.loc.start);
+            defer start = line.end;
+
+            try writer.writeAll(file.source[start..line.end]);
+            try writer.writeByte('\n');
+            for (line.start..item.loc.start) |_| try writer.writeByte(' ');
+            for (item.loc.start..item.loc.end) |_| try writer.writeByte('^');
+            if (item.loc.start == item.loc.end) try writer.writeByte('^');
+
+            const level_txt: []const u8 = switch (item.level) {
+                .err => "error",
+                .warn => "warning",
+                .info => "info",
+                .debug => "debug",
+            };
+            const color: std.debug.TTY.Color = switch (item.level) {
+                .err => .Red,
+                .warn => .Yellow,
+                .info => .White,
+                .debug => .White,
+            };
+            try tty_config.setColor(writer, color);
+            try writer.print(" {s}: ", .{level_txt});
+            try tty_config.setColor(writer, .Reset);
+            try writer.writeAll(item.message);
+        }
+
+        try writer.writeAll(file.source[start..file.source.len]);
+        try writer.writeByte('\n');
+    }
 }
 
 pub fn writeDebug(builder: *ErrorBuilder) void {
-    if (!builder.hasMessages()) return;
     std.debug.getStderrMutex().lock();
     defer std.debug.getStderrMutex().unlock();
-    nosuspend builder.write(std.io.getStdErr().writer()) catch return;
+    const stderr = std.io.getStdErr();
+    const tty_config = std.debug.detectTTYConfig(stderr);
+    // does zig trim the output or why is this needed?
+    stderr.writeAll(" ") catch return;
+    nosuspend builder.write(stderr.writer(), tty_config) catch return;
 }
+
+const File = struct {
+    source: []const u8,
+    messages: std.ArrayListUnmanaged(MsgItem) = .{},
+};
 
 const MsgItem = struct {
     loc: offsets.Loc,
@@ -86,9 +154,9 @@ const MsgItem = struct {
     message: []const u8,
 };
 
-fn lessThan(builder: *ErrorBuilder, lhs: MsgItem, rhs: MsgItem) bool {
+fn lessThan(source: []const u8, lhs: MsgItem, rhs: MsgItem) bool {
     const is_less = lhs.loc.start < rhs.loc.start;
-    const text = if (is_less) builder.source[lhs.loc.start..rhs.loc.start] else builder.source[rhs.loc.start..lhs.loc.start];
+    const text = if (is_less) source[lhs.loc.start..rhs.loc.start] else source[rhs.loc.start..lhs.loc.start];
 
     // report messages on the same line in reverse order
     if (std.mem.indexOfScalar(u8, text, '\n') == null) {

--- a/tests/lsp_features/references.zig
+++ b/tests/lsp_features/references.zig
@@ -56,15 +56,14 @@ test "references - local scope" {
         \\    return <0> + bar;
         \\}
     );
-    if (true) return error.SkipZigTest; // TODO
     try testReferences(
-        \\const foo = blk: {
-        \\    _ = blk: {
+        \\const foo = outer: {
+        \\    _ = inner: {
         \\        const <0> = 0;
-        \\        break :blk <0>;
+        \\        break :inner <0>;
         \\    };
         \\    const <1> = 0;
-        \\    break :blk <1>;
+        \\    break :outer <1>;
         \\};
         \\const bar = foo;
     );

--- a/tests/utility/ast.zig
+++ b/tests/utility/ast.zig
@@ -162,19 +162,22 @@ fn testNodesAtLoc(source: []const u8) !void {
         .end = offsets.nodeToLoc(tree, nodes[nodes.len - 1]).end,
     };
 
-    var error_builder = ErrorBuilder.init(allocator, new_source);
+    const uri = "file.zig";
+    var error_builder = ErrorBuilder.init(allocator);
     defer error_builder.deinit();
     errdefer error_builder.writeDebug();
 
+    try error_builder.addFile(uri, new_source);
+
     if (outer_loc.start != actual_loc.start) {
-        try error_builder.msgAtIndex("actual start here", actual_loc.start, .err, .{});
-        try error_builder.msgAtIndex("expected start here", outer_loc.start, .err, .{});
+        try error_builder.msgAtIndex("actual start here", uri, actual_loc.start, .err, .{});
+        try error_builder.msgAtIndex("expected start here", uri, outer_loc.start, .err, .{});
         return error.LocStartMismatch;
     }
 
     if (outer_loc.end != actual_loc.end) {
-        try error_builder.msgAtIndex("actual end here", actual_loc.end, .err, .{});
-        try error_builder.msgAtIndex("expected end here", outer_loc.end, .err, .{});
+        try error_builder.msgAtIndex("actual end here", uri, actual_loc.end, .err, .{});
+        try error_builder.msgAtIndex("expected end here", uri, outer_loc.end, .err, .{});
         return error.LocEndMismatch;
     }
 }


### PR DESCRIPTION
The ErrorBuilder now supports multiple files as well as the references tests. This should help with targeting #1071 and making sure it stays fixed.