### PR TITLE
`executeBuildRunner`: increase `.max_output_bytes`

### DIFF
--- a/src/DocumentStore.zig
+++ b/src/DocumentStore.zig
@@ -505,6 +505,7 @@ pub fn executeBuildRunner(
         .allocator = allocator,
         .argv = args,
         .cwd = build_file_directory_path,
+        .max_output_bytes = 1024 * 100,
     });
 }
 


### PR DESCRIPTION
Why:
`error: (store ): Failed to load build configuration for file:///home/rad/lab/zig/build.zig (error: error.StdoutStreamTooLong)`

What:
The project is the Zig compiler source.

Note:
[The debug log of stdout](https://zigbin.io/fe2bee) - maybe some dedup logic is in order?