### PR TITLE
provide more semantic token information + refactor and fixes

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -562,22 +562,8 @@ fn initializeHandler(server: *Server, request: types.InitializeParams) Error!typ
                     .full = .{ .bool = true },
                     .range = .{ .bool = true },
                     .legend = .{
-                        .tokenTypes = comptime block: {
-                            const tokTypeFields = std.meta.fields(semantic_tokens.TokenType);
-                            var names: [tokTypeFields.len][]const u8 = undefined;
-                            for (tokTypeFields, &names) |field, *name| {
-                                name.* = field.name;
-                            }
-                            break :block &names;
-                        },
-                        .tokenModifiers = comptime block: {
-                            const tokModFields = std.meta.fields(semantic_tokens.TokenModifiers);
-                            var names: [tokModFields.len][]const u8 = undefined;
-                            for (tokModFields, &names) |field, *name| {
-                                name.* = field.name;
-                            }
-                            break :block &names;
-                        },
+                        .tokenTypes = std.meta.fieldNames(semantic_tokens.TokenType),
+                        .tokenModifiers = std.meta.fieldNames(semantic_tokens.TokenModifiers),
                     },
                 },
             },

--- a/src/features/semantic_tokens.zig
+++ b/src/features/semantic_tokens.zig
@@ -516,8 +516,10 @@ fn writeNodeTokens(builder: *Builder, node: Ast.Node.Index) error{OutOfMemory}!v
             try writeToken(builder, if_node.ast.if_token, .keyword);
             try callWriteNodeTokens(allocator, .{ builder, if_node.ast.cond_expr });
 
-            if (if_node.payload_token) |payload| {
-                try writeTokenMod(builder, payload, .variable, .{ .declaration = true });
+            if (if_node.payload_token) |payload_token| {
+                const capture_is_ref = token_tags[payload_token] == .asterisk;
+                const actual_payload = payload_token + @boolToInt(capture_is_ref);
+                try writeTokenMod(builder, actual_payload, .variable, .{ .declaration = true });
             }
             try callWriteNodeTokens(allocator, .{ builder, if_node.ast.then_expr });
 

--- a/src/features/semantic_tokens.zig
+++ b/src/features/semantic_tokens.zig
@@ -44,7 +44,6 @@ const Builder = struct {
     analyser: *Analyser,
     handle: *const DocumentStore.Handle,
     previous_source_index: usize = 0,
-    previous_token: ?Ast.TokenIndex = null,
     token_buffer: std.ArrayListUnmanaged(u32) = .{},
     encoding: offsets.Encoding,
     limited: bool,
@@ -595,11 +594,6 @@ fn writeNodeTokens(builder: *Builder, node: Ast.Node.Index) error{OutOfMemory}!v
             try writeToken(builder, call.async_token, .keyword);
             try callWriteNodeTokens(allocator, .{ builder, call.ast.fn_expr });
 
-            if (builder.previous_token) |prev| {
-                if (prev != ast.lastToken(tree, call.ast.fn_expr) and token_tags[ast.lastToken(tree, call.ast.fn_expr)] == .identifier) {
-                    try writeToken(builder, ast.lastToken(tree, call.ast.fn_expr), .function);
-                }
-            }
             for (call.ast.params) |param| try callWriteNodeTokens(allocator, .{ builder, param });
         },
         .slice,

--- a/tests/lsp_features/semantic_tokens.zig
+++ b/tests/lsp_features/semantic_tokens.zig
@@ -197,6 +197,7 @@ test "semantic tokens - operators" {
 }
 
 test "semantic tokens - field access" {
+    if (builtin.target.isWasm()) return error.SkipZigTest;
     // this will make sure that the std module can be resolved
     try testSemanticTokens(
         \\const std = @import("std");

--- a/tests/lsp_features/semantic_tokens.zig
+++ b/tests/lsp_features/semantic_tokens.zig
@@ -202,7 +202,7 @@ test "semantic tokens - field access" {
         \\const std = @import("std");
     , &.{
         .{ "const", .keyword, .{} },
-        .{ "std", .type, .{ .namespace = true, .declaration = true } },
+        .{ "std", .namespace, .{ .declaration = true } },
         .{ "=", .operator, .{} },
         .{ "@import", .builtin, .{} },
         .{ "\"std\"", .string, .{} },
@@ -212,17 +212,17 @@ test "semantic tokens - field access" {
         \\const Ast = std.zig.Ast;
     , &.{
         .{ "const", .keyword, .{} },
-        .{ "std", .type, .{ .namespace = true, .declaration = true } },
+        .{ "std", .namespace, .{ .declaration = true } },
         .{ "=", .operator, .{} },
         .{ "@import", .builtin, .{} },
         .{ "\"std\"", .string, .{} },
 
         .{ "const", .keyword, .{} },
-        .{ "Ast", .type, .{ .@"struct" = true, .declaration = true } },
+        .{ "Ast", .@"struct", .{ .declaration = true } },
         .{ "=", .operator, .{} },
-        .{ "std", .type, .{ .namespace = true } },
-        .{ "zig", .type, .{ .namespace = true } },
-        .{ "Ast", .type, .{ .@"struct" = true } },
+        .{ "std", .namespace, .{} },
+        .{ "zig", .namespace, .{} },
+        .{ "Ast", .@"struct", .{} },
     });
 }
 
@@ -247,7 +247,7 @@ test "semantic tokens - call" {
         \\const alpha = ns.foo();
     , &.{
         .{ "const", .keyword, .{} },
-        .{ "ns", .type, .{ .namespace = true, .declaration = true } },
+        .{ "ns", .namespace, .{ .declaration = true } },
         .{ "=", .operator, .{} },
         .{ "struct", .keyword, .{} },
         .{ "fn", .keyword, .{} },
@@ -257,7 +257,7 @@ test "semantic tokens - call" {
         .{ "const", .keyword, .{} },
         .{ "alpha", .variable, .{ .declaration = true } },
         .{ "=", .operator, .{} },
-        .{ "ns", .type, .{ .namespace = true } },
+        .{ "ns", .namespace, .{} },
         .{ "foo", .function, .{} },
     });
 }
@@ -492,7 +492,7 @@ test "semantic tokens - struct" {
         \\const Foo = struct {};
     , &.{
         .{ "const", .keyword, .{} },
-        .{ "Foo", .type, .{ .namespace = true, .declaration = true } },
+        .{ "Foo", .namespace, .{ .declaration = true } },
         .{ "=", .operator, .{} },
         .{ "struct", .keyword, .{} },
     });
@@ -500,7 +500,7 @@ test "semantic tokens - struct" {
         \\const Foo = packed struct(u32) {};
     , &.{
         .{ "const", .keyword, .{} },
-        .{ "Foo", .type, .{ .namespace = true, .declaration = true } },
+        .{ "Foo", .namespace, .{ .declaration = true } },
         .{ "=", .operator, .{} },
         .{ "packed", .keyword, .{} },
         .{ "struct", .keyword, .{} },
@@ -513,7 +513,7 @@ test "semantic tokens - struct" {
         \\};
     , &.{
         .{ "const", .keyword, .{} },
-        .{ "Foo", .type, .{ .@"struct" = true, .declaration = true } },
+        .{ "Foo", .@"struct", .{ .declaration = true } },
         .{ "=", .operator, .{} },
         .{ "struct", .keyword, .{} },
         .{ "alpha", .property, .{} },
@@ -528,7 +528,7 @@ test "semantic tokens - struct" {
         \\};
     , &.{
         .{ "const", .keyword, .{} },
-        .{ "Foo", .type, .{ .@"struct" = true, .declaration = true } },
+        .{ "Foo", .@"struct", .{ .declaration = true } },
         .{ "=", .operator, .{} },
         .{ "struct", .keyword, .{} },
         .{ "alpha", .property, .{} },
@@ -552,7 +552,7 @@ test "semantic tokens - struct" {
         .{ "=", .operator, .{} },
         .{ "u32", .type, .{} },
         .{ "const", .keyword, .{} },
-        .{ "Foo", .type, .{ .@"struct" = true, .declaration = true } },
+        .{ "Foo", .@"struct", .{ .declaration = true } },
         .{ "=", .operator, .{} },
         .{ "struct", .keyword, .{} },
         .{ "u32", .type, .{} },
@@ -567,7 +567,7 @@ test "semantic tokens - union" {
         \\const Foo = union {};
     , &.{
         .{ "const", .keyword, .{} },
-        .{ "Foo", .type, .{ .@"union" = true, .declaration = true } },
+        .{ "Foo", .@"union", .{ .declaration = true } },
         .{ "=", .operator, .{} },
         .{ "union", .keyword, .{} },
     });
@@ -575,7 +575,7 @@ test "semantic tokens - union" {
         \\const Foo = packed union(enum) {};
     , &.{
         .{ "const", .keyword, .{} },
-        .{ "Foo", .type, .{ .@"union" = true, .declaration = true } },
+        .{ "Foo", .@"union", .{ .declaration = true } },
         .{ "=", .operator, .{} },
         .{ "packed", .keyword, .{} },
         .{ "union", .keyword, .{} },
@@ -588,7 +588,7 @@ test "semantic tokens - union" {
         \\};
     , &.{
         .{ "const", .keyword, .{} },
-        .{ "Foo", .type, .{ .@"union" = true, .declaration = true } },
+        .{ "Foo", .@"union", .{ .declaration = true } },
         .{ "=", .operator, .{} },
         .{ "union", .keyword, .{} },
         .{ "E", .variable, .{} },
@@ -601,7 +601,7 @@ test "semantic tokens - union" {
         \\};
     , &.{
         .{ "const", .keyword, .{} },
-        .{ "Foo", .type, .{ .@"union" = true, .declaration = true } },
+        .{ "Foo", .@"union", .{ .declaration = true } },
         .{ "=", .operator, .{} },
         .{ "union", .keyword, .{} },
         .{ "E", .variable, .{} },
@@ -615,7 +615,7 @@ test "semantic tokens - union" {
         \\};
     , &.{
         .{ "const", .keyword, .{} },
-        .{ "Foo", .type, .{ .@"union" = true, .declaration = true } },
+        .{ "Foo", .@"union", .{ .declaration = true } },
         .{ "=", .operator, .{} },
         .{ "union", .keyword, .{} },
         .{ "E", .variable, .{} },
@@ -632,7 +632,7 @@ test "semantic tokens - enum" {
         \\const Foo = enum {};
     , &.{
         .{ "const", .keyword, .{} },
-        .{ "Foo", .type, .{ .@"enum" = true, .declaration = true } },
+        .{ "Foo", .@"enum", .{ .declaration = true } },
         .{ "=", .operator, .{} },
         .{ "enum", .keyword, .{} },
     });
@@ -643,7 +643,7 @@ test "semantic tokens - enum" {
         \\};
     , &.{
         .{ "const", .keyword, .{} },
-        .{ "Foo", .type, .{ .@"enum" = true, .declaration = true } },
+        .{ "Foo", .@"enum", .{ .declaration = true } },
         .{ "=", .operator, .{} },
         .{ "enum", .keyword, .{} },
         .{ "alpha", .enumMember, .{} },
@@ -653,7 +653,7 @@ test "semantic tokens - enum" {
         \\const Foo = enum(u4) {};
     , &.{
         .{ "const", .keyword, .{} },
-        .{ "Foo", .type, .{ .@"enum" = true, .declaration = true } },
+        .{ "Foo", .@"enum", .{ .declaration = true } },
         .{ "=", .operator, .{} },
         .{ "enum", .keyword, .{} },
         .{ "u4", .type, .{} },
@@ -687,7 +687,7 @@ test "semantic tokens - opaque" {
         \\const Foo = opaque {};
     , &.{
         .{ "const", .keyword, .{} },
-        .{ "Foo", .type, .{ .@"opaque" = true, .declaration = true } },
+        .{ "Foo", .@"opaque", .{ .declaration = true } },
         .{ "=", .operator, .{} },
         .{ "opaque", .keyword, .{} },
     });

--- a/tests/lsp_features/semantic_tokens.zig
+++ b/tests/lsp_features/semantic_tokens.zig
@@ -581,7 +581,6 @@ test "semantic tokens - union" {
         .{ "union", .keyword, .{} },
         .{ "enum", .keyword, .{} },
     });
-    if (true) return error.SkipZigTest; // TODO
     try testSemanticTokens(
         \\const Foo = union(E) {
         \\    alpha,
@@ -607,7 +606,7 @@ test "semantic tokens - union" {
         .{ "E", .variable, .{} },
         .{ "alpha", .property, .{} },
         .{ "beta", .property, .{} },
-        .{ "void", .keyword, .{} },
+        .{ "void", .type, .{} },
     });
     try testSemanticTokens(
         \\const Foo = union(E) {
@@ -620,14 +619,13 @@ test "semantic tokens - union" {
         .{ "union", .keyword, .{} },
         .{ "E", .variable, .{} },
         .{ "alpha", .property, .{} },
-        .{ "void", .keyword, .{} },
+        .{ "void", .type, .{} },
         .{ "align", .keyword, .{} },
         .{ "2", .number, .{} },
     });
 }
 
 test "semantic tokens - enum" {
-    if (true) return error.SkipZigTest; // TODO
     try testSemanticTokens(
         \\const Foo = enum {};
     , &.{
@@ -638,7 +636,7 @@ test "semantic tokens - enum" {
     });
     try testSemanticTokens(
         \\const Foo = enum {
-        \\    alpha,
+        \\    alpha = 3,
         \\    beta,
         \\};
     , &.{
@@ -647,6 +645,8 @@ test "semantic tokens - enum" {
         .{ "=", .operator, .{} },
         .{ "enum", .keyword, .{} },
         .{ "alpha", .enumMember, .{} },
+        .{ "=", .operator, .{} },
+        .{ "3", .number, .{} },
         .{ "beta", .enumMember, .{} },
     });
     try testSemanticTokens(

--- a/tests/lsp_features/semantic_tokens.zig
+++ b/tests/lsp_features/semantic_tokens.zig
@@ -516,9 +516,9 @@ test "semantic tokens - struct" {
         .{ "Foo", .type, .{ .@"struct" = true, .declaration = true } },
         .{ "=", .operator, .{} },
         .{ "struct", .keyword, .{} },
-        .{ "alpha", .field, .{} },
+        .{ "alpha", .property, .{} },
         .{ "u32", .type, .{} },
-        .{ "beta", .field, .{} },
+        .{ "beta", .property, .{} },
         .{ "void", .type, .{} },
     });
     try testSemanticTokens(
@@ -531,12 +531,12 @@ test "semantic tokens - struct" {
         .{ "Foo", .type, .{ .@"struct" = true, .declaration = true } },
         .{ "=", .operator, .{} },
         .{ "struct", .keyword, .{} },
-        .{ "alpha", .field, .{} },
+        .{ "alpha", .property, .{} },
         .{ "u32", .type, .{} },
         .{ "=", .operator, .{} },
         .{ "3", .number, .{} },
         .{ "comptime", .keyword, .{} },
-        .{ "beta", .field, .{} },
+        .{ "beta", .property, .{} },
         .{ "void", .type, .{} },
         .{ "=", .operator, .{} },
     });
@@ -592,7 +592,7 @@ test "semantic tokens - union" {
         .{ "=", .operator, .{} },
         .{ "union", .keyword, .{} },
         .{ "E", .variable, .{} },
-        .{ "alpha", .field, .{} },
+        .{ "alpha", .property, .{} },
     });
     try testSemanticTokens(
         \\const Foo = union(E) {
@@ -605,8 +605,8 @@ test "semantic tokens - union" {
         .{ "=", .operator, .{} },
         .{ "union", .keyword, .{} },
         .{ "E", .variable, .{} },
-        .{ "alpha", .field, .{} },
-        .{ "beta", .field, .{} },
+        .{ "alpha", .property, .{} },
+        .{ "beta", .property, .{} },
         .{ "void", .keyword, .{} },
     });
     try testSemanticTokens(
@@ -619,7 +619,7 @@ test "semantic tokens - union" {
         .{ "=", .operator, .{} },
         .{ "union", .keyword, .{} },
         .{ "E", .variable, .{} },
-        .{ "alpha", .field, .{} },
+        .{ "alpha", .property, .{} },
         .{ "void", .keyword, .{} },
         .{ "align", .keyword, .{} },
         .{ "2", .number, .{} },

--- a/tests/lsp_features/semantic_tokens.zig
+++ b/tests/lsp_features/semantic_tokens.zig
@@ -226,6 +226,42 @@ test "semantic tokens - field access" {
     });
 }
 
+test "semantic tokens - call" {
+    try testSemanticTokens(
+        \\fn foo() void {}
+        \\const alpha = foo();
+    , &.{
+        .{ "fn", .keyword, .{} },
+        .{ "foo", .function, .{ .declaration = true } },
+        .{ "void", .type, .{} },
+
+        .{ "const", .keyword, .{} },
+        .{ "alpha", .variable, .{ .declaration = true } },
+        .{ "=", .operator, .{} },
+        .{ "foo", .function, .{} },
+    });
+    try testSemanticTokens(
+        \\const ns = struct {
+        \\    fn foo() void {}
+        \\};
+        \\const alpha = ns.foo();
+    , &.{
+        .{ "const", .keyword, .{} },
+        .{ "ns", .type, .{ .namespace = true, .declaration = true } },
+        .{ "=", .operator, .{} },
+        .{ "struct", .keyword, .{} },
+        .{ "fn", .keyword, .{} },
+        .{ "foo", .function, .{ .declaration = true } },
+        .{ "void", .type, .{} },
+
+        .{ "const", .keyword, .{} },
+        .{ "alpha", .variable, .{ .declaration = true } },
+        .{ "=", .operator, .{} },
+        .{ "ns", .type, .{ .namespace = true } },
+        .{ "foo", .function, .{} },
+    });
+}
+
 test "semantic tokens - catch" {
     try testSemanticTokens(
         \\var alpha = a catch b;

--- a/tests/lsp_features/semantic_tokens.zig
+++ b/tests/lsp_features/semantic_tokens.zig
@@ -15,7 +15,6 @@ test "semantic tokens - empty" {
 }
 
 test "semantic tokens - comment" {
-    if (true) return error.SkipZigTest; // TODO
     try testSemanticTokens(
         \\// hello world
     , &.{
@@ -26,6 +25,14 @@ test "semantic tokens - comment" {
         \\
     , &.{
         .{ "//! hello world", .comment, .{ .documentation = true } },
+    });
+    try testSemanticTokens(
+        \\//! first line
+        \\//! second line
+        \\
+    , &.{
+        .{ "//! first line", .comment, .{ .documentation = true } },
+        .{ "//! second line", .comment, .{ .documentation = true } },
     });
     try testSemanticTokens(
         \\/// hello world

--- a/tests/lsp_features/semantic_tokens.zig
+++ b/tests/lsp_features/semantic_tokens.zig
@@ -808,6 +808,16 @@ test "semantic tokens - if" {
         .{ "err", .variable, .{ .declaration = true } },
         .{ "err", .variable, .{} },
     });
+    try testSemanticTokens(
+        \\const foo = if (null) |*value| {};
+    , &.{
+        .{ "const", .keyword, .{} },
+        .{ "foo", .variable, .{ .declaration = true } },
+        .{ "=", .operator, .{} },
+        .{ "if", .keyword, .{} },
+        .{ "null", .keywordLiteral, .{} },
+        .{ "value", .variable, .{ .declaration = true } },
+    });
 }
 
 test "semantic tokens - while" {


### PR DESCRIPTION
these changes had a visible effect depending on the theme used:
- whether or not something is a namespace, struct, union, etc. is now set with a `TokenType` instead of `TokenModifiers`
- container fields that are named after a keyword were previously highlighted like an identifier

fixes #843

Here is how the above changed have affected highlighting.

Before |After
|:--------:|:--------:|
VS-Code "Default Dark+" | VS-Code "Default Dark+"
![](https://user-images.githubusercontent.com/19954306/229207849-8c9e07b7-30da-4283-a890-e6d8731c04c9.png)  |  ![](https://user-images.githubusercontent.com/19954306/229207854-c3f5243f-c381-48e8-ad8c-3644fe000692.png)
VS-Code "Monokai" | VS-Code "Monokai"
![](https://user-images.githubusercontent.com/19954306/229209575-9ffe42de-4ecc-44a0-a361-7f34588ff622.png) | ![](https://user-images.githubusercontent.com/19954306/229209570-147db3e3-ada6-481b-b646-30148ea0e376.png)
Sublime Text 4 "Default Dark" | Sublime Text 4 "Default Dark"
![](https://user-images.githubusercontent.com/19954306/229216161-b74e1691-8935-45ff-9d09-052fdca6fc59.png) | ![](https://user-images.githubusercontent.com/19954306/229216158-a8d30f7f-e0a2-436a-98e8-f4c5dc6e5421.png)



