### PR TITLE
Added std.zig.number_literal.Error.invalid_hex_exponent rule

### DIFF
--- a/src/stage2/AstGen.zig
+++ b/src/stage2/AstGen.zig
@@ -7628,6 +7628,7 @@ fn failWithNumberError(astgen: *AstGen, err: std.zig.number_literal.Error, token
         .invalid_underscore_after_special => |i| return astgen.failOff(token, @intCast(u32, i), "expected digit before digit separator", .{}),
         .invalid_digit => |info| return astgen.failOff(token, @intCast(u32, info.i), "invalid digit '{c}' for {s} base", .{ bytes[info.i], @tagName(info.base) }),
         .invalid_digit_exponent => |i| return astgen.failOff(token, @intCast(u32, i), "invalid digit '{c}' in exponent", .{bytes[i]}),
+        .invalid_hex_exponent => |i| return astgen.failOff(token, @intCast(u32, i), "invalid hexadecimal '{x}' in exponent", .{bytes[i]}),
         .duplicate_exponent => |i| return astgen.failOff(token, @intCast(u32, i), "duplicate exponent", .{}),
         .exponent_after_underscore => |i| return astgen.failOff(token, @intCast(u32, i), "expected digit before exponent", .{}),
         .special_after_underscore => |i| return astgen.failOff(token, @intCast(u32, i), "expected digit before '{c}'", .{bytes[i]}),


### PR DESCRIPTION
Added simple support for a new field in `std.zig.number_literal.Error` for zig version `0.11.0-dev`.

This missing field in the switch breaks compilation.