### PR TITLE
improve self param detection in inlay hints

### DIFF
--- a/src/features/inlay_hints.zig
+++ b/src/features/inlay_hints.zig
@@ -87,7 +87,10 @@ fn writeCallHint(builder: *Builder, call: Ast.full.Call, decl_handle: Analyser.D
     var i: usize = 0;
     var it = fn_proto.iterate(&decl_tree);
 
-    if (try builder.analyser.hasSelfParam(decl_handle.handle, fn_proto)) {
+    if (tree.tokens.items(.tag)[call.ast.lparen - 2] == .period and
+        call.ast.params.len + 1 == fn_proto.ast.params.len and
+        try builder.analyser.hasSelfParam(decl_handle.handle, fn_proto))
+    {
         _ = ast.nextFnParam(&it);
     }
 

--- a/tests/lsp_features/inlay_hints.zig
+++ b/tests/lsp_features/inlay_hints.zig
@@ -48,6 +48,18 @@ test "inlayhints - function self parameter" {
         \\const foo: Foo = .{};
         \\const _ = foo.bar(<alpha>5,<beta>"");
     );
+    try testInlayHints(
+        \\const Foo = struct { pub fn bar(self: Foo, alpha: u32, beta: []const u8) void {} };
+        \\const _ = Foo.bar(<self>undefined,<alpha>5,<beta>"");
+    );
+    try testInlayHints(
+        \\const Foo = struct {
+        \\  pub fn bar(self: Foo, alpha: u32, beta: []const u8) void {}
+        \\  pub fn foo() void {
+        \\      bar(<self>undefined,<alpha>5,<beta>"");
+        \\  }
+        \\};
+    );
 }
 
 test "inlayhints - builtin call" {


### PR DESCRIPTION
without a clear reproducer I can only suspect that this fi-xes #1240, fixes #1256