### PR TITLE
Fix `configuration.getConfigurationType` returning non null values

### DIFF
--- a/src/configuration.zig
+++ b/src/configuration.zig
@@ -226,6 +226,7 @@ fn getConfigurationType() type {
                 .Optional = .{ .child = field.type },
             });
         }
+        new_field.default_value = &@as(new_field.type, null);
     }
     config_info.Struct.fields = fields[0..];
     config_info.Struct.decls = &.{};


### PR DESCRIPTION
The function would change the `Config` struct fields' type to optional but keep a non null value which led to `Server.didChangeConfigurationHandler` assigning unintended values to `server.config`.

Tested with Neovim 0.10, 
```
require('lsp-setup').setup({
    servers = {
        zls = {
            settings = {
--                zls = {
                    enable_inlay_hints = true,
                    inlay_hints_show_builtin = true,
                    inlay_hints_exclude_single_argument = true,
                    inlay_hints_hide_redundant_param_names = false,
                    inlay_hints_hide_redundant_param_names_last_token = false,
--                }
            }
        },
    },
```

Before
```
info : (message): received:{\"jsonrpc\":\"2.0\",\"method\":\"workspace\\/didChangeConfiguration\",\"params\":{\"settings\":{\"enable_inlay_hints\":true,\"inlay_hints_show_builtin\":true,\"inlay_hints_exclude_single_argument\":true,\"inlay_hints_hide_redundant_param_names\":false,\"inlay_hints_hide_redundant_param_names_last_token\":false}}}
debug: (server): setting configuration option 'enable_snippets' to 'false'
debug: (server): setting configuration option 'enable_ast_check_diagnostics' to 'false'
debug: (server): setting configuration option 'enable_autofix' to 'false'
debug: (server): setting configuration option 'enable_import_embedfile_argument_completions' to 'false'
debug: (server): setting configuration option 'semantic_tokens' to 'Config.Config__enum_6037.none'
debug: (server): setting configuration option 'enable_inlay_hints' to 'true'
debug: (server): setting configuration option 'inlay_hints_show_builtin' to 'true'
debug: (server): setting configuration option 'inlay_hints_exclude_single_argument' to 'true
debug: (server): setting configuration option 'inlay_hints_hide_redundant_param_names' to 'false'
debug: (server): setting configuration option 'inlay_hints_hide_redundant_param_names_last_token' to 'false'
debug: (server): setting configuration option 'operator_completions' to 'false'
debug: (server): setting configuration option 'max_detail_length' to '0'
debug: (server): setting configuration option 'prefer_ast_check_as_child_process' to 'false'
```

After
```
info : (message): received: {\"params\":{\"settings\":{\"inlay_hints_hide_redundant_param_names_last_token\":false,\"enable_inlay_hints\":true,\"inlay_hints_show_builtin\":true,\"inlay_hints_exclude_single_argument\":true,\"inlay_hints_hide_redundant_param_names\":false}},\"method\":\"workspace\\/didChangeConfiguration\",\"jsonrpc\":\"2.0\"}
debug: (server): setting configuration option 'enable_inlay_hints' to 'true'
debug: (server): setting configuration option 'inlay_hints_show_builtin' to 'true'
debug: (server): setting configuration option 'inlay_hints_exclude_single_argument' to 'true'
debug: (server): setting configuration option 'inlay_hints_hide_redundant_param_names' to 'false'
debug: (server): setting configuration option 'inlay_hints_hide_redundant_param_names_last_token' to 'false'
```

Fixes #1111