### PR TITLE
Update tracy to 0.9.1

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -35,8 +35,8 @@ pub fn build(b: *std.build.Builder) !void {
     exe_options.addOption(shared.ZigVersion, "data_version", b.option(shared.ZigVersion, "data_version", "The Zig version your compiler is.") orelse .master);
     exe_options.addOption(std.log.Level, "log_level", b.option(std.log.Level, "log_level", "The Log Level to be used.") orelse .info);
     exe_options.addOption(bool, "enable_tracy", enable_tracy);
-    exe_options.addOption(bool, "enable_tracy_allocation", b.option(bool, "enable_tracy_allocation", "Enable using TracyAllocator to monitor allocations.") orelse false);
-    exe_options.addOption(bool, "enable_tracy_callstack", b.option(bool, "enable_tracy_callstack", "Enable callstack graphs.") orelse false);
+    exe_options.addOption(bool, "enable_tracy_allocation", b.option(bool, "enable_tracy_allocation", "Enable using TracyAllocator to monitor allocations.") orelse enable_tracy);
+    exe_options.addOption(bool, "enable_tracy_callstack", b.option(bool, "enable_tracy_callstack", "Enable callstack graphs.") orelse enable_tracy);
     exe_options.addOption(bool, "enable_failing_allocator", b.option(bool, "enable_failing_allocator", "Whether to use a randomly failing allocator.") orelse false);
     exe_options.addOption(u32, "enable_failing_allocator_likelihood", b.option(u32, "enable_failing_allocator_likelihood", "The chance that an allocation will fail is `1/likelihood`") orelse 256);
 

--- a/build.zig
+++ b/build.zig
@@ -89,7 +89,7 @@ pub fn build(b: *std.build.Builder) !void {
     exe.addModule("diffz", diffz_module);
 
     if (enable_tracy) {
-        const client_cpp = "src/tracy/TracyClient.cpp";
+        const client_cpp = "src/tracy/public/TracyClient.cpp";
 
         // On mingw, we need to opt into windows 7+ to get some features required by tracy.
         const tracy_c_flags: []const []const u8 = if (target.isWindows() and target.getAbi() == .gnu)


### PR DESCRIPTION
`enable_tracy_allocation` and `enable_tracy_callstack` will also be enabled by default when using tracy which matches zig's behavior.