### PR TITLE
fix semantic token generation crash on continue expression

### DIFF
--- a/src/features/semantic_tokens.zig
+++ b/src/features/semantic_tokens.zig
@@ -701,13 +701,16 @@ fn writeNodeTokens(builder: *Builder, node: Ast.Node.Index) error{OutOfMemory}!v
         .grouped_expression => {
             try callWriteNodeTokens(allocator, .{ builder, node_data[node].lhs });
         },
-        .@"break",
-        .@"continue",
-        => {
+        .@"break" => {
             try writeToken(builder, main_token, .keyword);
             if (node_data[node].lhs != 0)
                 try writeToken(builder, node_data[node].lhs, .label);
             try callWriteNodeTokens(allocator, .{ builder, node_data[node].rhs });
+        },
+        .@"continue" => {
+            try writeToken(builder, main_token, .keyword);
+            if (node_data[node].lhs != 0)
+                try writeToken(builder, node_data[node].lhs, .label);
         },
         .@"suspend", .@"return" => {
             try writeToken(builder, main_token, .keyword);


### PR DESCRIPTION
the `rhs` field of a continue node has an undefined value.
fixes #1183
fixes #1175