### PR TITLE
Update config to highlight danger of the comptime interpreter

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The following options are currently available.
 | `operator_completions` | `bool` | `true` | Enables `*` and `?` operators in completion lists |
 | `warn_style` | `bool` | `false` | Enables warnings for style guideline mismatches |
 | `highlight_global_var_declarations` | `bool` | `false` | Whether to highlight global var declarations |
-| `use_comptime_interpreter` | `bool` | `false` | Whether to use the comptime interpreter |
+| `dangerous_comptime_experiments_do_not_enable` | `bool` | `false` | Whether to use the comptime interpreter |
 | `include_at_in_builtins` | `bool` | `false` | Whether the @ sign should be part of the completion of builtins |
 | `skip_std_references` | `bool` | `false` | When true, skips searching for references in std. Improves lookup speed for functions in user's code. Renaming and go-to-definition will continue to work as is |
 | `max_detail_length` | `usize` | `1048576` | The detail field of completions is truncated to be no longer than this (in bytes) |

--- a/schema.json
+++ b/schema.json
@@ -74,7 +74,7 @@
             "type": "boolean",
             "default": "false"
         },
-        "use_comptime_interpreter": {
+        "dangerous_comptime_experiments_do_not_enable": {
             "description": "Whether to use the comptime interpreter",
             "type": "boolean",
             "default": "false"

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -50,7 +50,7 @@ warn_style: bool = false,
 highlight_global_var_declarations: bool = false,
 
 /// Whether to use the comptime interpreter
-use_comptime_interpreter: bool = false,
+dangerous_comptime_experiments_do_not_enable: bool = false,
 
 /// Whether the @ sign should be part of the completion of builtins
 include_at_in_builtins: bool = false,

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -653,7 +653,7 @@ pub fn isTypeIdent(text: []const u8) bool {
         .{"type"},         .{"anyerror"},
         .{"comptime_int"}, .{"comptime_float"},
         .{"anyframe"},     .{"anytype"},
-        .{"c_char"}
+        .{"c_char"},
     });
 
     if (PrimitiveTypes.has(text)) return true;
@@ -810,7 +810,7 @@ fn resolveTypeOfNodeUncached(analyser: *Analyser, node_handle: NodeWithHandle) e
                 const body = decl.handle.tree.nodes.items(.data)[decl_node].rhs;
                 if (try analyser.resolveReturnType(fn_decl, decl.handle, if (has_body) body else null)) |ret| {
                     return ret;
-                } else if (analyser.store.config.use_comptime_interpreter) {
+                } else if (analyser.store.config.dangerous_comptime_experiments_do_not_enable) {
                     // TODO: Better case-by-case; we just use the ComptimeInterpreter when all else fails,
                     // probably better to use it more liberally
                     // TODO: Handle non-isolate args; e.g. `const T = u8; TypeFunc(T);`

--- a/src/config_gen/config.json
+++ b/src/config_gen/config.json
@@ -84,7 +84,7 @@
             "default": "false"
         },
         {
-            "name": "use_comptime_interpreter",
+            "name": "dangerous_comptime_experiments_do_not_enable",
             "description": "Whether to use the comptime interpreter",
             "type": "bool",
             "default": "false"


### PR DESCRIPTION
This should fix #1126

All the files (besides `analysis.zig` and `src/config_gen/config.json`) have been updated via `zig build gen`

I also added a `,` in order to preserve the formatting with autofix enabled.