### PR TITLE
fix completions on non-exhaustive enums

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -2729,7 +2729,7 @@ fn makeInnerScope(context: ScopeContext, tree: Ast, node_idx: Ast.Node.Index) er
         if ((node_idx != 0 and token_tags[container_decl.ast.main_token] == .keyword_enum) or
             container_decl.ast.enum_token != null)
         {
-            if (std.mem.eql(u8, name, "_")) return;
+            if (std.mem.eql(u8, name, "_")) continue;
 
             const doc = try getDocComments(allocator, tree, decl, .markdown);
             errdefer if (doc) |d| allocator.free(d);

--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -330,9 +330,11 @@ fn declToCompletion(context: DeclToCompletionContext, decl_handle: Analyser.Decl
     const tree = decl_handle.handle.tree;
     const decl = decl_handle.decl.*;
 
+    const name = tree.tokenSlice(decl_handle.nameToken());
+    if (std.mem.eql(u8, name, "_")) return;
+
     const is_cimport = std.mem.eql(u8, std.fs.path.basename(decl_handle.handle.uri), "cimport.zig");
     if (is_cimport) {
-        const name = tree.tokenSlice(decl_handle.nameToken());
         if (std.mem.startsWith(u8, name, "_")) return;
         // TODO figuring out which declarations should be excluded could be made more complete and accurate
         // by translating an empty file to acquire all exclusions
@@ -371,11 +373,11 @@ fn declToCompletion(context: DeclToCompletionContext, decl_handle: Analyser.Decl
             } } else null;
 
             try context.completions.append(allocator, .{
-                .label = tree.tokenSlice(param.name_token.?),
+                .label = name,
                 .kind = .Constant,
                 .documentation = doc,
                 .detail = ast.paramSlice(tree, param),
-                .insertText = tree.tokenSlice(param.name_token.?),
+                .insertText = name,
                 .insertTextFormat = .PlainText,
             });
         },
@@ -385,8 +387,6 @@ fn declToCompletion(context: DeclToCompletionContext, decl_handle: Analyser.Decl
         .switch_payload,
         .label_decl,
         => {
-            const name = tree.tokenSlice(decl_handle.nameToken());
-
             try context.completions.append(allocator, .{
                 .label = name,
                 .kind = if (decl == .label_decl) .Text else .Variable,
@@ -395,8 +395,6 @@ fn declToCompletion(context: DeclToCompletionContext, decl_handle: Analyser.Decl
             });
         },
         .error_token => {
-            const name = tree.tokenSlice(decl_handle.decl.error_token);
-
             try context.completions.append(allocator, .{
                 .label = name,
                 .kind = .Constant,

--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -310,6 +310,25 @@ test "completion - enum" {
         .{ .label = "alpha", .kind = .EnumMember },
         .{ .label = "beta", .kind = .EnumMember },
     });
+    try testCompletion(
+        \\const E = enum {
+        \\    _,
+        \\    fn inner(_: E) void {} 
+        \\};
+        \\const foo = E.<cursor>
+    , &.{
+        .{ .label = "inner", .kind = .Function, .detail = "fn inner(_: E) void" },
+    });
+    try testCompletion(
+        \\const E = enum {
+        \\    _,
+        \\    fn inner(_: E) void {} 
+        \\};
+        \\const e: E = undefined;
+        \\const foo = e.<cursor>
+    , &.{
+        .{ .label = "inner", .kind = .Function, .detail = "fn inner(_: E) void" },
+    });
 }
 
 test "completion - error union" {


### PR DESCRIPTION
bug introduced in 3f2700eaa525e00f7efeaaf057cd055d398df01d. fixes #1266
I've also added a check that removes all declarations that are named `_` from completions. I don't think someone who names something `_` would want it to be used that is why I excluded it from completions.
