### PR TITLE
Resolve type of simple labeled block

### DIFF
--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -509,6 +509,17 @@ test "completion - block" {
     , &.{
         .{ .label = "blk", .kind = .Text }, // idk what kind this should be
     });
+
+    try testCompletion(
+        \\const S = struct { alpha: u32 };
+        \\const foo: S = undefined;
+        \\const bar = blk: {
+        \\    break :blk foo;
+        \\};
+        \\const baz = bar.<cursor>
+    , &.{
+        .{ .label = "alpha", .kind = .Field, .detail = "alpha: u32" },
+    });
 }
 
 fn testCompletion(source: []const u8, expected_completions: []const Completion) !void {


### PR DESCRIPTION
For example, the following snippet is found in [`std.testing`](https://github.com/ziglang/zig/blob/a5e15ec/lib/std/testing.zig):

```zig
pub var allocator_instance = b: {
    if (!builtin.is_test)
        @compileError("Cannot use testing allocator outside of test block");
    break :b std.heap.GeneralPurposeAllocator(.{}){};
};
```