### PR TITLE
fix timeout in ZCS receiveMessage

### DIFF
--- a/src/translate_c.zig
+++ b/src/translate_c.zig
@@ -236,12 +236,10 @@ pub fn translate(
                 const body_size = @sizeOf(std.zig.Server.Message.EmitBinPath);
                 if (header.bytes_len <= body_size) return error.InvalidResponse;
 
-                const trailing_size = header.bytes_len - body_size;
-
                 _ = try zcs.receiveEmitBinPath();
 
-                const result_path = try zcs.receiveBytes(allocator, trailing_size);
-                defer allocator.free(result_path);
+                const trailing_size = header.bytes_len - body_size;
+                const result_path = zcs.pooler.fifo(.in).readableSliceOfLen(trailing_size);
 
                 return Result{ .success = try URI.fromPath(allocator, std.mem.sliceTo(result_path, '\n')) };
             },

--- a/tests/language_features/cimport.zig
+++ b/tests/language_features/cimport.zig
@@ -9,9 +9,6 @@ const translate_c = zls.translate_c;
 const allocator: std.mem.Allocator = std.testing.allocator;
 
 test "zig compile server - translate c" {
-    // FIXME: Disabled due to https://github.com/zigtools/zls/issues/1252
-    if (@import("builtin").os.tag == .windows) return error.SkipZigTest;
-
     var result1 = try testTranslate(
         \\void foo(int);
         \\void bar(float*);


### PR DESCRIPTION
I may be wrong, but I think I finally understand `std.io.Poller`
fixes #1252