### PR TITLE
 Fix panic caused by custom zls.json path

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -1569,7 +1569,12 @@ pub fn create(
     };
     server.analyser = Analyser.init(allocator, &server.document_store);
 
-    try configuration.configChanged(config, &server.runtime_zig_version, allocator, config_path);
+    var builtin_creation_dir = config_path;
+    if (config_path) |path| {
+        builtin_creation_dir = std.fs.path.dirname(path);
+    }
+
+    try configuration.configChanged(config, &server.runtime_zig_version, allocator, builtin_creation_dir);
 
     if (config.dangerous_comptime_experiments_do_not_enable) {
         server.analyser.ip = try analyser.InternPool.init(allocator);

--- a/src/configuration.zig
+++ b/src/configuration.zig
@@ -130,7 +130,11 @@ pub fn configChanged(config: *Config, runtime_zig_version: *?ZigVersionWrapper, 
         defer allocator.free(result.stdout);
         defer allocator.free(result.stderr);
 
-        var d = try std.fs.cwd().openDir(builtin_creation_dir.?, .{});
+        var d = if (std.fs.path.isAbsolute(builtin_creation_dir.?))
+            try std.fs.openDirAbsolute(builtin_creation_dir.?, .{})
+         else
+            try std.fs.cwd().openDir(builtin_creation_dir.?, .{})
+        ;
         defer d.close();
 
         const f = d.createFile("builtin.zig", .{}) catch |err| switch (err) {

--- a/src/configuration.zig
+++ b/src/configuration.zig
@@ -130,11 +130,7 @@ pub fn configChanged(config: *Config, runtime_zig_version: *?ZigVersionWrapper, 
         defer allocator.free(result.stdout);
         defer allocator.free(result.stderr);
 
-        var d = if (std.fs.path.isAbsolute(builtin_creation_dir.?))
-            try std.fs.openDirAbsolute(builtin_creation_dir.?, .{})
-         else
-            try std.fs.cwd().openDir(builtin_creation_dir.?, .{})
-        ;
+        var d = try std.fs.cwd().openDir(builtin_creation_dir.?, .{});
         defer d.close();
 
         const f = d.createFile("builtin.zig", .{}) catch |err| switch (err) {


### PR DESCRIPTION
Resolve https://github.com/zigtools/zls/issues/1170. 

If `builtin_path` is set to `null` in zls.json, then the same directory as zls.json will be used.

Support:

- relative path, e.g. `./zls.json` 
- absolute path, e.g. `/tmp/zls.json`


