### PR TITLE
Mem fixes

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -7,7 +7,7 @@ const zls_version = std.builtin.Version{ .major = 0, .minor = 11, .patch = 0 };
 pub fn build(b: *std.build.Builder) !void {
     comptime {
         const current_zig = builtin.zig_version;
-        const min_zig = std.SemanticVersion.parse("0.11.0-dev.2571+31738de28") catch unreachable; // add c_char - https://github.com/ziglang/zig/pull/15263
+        const min_zig = std.SemanticVersion.parse("0.11.0-dev.2730+bd801dc48") catch unreachable; // gpa.deinit() now returns an enum
         if (current_zig.order(min_zig) == .lt) {
             @compileError(std.fmt.comptimePrint("Your Zig version v{} does not meet the minimum build requirement of v{}", .{ current_zig, min_zig }));
         }

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -1549,6 +1549,7 @@ pub fn create(
     message_tracing_enabled: bool,
 ) !*Server {
     const server = try allocator.create(Server);
+    errdefer server.destroy();
     server.* = Server{
         .config = config,
         .runtime_zig_version = null,

--- a/src/main.zig
+++ b/src/main.zig
@@ -164,7 +164,7 @@ fn getConfig(
 ) !ConfigWithPath {
     if (config_path) |path| {
         if (configuration.loadFromFile(allocator, path)) |config| {
-            return ConfigWithPath{ .config = config, .config_path = path };
+            return ConfigWithPath{ .config = config, .config_path = try allocator.dupe(u8, path) };
         }
         std.debug.print(
             \\Could not open configuration file '{s}'
@@ -357,7 +357,7 @@ const stack_frames = switch (zig_builtin.mode) {
 
 pub fn main() !void {
     var gpa_state = std.heap.GeneralPurposeAllocator(.{ .stack_trace_frames = stack_frames }){};
-    defer std.debug.assert(!gpa_state.deinit());
+    defer std.debug.assert(gpa_state.deinit() == .ok);
 
     var tracy_state = if (tracy.enable_allocation) tracy.tracyAllocator(gpa_state.allocator()) else void{};
     const inner_allocator: std.mem.Allocator = if (tracy.enable_allocation) tracy_state.allocator() else gpa_state.allocator();


### PR DESCRIPTION
* `gpa.deinit()` now returns an enum (Zig `0.11.0-dev.2730+`)
* avoid double free when `--config-path` is specified
* avoid leaking memory in `Server.create` if `configChanged` returns err

These fixes reveal a discrepancy — `main.getConfig` expects `--config-path` to be a path to file, a `zls.json`, while
`Server.configChanged` expects it to be a `/path/to/dir` (`builtin_creation_dir`).