### PR TITLE
do not print error messages in comptime interpreter tests

### DIFF
--- a/tests/language_features/comptime_interpreter.zig
+++ b/tests/language_features/comptime_interpreter.zig
@@ -296,14 +296,7 @@ const Context = struct {
     document_store: *zls.DocumentStore,
     interpreter: *ComptimeInterpreter,
 
-    // this is very annoying and ugly
-    boxed_null: *const ?ZigVersionWrapper,
-
     pub fn init(source: []const u8) !Context {
-        var boxed_null = try allocator.create(?ZigVersionWrapper);
-        errdefer allocator.destroy(boxed_null);
-        boxed_null.* = null;
-
         var config = try allocator.create(zls.Config);
         errdefer allocator.destroy(config);
 
@@ -317,7 +310,7 @@ const Context = struct {
         document_store.* = .{
             .allocator = allocator,
             .config = config,
-            .runtime_zig_version = boxed_null,
+            .runtime_zig_version = &@as(?ZigVersionWrapper, null),
         };
         errdefer document_store.deinit();
 
@@ -345,8 +338,6 @@ const Context = struct {
             .config = config,
             .document_store = document_store,
             .interpreter = interpreter,
-
-            .boxed_null = boxed_null,
         };
     }
 
@@ -357,7 +348,6 @@ const Context = struct {
         allocator.destroy(self.config);
         allocator.destroy(self.document_store);
         allocator.destroy(self.interpreter);
-        allocator.destroy(self.boxed_null);
     }
 
     pub fn call(self: *Context, func_node: Ast.Node.Index, arguments: []const KV) !KV {

--- a/tests/language_features/comptime_interpreter.zig
+++ b/tests/language_features/comptime_interpreter.zig
@@ -338,7 +338,8 @@ const Context = struct {
         };
         errdefer interpreter.deinit();
 
-        _ = try interpretReportErrors(interpreter, 0, .none);
+        _ = try interpreter.interpret(0, .none, .{});
+        // _ = reportErrors(interpreter);
 
         return .{
             .config = config,
@@ -470,13 +471,7 @@ fn expectEqualKey(ip: InternPool, expected: Key, actual: ?Key) !void {
     }
 }
 
-fn interpretReportErrors(
-    interpreter: *ComptimeInterpreter,
-    node_idx: Ast.Node.Index,
-    namespace: InternPool.NamespaceIndex,
-) !ComptimeInterpreter.InterpretResult {
-    const result = interpreter.interpret(node_idx, namespace, .{});
-
+fn reportErrors(interpreter: *ComptimeInterpreter) void {
     // TODO use ErrorBuilder
     var err_it = interpreter.errors.iterator();
     if (interpreter.errors.count() != 0) {
@@ -488,5 +483,4 @@ fn interpretReportErrors(
             std.debug.print("{d}:{d}: {s}\n", .{ position.line, position.character, entry.value_ptr.message });
         }
     }
-    return result;
 }


### PR DESCRIPTION
I've also removed some boilerplate from comptime interpreter test that way annoying me for a while now.