### PR TITLE
build.zig: Update minimum Zig version

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -7,7 +7,7 @@ const zls_version = std.builtin.Version{ .major = 0, .minor = 11, .patch = 0 };
 pub fn build(b: *std.build.Builder) !void {
     comptime {
         const current_zig = builtin.zig_version;
-        const min_zig = std.SemanticVersion.parse("0.11.0-dev.2861+3c66850e4") catch unreachable; // std.http: do -> wait, fix redirects
+        const min_zig = std.SemanticVersion.parse("0.11.0-dev.3003+e1f5ad3cc") catch unreachable; // std.http: do -> wait, fix redirects
         if (current_zig.order(min_zig) == .lt) {
             @compileError(std.fmt.comptimePrint("Your Zig version v{} does not meet the minimum build requirement of v{}", .{ current_zig, min_zig }));
         }

--- a/flake.lock
+++ b/flake.lock
@@ -95,11 +95,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1682716666,
-        "narHash": "sha256-RGKVQ6pt12VWzJ0vPTLTdsmsyTfsfL4WYgLztE2ZACg=",
+        "lastModified": 1683594133,
+        "narHash": "sha256-iUhLhEAgOCnexSGDsYT2ouydis09uDoNzM7UC685XGE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "358a179550508bf2dafdf1657a94b7f65d91c4bf",
+        "rev": "8d447c5626cfefb9b129d5b30103344377fe09bc",
         "type": "github"
       },
       "original": {
@@ -156,11 +156,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1682727718,
-        "narHash": "sha256-Iv6BccjYkbh8QJdm2pFhH5kPVI0Z4WluvXQanqhNg9g=",
+        "lastModified": 1683635864,
+        "narHash": "sha256-ZeRXwznwKZrVArp7mtf6uZXmTk2/5eeW1StqQkBHul8=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "f555394c03b10e455b465a6c657c5a6ddd89c5a8",
+        "rev": "7b05e01b76b1776859170ab9a8fe55e412cf17a1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
It looks like https://github.com/ziglang/zig/pull/15485 caused breakage for ZLS and https://github.com/zigtools/zls/pull/1178 addressed it without updating the minimum supported version or the Nix Flake lockfile.