### PR TITLE
Use plain text if the client tells zls it's preferred

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -399,6 +399,9 @@ fn initializeHandler(server: *Server, request: types.InitializeParams) Error!typ
         if (textDocument.hover) |hover| {
             if (hover.contentFormat) |content_format| {
                 for (content_format) |format| {
+                    if (format == .plaintext) {
+                        break;
+                    }
                     if (format == .markdown) {
                         server.client_capabilities.hover_supports_md = true;
                         break;
@@ -412,6 +415,9 @@ fn initializeHandler(server: *Server, request: types.InitializeParams) Error!typ
                 server.client_capabilities.supports_snippets = completionItem.snippetSupport orelse false;
                 if (completionItem.documentationFormat) |documentation_format| {
                     for (documentation_format) |format| {
+                        if (format == .plaintext) {
+                            break;
+                        }
                         if (format == .markdown) {
                             server.client_capabilities.completion_doc_supports_md = true;
                             break;


### PR DESCRIPTION
LSP clients send a list of supported formats for definition and completion; the specification says "the order describes the preferred format of the client."[1]

My client sends:

	'hover': {'contentFormat': ['plaintext', 'markdown']},

So it should prefer plaintext, using markdown if that's not supported by the server. zls behaved slightly different: it would use Markdown if it appears at all in the list of supported formats.

This fixes it so that it will use plain text if that appears before 'markdown' in the list.

[1]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_hover