### PR TITLE
flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -29,12 +29,15 @@
       }
     },
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1678901627,
-        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
         "type": "github"
       },
       "original": {
@@ -92,11 +95,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1679410443,
-        "narHash": "sha256-xDHO/jixWD+y5pmW5+2q4Z4O/I/nA4MAa30svnZKK+M=",
+        "lastModified": 1681272286,
+        "narHash": "sha256-9X5p+gwYrowgbsRgkf14HFI0fkr6UikuwRIQAMlF1yI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c9ece0059f42e0ab53ac870104ca4049df41b133",
+        "rev": "6b70761ea8c896aff8994eb367d9526686501860",
         "type": "github"
       },
       "original": {
@@ -115,6 +118,21 @@
         "nixpkgs": "nixpkgs",
         "tres": "tres",
         "zig-overlay": "zig-overlay"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     },
     "tres": {
@@ -138,11 +156,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1679486902,
-        "narHash": "sha256-bGyKUZTnZeXHVrA1J5bBuurXyVM48/gVN5hEBMePxFM=",
+        "lastModified": 1681345266,
+        "narHash": "sha256-OWtRArUMtFHkbnJeaQCSBzo9P7c9CHlt14YIOP8fP8Q=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "10704a6e0705a7e5494a6baa8086c4eb88940db0",
+        "rev": "320441bdd26a344d97020cb19f17983ed972923b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
I got this error when trying to compile ZLS:
```Your Zig version v0.11.0-dev.2227+f9b582950 does not meet the minimum build requirement of v0.11.0-dev.2558+d3a237a98```

Updating the flake seems to fix the issue.