### PR TITLE
autofix now handles comments in the event of a newline w/ comments

### DIFF
--- a/src/features/code_actions.zig
+++ b/src/features/code_actions.zig
@@ -183,9 +183,16 @@ fn handleUnusedCapture(
     // look for next non-whitespace after last '|'. if its a '{' we can insert discards.
     // this means bare loop/switch captures (w/out curlies) aren't supported.
     var block_start = capture_loc.end + 1;
-    while (block_start < builder.handle.text.len and
-        std.ascii.isWhitespace(builder.handle.text[block_start])) : (block_start += 1)
-    {}
+    var is_comment = false;
+    while (block_start < builder.handle.text.len) : (block_start += 1)
+    {
+        //If the next two characters are // then its a comment
+        if(builder.handle.text[block_start] == '/' and builder.handle.text[block_start + 1] == '/') is_comment = true;
+        // if we go to a new line, drop the is_comment boolean
+        if(builder.handle.text[block_start] == '\n' and is_comment) is_comment = false;
+        //If the character is not a whitespace, and we're not in a comment then break out of the loop
+        if(!std.ascii.isWhitespace(builder.handle.text[block_start]) and !is_comment) break;
+    }
     if (builder.handle.text[block_start] != '{') {
         return;
     }

--- a/tests/lsp_features/code_actions.zig
+++ b/tests/lsp_features/code_actions.zig
@@ -81,6 +81,25 @@ test "code actions - discard captures" {
     );
 }
 
+test "code actions - discard capture with comment" {
+    try testAutofix(
+        \\test {
+        \\  if (1 == 1) |a|
+        \\      //a
+        \\      {}
+        \\}
+    ,
+        \\test {
+        \\    if (1 == 1) |a|
+        \\    //a
+        \\    {
+        \\        _ = a;
+        \\    }
+        \\}
+        \\
+    );
+}
+
 test "code actions - remove pointless discard" {
     try testAutofix(
         \\fn foo(a: u32) u32 {


### PR DESCRIPTION
This expands slightly on the implementation which currently checks to see if there was a non whitespace character by:
- checking to see if there is a comment
- if there is a comment, wait until there is a newline before caring about whether or not there is a non-whitespace character

This should cover the basis of needing to handle comments, and if there are comments from line to line that should also be fine