### PR TITLE
Avoid accessing inactive union fields in `completeDot`

### DIFF
--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -872,6 +872,10 @@ fn completeDot(server: *Server, handle: *const DocumentStore.Handle, source_inde
             if (maybe_decl) |local_decl| {
                 const nodes_tags = handle.tree.nodes.items(.tag);
                 const nodes_data = handle.tree.nodes.items(.data);
+                switch (local_decl.decl.*) {
+                    .ast_node => {},
+                    else => break :struct_init,
+                }
                 const node_data = nodes_data[local_decl.decl.ast_node];
                 if (node_data.rhs != 0) {
                     switch (nodes_tags[node_data.rhs]) {


### PR DESCRIPTION
As reported on Discord by CodotakuYT:
```zig
fn populate(T: type, index: i32) T {
    _ = index;
    @typeInfo(T).struct.
}
```
```
thread 17384 panic: access of union field 'ast_node' while field 'param_payload' is active
C:\Users\taoua\zls\src\features\completions.zig:875:61: 0x7ff68070caac in completeDot (zls.exe.obj)
                const node_data = nodes_data[local_decl.decl.ast_node];
```