### PR TITLE
Replace nonexistent `std.sort.sort` with `std.mem.sort`

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -1142,7 +1142,7 @@ fn inlayHintHandler(server: *Server, request: types.InlayHintParams) Error!?[]ty
         }
     };
 
-    std.sort.sort(inlay_hints.InlayHint, hints, {}, helper.lessThan);
+    std.mem.sort(inlay_hints.InlayHint, hints, {}, helper.lessThan);
 
     var last_index: usize = 0;
     var last_position: types.Position = .{ .line = 0, .character = 0 };

--- a/src/diff.zig
+++ b/src/diff.zig
@@ -125,7 +125,7 @@ pub fn applyTextEdits(
     defer allocator.free(text_edits_sortable);
 
     std.mem.copy(types.TextEdit, text_edits_sortable, text_edits);
-    std.sort.sort(types.TextEdit, text_edits_sortable, {}, textEditLessThan);
+    std.mem.sort(types.TextEdit, text_edits_sortable, {}, textEditLessThan);
 
     var final_text = std.ArrayListUnmanaged(u8){};
     errdefer final_text.deinit(allocator);

--- a/src/features/document_symbol.zig
+++ b/src/features/document_symbol.zig
@@ -171,7 +171,7 @@ fn convertSymbols(
     const result = convertSymbolsInternal(from, &symbol_buffer, &mappings);
 
     // sort items based on their source position
-    std.sort.sort(IndexToPositionEntry, mappings.items, {}, IndexToPositionEntry.lessThan);
+    std.mem.sort(IndexToPositionEntry, mappings.items, {}, IndexToPositionEntry.lessThan);
 
     var last_index: usize = 0;
     var last_position: types.Position = .{ .line = 0, .character = 0 };

--- a/src/features/folding_range.zig
+++ b/src/features/folding_range.zig
@@ -93,7 +93,7 @@ const Builder = struct {
         }
 
         // sort mappings based on their source index
-        std.sort.sort(IndexToPositionEntry, mappings, {}, IndexToPositionEntry.lessThan);
+        std.mem.sort(IndexToPositionEntry, mappings, {}, IndexToPositionEntry.lessThan);
 
         var last_index: usize = 0;
         var last_position: types.Position = .{ .line = 0, .character = 0 };

--- a/src/features/selection_range.zig
+++ b/src/features/selection_range.zig
@@ -37,7 +37,7 @@ pub fn generateSelectionRanges(
             }
         }
 
-        std.sort.sort(offsets.Loc, locs.items, {}, shorterLocsFirst);
+        std.mem.sort(offsets.Loc, locs.items, {}, shorterLocsFirst);
         {
             var i: usize = 0;
             while (i + 1 < locs.items.len) {

--- a/tests/ErrorBuilder.zig
+++ b/tests/ErrorBuilder.zig
@@ -92,7 +92,7 @@ pub fn write(builder: *ErrorBuilder, writer: anytype, tty_config: std.debug.TTY.
     for (builder.files.keys(), builder.files.values()) |file_name, file| {
         if (file.messages.items.len == 0) continue;
 
-        std.sort.sort(MsgItem, file.messages.items, file.source, ErrorBuilder.lessThan);
+        std.mem.sort(MsgItem, file.messages.items, file.source, ErrorBuilder.lessThan);
 
         try writer.writeByte('\n');
         if (builder.files.count() > 1) {

--- a/tests/ErrorBuilder.zig
+++ b/tests/ErrorBuilder.zig
@@ -88,7 +88,7 @@ pub fn clearMessages(builder: *ErrorBuilder) void {
     builder.message_count = 0;
 }
 
-pub fn write(builder: *ErrorBuilder, writer: anytype, tty_config: std.debug.TTY.Config) !void {
+pub fn write(builder: *ErrorBuilder, writer: anytype, tty_config: std.io.tty.Config) !void {
     for (builder.files.keys(), builder.files.values()) |file_name, file| {
         if (file.messages.items.len == 0) continue;
 
@@ -116,15 +116,15 @@ pub fn write(builder: *ErrorBuilder, writer: anytype, tty_config: std.debug.TTY.
                 .info => "info",
                 .debug => "debug",
             };
-            const color: std.debug.TTY.Color = switch (item.level) {
-                .err => .Red,
-                .warn => .Yellow,
-                .info => .White,
-                .debug => .White,
+            const color: std.io.tty.Color = switch (item.level) {
+                .err => .red,
+                .warn => .yellow,
+                .info => .white,
+                .debug => .white,
             };
             try tty_config.setColor(writer, color);
             try writer.print(" {s}: ", .{level_txt});
-            try tty_config.setColor(writer, .Reset);
+            try tty_config.setColor(writer, .reset);
             try writer.writeAll(item.message);
         }
 
@@ -137,7 +137,7 @@ pub fn writeDebug(builder: *ErrorBuilder) void {
     std.debug.getStderrMutex().lock();
     defer std.debug.getStderrMutex().unlock();
     const stderr = std.io.getStdErr();
-    const tty_config = std.debug.detectTTYConfig(stderr);
+    const tty_config = std.io.tty.detectConfig(stderr);
     // does zig trim the output or why is this needed?
     stderr.writeAll(" ") catch return;
     nosuspend builder.write(stderr.writer(), tty_config) catch return;


### PR DESCRIPTION
The pull request ziglang/zig#15412 changes the sorting functions built into Zig and as a result `std.sort.sort` doesn't exist anymore. This pull request changes usages of `std.sort.sort` to `std.mem.sort` which is consistent with the changes made in the standard library to change `std.sort.sort` to `std.mem.sort`. Currently, `std.mem.sort` calls `std.sort.block`, which is an stable in-place sort with $`O(n)`$ best case, $`O(n\log(n))`$ worst case, and $`O(n\log(n))`$ average case time complexity. The block sort also has $`O(1)`$ memory usage.