### PR TITLE
Implement $/setTrace and add --enable-message-tracing

### DIFF
--- a/tests/context.zig
+++ b/tests/context.zig
@@ -41,7 +41,7 @@ pub const Context = struct {
 
         config.* = default_config;
 
-        const server = try Server.create(allocator, config, null, false, false);
+        const server = try Server.create(allocator, config, null, false, false, false);
         errdefer server.destroy();
 
         var context: Context = .{


### PR DESCRIPTION
Added this to verify some messages my emacs LSP client was sending.

Note: vscode always sets this to "off" due to: https://github.com/ziglang/vscode-zig/issues/99