### PR TITLE
Fixed compatibility with latest builds of Zig

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -12,8 +12,8 @@
             .hash = "12204d32c44b494c0cbe553811dedfb7a73da37b13b492872dd4edc0340983072697",
         },
         .diffz = .{
-            .url = "https://github.com/ziglibs/diffz/archive/b966296b4489eb082b0831ec9a37d6f5e1906040.tar.gz",
-            .hash = "1220ed4aed884221108ad39f2658b69a91653e0bbc8ce429bc7f1bc4e58f6a751553",
+            .url = "https://github.com/ziglibs/diffz/archive/2fd03fc72760a700e41f30f2b180f26e11c3365b.tar.gz",
+            .hash = "1220de3226674f638ef4afcc919d121e06207a868cd163b24426b55d77c1048fc608",
         },
         .binned_allocator = .{
             .url = "https://gist.github.com/silversquirl/c1e4840048fdf48e669b6eac76d80634/archive/8bbe137e65f26854ff936046d884a45d4fa156de.tar.gz",

--- a/src/analyser/InternPool.zig
+++ b/src/analyser/InternPool.zig
@@ -3023,8 +3023,8 @@ test "float value" {
     const f32_nan_value = try ip.get(gpa, .{ .float_32_value = std.math.nan_f32 });
     const f32_qnan_value = try ip.get(gpa, .{ .float_32_value = std.math.qnan_f32 });
 
-    const f32_inf_value = try ip.get(gpa, .{ .float_32_value = std.math.inf_f32 });
-    const f32_ninf_value = try ip.get(gpa, .{ .float_32_value = -std.math.inf_f32 });
+    const f32_inf_value = try ip.get(gpa, .{ .float_32_value = std.math.inf(f32) });
+    const f32_ninf_value = try ip.get(gpa, .{ .float_32_value = -std.math.inf(f32) });
 
     const f32_zero_value = try ip.get(gpa, .{ .float_32_value = 0.0 });
     const f32_nzero_value = try ip.get(gpa, .{ .float_32_value = -0.0 });

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -792,7 +792,7 @@ fn resolveTypeOfNodeUncached(analyser: *Analyser, node_handle: NodeWithHandle) e
                 }
 
                 // Bind type params to the arguments passed in the call.
-                const param_len = std.math.min(call.ast.params.len, expected_params);
+                const param_len = @min(call.ast.params.len, expected_params);
                 var i: usize = 0;
                 while (ast.nextFnParam(&it)) |decl_param| : (i += 1) {
                     if (i >= param_len) break;


### PR DESCRIPTION
# Problem
`std.math.min`,
`std.math.max`,
`std.math.inf_f32`
Have been removed from the zig standard library and replaced with `@compileError`

# Solution
Replaced them with `@min`, `@max`, and `std.math.inf(f32)` respectively.

# Testing
This fix compiles and all tests with `zig build test` run properly under both `0.11.0-dev.3658+5d9e8f27d` and `0.11.0-dev.3678+f043071cd` when both this fix and the fix in diffz are applied. (latest versions on the website and the zig git repo as of writing this PR)

## Notes
Related to: https://github.com/ziglibs/diffz/pull/13