### PR TITLE
Update `config_gen` and data

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -7,7 +7,7 @@ const zls_version = std.builtin.Version{ .major = 0, .minor = 11, .patch = 0 };
 pub fn build(b: *std.build.Builder) !void {
     comptime {
         const current_zig = builtin.zig_version;
-        const min_zig = std.SemanticVersion.parse("0.11.0-dev.2730+bd801dc48") catch unreachable; // gpa.deinit() now returns an enum
+        const min_zig = std.SemanticVersion.parse("0.11.0-dev.2835+7285eedcd") catch unreachable; // std.http: do -> wait, fix redirects
         if (current_zig.order(min_zig) == .lt) {
             @compileError(std.fmt.comptimePrint("Your Zig version v{} does not meet the minimum build requirement of v{}", .{ current_zig, min_zig }));
         }

--- a/src/config_gen/config_gen.zig
+++ b/src/config_gen/config_gen.zig
@@ -969,7 +969,7 @@ fn httpGET(allocator: std.mem.Allocator, uri: std.Uri) !Response {
 
     try request.start();
     // try request.finish();
-    try request.do();
+    try request.wait();
 
     if (request.response.status.class() != .success) {
         return .{
@@ -984,7 +984,7 @@ fn httpGET(allocator: std.mem.Allocator, uri: std.Uri) !Response {
 
 pub fn main() !void {
     var general_purpose_allocator = std.heap.GeneralPurposeAllocator(.{}){};
-    defer std.debug.assert(!general_purpose_allocator.deinit());
+    defer std.debug.assert(general_purpose_allocator.deinit() == .ok);
     var gpa = general_purpose_allocator.allocator();
 
     var stderr = std.io.getStdErr().writer();

--- a/src/data/master.zig
+++ b/src/data/master.zig
@@ -391,7 +391,7 @@ pub const builtins = [_]Builtin{
         \\
         \\`operand` may be an [integer](https://ziglang.org/documentation/master/#Integers) or [vector](https://ziglang.org/documentation/master/#Vectors).
         \\
-        \\This function counts the number of most-significant (leading in a big-Endian sense) zeroes in an integer.
+        \\Counts the number of most-significant (leading in a big-endian sense) zeroes in an integer - "count leading zeroes".
         \\
         \\If `operand` is a [comptime](https://ziglang.org/documentation/master/#comptime)-known integer, the return type is `comptime_int`. Otherwise, the return type is an unsigned integer or vector of unsigned integers with the minimum number of bits that can represent the bit count of the integer type.
         \\
@@ -542,7 +542,7 @@ pub const builtins = [_]Builtin{
         \\
         \\`operand` may be an [integer](https://ziglang.org/documentation/master/#Integers) or [vector](https://ziglang.org/documentation/master/#Vectors).
         \\
-        \\This function counts the number of least-significant (trailing in a big-Endian sense) zeroes in an integer.
+        \\Counts the number of least-significant (trailing in a big-endian sense) zeroes in an integer - "count trailing zeroes".
         \\
         \\If `operand` is a [comptime](https://ziglang.org/documentation/master/#comptime)-known integer, the return type is `comptime_int`. Otherwise, the return type is an unsigned integer or vector of unsigned integers with the minimum number of bits that can represent the bit count of the integer type.
         \\
@@ -946,14 +946,25 @@ pub const builtins = [_]Builtin{
         \\The following packages are always available:
         \\
         \\ - `@import("std")` - Zig Standard Library
-        \\ - `@import("builtin")` - Target-specific information. The command
+        \\ - `@import("builtin")` - Target-specific information The command
         \\`zig build-exe --show-builtin`outputs the source to stdout for reference.
-        \\ - `@import("root")` - Points to the root source file. This is usually
-        \\`src/main.zig`but it depends on what file is chosen to be built.
+        \\ - `@import("root")` - Root source file This is usually
+        \\`src/main.zig`but depends on what file is built.
         ,
         .arguments = &.{
             "comptime path: []u8",
         },
+    },
+    .{
+        .name = "@inComptime",
+        .signature = "@inComptime() bool",
+        .snippet = "@inComptime()",
+        .documentation =
+        \\Returns whether the builtin was run in a `comptime` context. The result is a compile-time constant.
+        \\
+        \\This can be used to provide alternative, comptime-friendly implementations of functions. It should not be used, for instance, to exclude certain functions from being evaluated at comptime.
+        ,
+        .arguments = &.{},
     },
     .{
         .name = "@intCast",
@@ -1203,7 +1214,7 @@ pub const builtins = [_]Builtin{
         \\
         \\`operand` may be an [integer](https://ziglang.org/documentation/master/#Integers) or [vector](https://ziglang.org/documentation/master/#Vectors).
         \\
-        \\Counts the number of bits set in an integer.
+        \\Counts the number of bits set in an integer - "population count".
         \\
         \\If `operand` is a [comptime](https://ziglang.org/documentation/master/#comptime)-known integer, the return type is `comptime_int`. Otherwise, the return type is an unsigned integer or vector of unsigned integers with the minimum number of bits that can represent the bit count of the integer type.
         ,
@@ -1228,6 +1239,8 @@ pub const builtins = [_]Builtin{
         \\pub const PrefetchOptions = struct {
         \\    /// Whether the prefetch should prepare for a read or a write.
         \\    rw: Rw = .read,
+        \\    /// The data's locality in an inclusive range from 0 to 3.
+        \\    ///
         \\    /// 0 means no temporal locality. That is, the data can be immediately
         \\    /// dropped from the cache after it is accessed.
         \\    ///
@@ -1236,11 +1249,11 @@ pub const builtins = [_]Builtin{
         \\    locality: u2 = 3,
         \\    /// The cache that the prefetch should be preformed on.
         \\    cache: Cache = .data,
-        \\    pub const Rw = enum {
+        \\    pub const Rw = enum(u1) {
         \\        read,
         \\        write,
         \\    };
-        \\    pub const Cache = enum {
+        \\    pub const Cache = enum(u1) {
         \\        instruction,
         \\        data,
         \\    };


### PR DESCRIPTION
While this was up, another breaking change kicked in — std.http fixes !

PR now also 
* changes `req.do()` -> `req.wait()`
* ups min zig version