### PR TITLE
disable `.fixall` autofix mode

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -493,7 +493,8 @@ fn getAutofixMode(server: *Server) enum {
     none,
 } {
     if (!server.config.enable_autofix) return .none;
-    if (server.client_capabilities.supports_code_action_fixall) return .fixall;
+    // TODO https://github.com/zigtools/zls/issues/1093
+    // if (server.client_capabilities.supports_code_action_fixall) return .fixall;
     if (server.client_capabilities.supports_apply_edits) {
         if (server.client_capabilities.supports_will_save_wait_until) return .will_save_wait_until;
         return .on_save;


### PR DESCRIPTION
Unti #1093 is properly handled, just disabling .fixall will resolve this by falling back to willSaveWaitUntil in VS-Code.