### PR TITLE
Remove desitination type param from cast builtins (update to compile using zig master)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -7,7 +7,7 @@ const zls_version = std.SemanticVersion{ .major = 0, .minor = 11, .patch = 0 };
 pub fn build(b: *std.build.Builder) !void {
     comptime {
         const current_zig = builtin.zig_version;
-        const min_zig = std.SemanticVersion.parse("0.11.0-dev.3737+9eb008717") catch unreachable; // std.builtin.Version -> std.SemanticVersion
+        const min_zig = std.SemanticVersion.parse("0.11.0-dev.3834+d98147414") catch unreachable; // std.builtin.Version -> std.SemanticVersion
         if (current_zig.order(min_zig) == .lt) {
             @compileError(std.fmt.comptimePrint("Your Zig version v{} does not meet the minimum build requirement of v{}", .{ current_zig, min_zig }));
         }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,20 +4,20 @@
 
     .dependencies = .{
         .known_folders = .{
-            .url = "https://github.com/ziglibs/known-folders/archive/d13ba6137084e55f873f6afb67447fe8906cc951.tar.gz",
-            .hash = "122028c00915d9b37296059be8a3883c718dbb5bd174350caedf152fed1f46f99607",
+            .url = "https://github.com/ziglibs/known-folders/archive/d070896807cbbd2847d24d561438994504b929dd.tar.gz",
+            .hash = "122001a81a0ba2faca0271d53c50e8069721fe66a19d71dd8498e61fa26d7ca6f558",
         },
         .tres = .{
-            .url = "https://github.com/ziglibs/tres/archive/67d5b6305135d15ea84024e447c9070ce14fa5d0.tar.gz",
-            .hash = "1220b23398142f65003da68986b8e7b015720d4b62f7bcb5f73a111c9220422658f6",
+            .url = "https://github.com/ziglibs/tres/archive/9ca9cd547d10d30984565399dec92068fefd7ad2.tar.gz",
+            .hash = "122026823fb890736435cb5ddbfdf5691d4b9d4759ab1147f245beced0abec17c483",
         },
         .diffz = .{
-            .url = "https://github.com/ziglibs/diffz/archive/df02d432be9b40d55b5d7de5c1c53ec80aad6d5d.tar.gz",
-            .hash = "122041f6531ee2cd10e7d5f81817c50b45037affc95d748cbcd71a766866fb6030d4",
+            .url = "https://github.com/ziglibs/diffz/archive/90353d401c59e2ca5ed0abe5444c29ad3d7489aa.tar.gz",
+            .hash = "122089a8247a693cad53beb161bde6c30f71376cd4298798d45b32740c3581405864",
         },
         .binned_allocator = .{
-            .url = "https://gist.github.com/FalsePattern/48fded613c115e16e91c46db8642c7e4/archive/75e3d5e6a0e0cf23dbf7abfe16831e23c38721bc.tar.gz",
-            .hash = "1220ba896ddd4258eed9274b36284d4cc4600ee69c4c0978cbe237ec09a524a2e252",
+            .url = "https://gist.github.com/antlilja/8372900fcc09e38d7b0b6bbaddad3904/archive/6c3321e0969ff2463f8335da5601986cf2108690.tar.gz",
+            .hash = "1220363c7e27b2d3f39de6ff6e90f9537a0634199860fea237a55ddb1e1717f5d6a5",
         },
     },
 }

--- a/src/ComptimeInterpreter.zig
+++ b/src/ComptimeInterpreter.zig
@@ -195,7 +195,7 @@ pub fn interpret(
                 .node_idx = node_idx,
                 .ty = .none,
             });
-            const container_namespace = @enumFromInt(Namespace.Index, interpreter.namespaces.len - 1);
+            const container_namespace = @as(Namespace.Index, @enumFromInt(interpreter.namespaces.len - 1));
 
             const struct_index = try interpreter.ip.createStruct(interpreter.allocator, .{
                 .fields = .{},
@@ -324,7 +324,7 @@ pub fn interpret(
                 .node_idx = node_idx,
                 .ty = .none,
             });
-            const block_namespace = @enumFromInt(Namespace.Index, interpreter.namespaces.len - 1);
+            const block_namespace = @as(Namespace.Index, @enumFromInt(interpreter.namespaces.len - 1));
 
             var buffer: [2]Ast.Node.Index = undefined;
             const statements = ast.blockStatements(tree, node_idx, &buffer).?;
@@ -1236,7 +1236,7 @@ pub fn call(
         .node_idx = func_node_idx,
         .ty = .none,
     });
-    const fn_namespace = @enumFromInt(Namespace.Index, interpreter.namespaces.len - 1);
+    const fn_namespace = @as(Namespace.Index, @enumFromInt(interpreter.namespaces.len - 1));
 
     var arg_it = proto.iterate(&tree);
     var arg_index: usize = 0;

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -21,7 +21,7 @@ semantic_tokens: enum {
     none,
     partial,
     full,
-
+    
     pub const tres_string_enum = true;
 } = .full,
 

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -1092,7 +1092,7 @@ pub fn generalReferencesHandler(server: *Server, request: GeneralReferencesReque
 
             // TODO can we avoid having to move map from `changes` to `new_changes`?
             var new_changes: types.Map(types.DocumentUri, []const types.TextEdit) = .{};
-            try new_changes.ensureTotalCapacity(allocator, @intCast(u32, changes.count()));
+            try new_changes.ensureTotalCapacity(allocator, @intCast(changes.count()));
 
             var changes_it = changes.iterator();
             while (changes_it.next()) |entry| {

--- a/src/ZigCompileServer.zig
+++ b/src/ZigCompileServer.zig
@@ -98,7 +98,7 @@ pub fn serveMessage(
     var iovecs: [10]std.os.iovec_const = undefined;
     const header_le = bswap(header);
     iovecs[0] = .{
-        .iov_base = @ptrCast([*]const u8, &header_le),
+        .iov_base = @as([*]const u8, @ptrCast(&header_le)),
         .iov_len = @sizeOf(OutMessage.Header),
     };
     for (bufs, iovecs[1 .. bufs.len + 1]) |buf, *iovec| {
@@ -115,7 +115,7 @@ fn bswap(x: anytype) @TypeOf(x) {
 
     const T = @TypeOf(x);
     switch (@typeInfo(T)) {
-        .Enum => return @enumFromInt(T, @byteSwap(@intFromEnum(x))),
+        .Enum => return @as(T, @enumFromInt(@byteSwap(@intFromEnum(x)))),
         .Int => return @byteSwap(x),
         .Struct => |info| switch (info.layout) {
             .Extern => {
@@ -127,7 +127,7 @@ fn bswap(x: anytype) @TypeOf(x) {
             },
             .Packed => {
                 const I = info.backing_integer.?;
-                return @bitCast(T, @byteSwap(@bitCast(I, x)));
+                return @as(T, @bitCast(@byteSwap(@as(I, @bitCast(x)))));
             },
             .Auto => @compileError("auto layout struct"),
         },
@@ -148,7 +148,7 @@ fn bswap_and_workaround_u32(bytes_ptr: *const [4]u8) u32 {
 /// workaround for https://github.com/ziglang/zig/issues/14904
 fn bswap_and_workaround_tag(bytes_ptr: *const [4]u8) InMessage.Tag {
     const int = std.mem.readIntLittle(u32, bytes_ptr);
-    return @enumFromInt(InMessage.Tag, int);
+    return @as(InMessage.Tag, @enumFromInt(int));
 }
 
 const OutMessage = std.zig.Client.Message;

--- a/src/ast.zig
+++ b/src/ast.zig
@@ -270,7 +270,7 @@ pub fn forSimple(tree: Ast, node: Node.Index) full.For {
 
 pub fn forFull(tree: Ast, node: Node.Index) full.For {
     const data = tree.nodes.items(.data)[node];
-    const extra = @bitCast(Node.For, data.rhs);
+    const extra = @as(Node.For, @bitCast(data.rhs));
     const inputs = tree.extra_data[data.lhs..][0..extra.inputs];
     const then_expr = tree.extra_data[data.lhs + extra.inputs];
     const else_expr = if (extra.has_else) tree.extra_data[data.lhs + extra.inputs + 1] else 0;
@@ -327,7 +327,7 @@ pub fn lastToken(tree: Ast, node: Ast.Node.Index) Ast.TokenIndex {
     var n = node;
     var end_offset: TokenIndex = 0;
     while (true) switch (tags[n]) {
-        .root => return @intCast(TokenIndex, tree.tokens.len - 1),
+        .root => return @as(TokenIndex, @intCast(tree.tokens.len - 1)),
         .@"usingnamespace" => {
             // lhs is the expression
             if (datas[n].lhs == 0) {
@@ -963,7 +963,7 @@ pub fn lastToken(tree: Ast, node: Ast.Node.Index) Ast.TokenIndex {
             n = extra.else_expr;
         },
         .@"for" => {
-            const extra = @bitCast(Node.For, datas[n].rhs);
+            const extra = @as(Node.For, @bitCast(datas[n].rhs));
             n = tree.extra_data[datas[n].lhs + extra.inputs + @intFromBool(extra.has_else)];
         },
         .@"suspend" => {

--- a/src/config_gen/config_gen.zig
+++ b/src/config_gen/config_gen.zig
@@ -237,7 +237,7 @@ fn generateVSCodeConfigFile(allocator: std.mem.Allocator, config: Config, path: 
 
     const predefined_configurations: usize = 3;
     var configuration: std.StringArrayHashMapUnmanaged(ConfigurationProperty) = .{};
-    try configuration.ensureTotalCapacity(allocator, predefined_configurations + @intCast(u32, config.options.len));
+    try configuration.ensureTotalCapacity(allocator, predefined_configurations + @as(u32, @intCast(config.options.len)));
     defer {
         for (configuration.keys()[predefined_configurations..]) |name| allocator.free(name);
         configuration.deinit(allocator);

--- a/src/data/master.zig
+++ b/src/data/master.zig
@@ -14,13 +14,12 @@ const Builtin = struct {
 pub const builtins = [_]Builtin{
     .{
         .name = "@addrSpaceCast",
-        .signature = "@addrSpaceCast(comptime addrspace: std.builtin.AddressSpace, ptr: anytype) anytype",
-        .snippet = "@addrSpaceCast(${1:comptime addrspace: std.builtin.AddressSpace}, ${2:ptr: anytype})",
+        .signature = "@addrSpaceCast(ptr: anytype) anytype",
+        .snippet = "@addrSpaceCast(${1:ptr: anytype})",
         .documentation =
-        \\Converts a pointer from one address space to another. Depending on the current target and address spaces, this cast may be a no-op, a complex operation, or illegal. If the cast is legal, then the resulting pointer points to the same memory location as the pointer operand. It is always valid to cast a pointer between the same address spaces.
+        \\Converts a pointer from one address space to another. The new address space is inferred based on the result type. Depending on the current target and address spaces, this cast may be a no-op, a complex operation, or illegal. If the cast is legal, then the resulting pointer points to the same memory location as the pointer operand. It is always valid to cast a pointer between the same address spaces.
         ,
         .arguments = &.{
-            "comptime addrspace: std.builtin.AddressSpace",
             "ptr: anytype",
         },
     },
@@ -38,15 +37,14 @@ pub const builtins = [_]Builtin{
     },
     .{
         .name = "@alignCast",
-        .signature = "@alignCast(comptime alignment: u29, ptr: anytype) anytype",
-        .snippet = "@alignCast(${1:comptime alignment: u29}, ${2:ptr: anytype})",
+        .signature = "@alignCast(ptr: anytype) anytype",
+        .snippet = "@alignCast(${1:ptr: anytype})",
         .documentation =
-        \\`ptr` can be `*T`, `?*T`, or `[]T`. It returns the same type as `ptr` except with the alignment adjusted to the new value.
+        \\`ptr` can be `*T`, `?*T`, or `[]T`. Changes the alignment of a pointer. The alignment to use is inferred based on the result type.
         \\
         \\A [pointer alignment safety check](https://ziglang.org/documentation/master/#Incorrect-Pointer-Alignment) is added to the generated code to make sure the pointer is aligned as promised.
         ,
         .arguments = &.{
-            "comptime alignment: u29",
             "ptr: anytype",
         },
     },
@@ -143,10 +141,10 @@ pub const builtins = [_]Builtin{
     },
     .{
         .name = "@bitCast",
-        .signature = "@bitCast(comptime DestType: type, value: anytype) DestType",
-        .snippet = "@bitCast(${1:comptime DestType: type}, ${2:value: anytype})",
+        .signature = "@bitCast(value: anytype) anytype",
+        .snippet = "@bitCast(${1:value: anytype})",
         .documentation =
-        \\Converts a value of one type to another type.
+        \\Converts a value of one type to another type. The return type is the inferred result type.
         \\
         \\Asserts that `@sizeOf(@TypeOf(value)) == @sizeOf(DestType)`.
         \\
@@ -159,7 +157,6 @@ pub const builtins = [_]Builtin{
         \\Works at compile-time if `value` is known at compile time. It's a compile error to bitcast a value of undefined layout; this means that, besides the restriction from types which possess dedicated casting builtins (enums, pointers, error sets), bare structs, error unions, slices, optionals, and any other type without a well-defined memory layout, also cannot be used in this operation.
         ,
         .arguments = &.{
-            "comptime DestType: type",
             "value: anytype",
         },
     },
@@ -723,13 +720,12 @@ pub const builtins = [_]Builtin{
     },
     .{
         .name = "@errSetCast",
-        .signature = "@errSetCast(comptime T: DestType, value: anytype) DestType",
-        .snippet = "@errSetCast(${1:comptime T: DestType}, ${2:value: anytype})",
+        .signature = "@errSetCast(value: anytype) anytype",
+        .snippet = "@errSetCast(${1:value: anytype})",
         .documentation =
-        \\Converts an error value from one error set to another error set. Attempting to convert an error which is not in the destination error set results in safety-protected [Undefined Behavior](https://ziglang.org/documentation/master/#Undefined-Behavior).
+        \\Converts an error value from one error set to another error set. The return type is the inferred result type. Attempting to convert an error which is not in the destination error set results in safety-protected [Undefined Behavior](https://ziglang.org/documentation/master/#Undefined-Behavior).
         ,
         .arguments = &.{
-            "comptime T: DestType",
             "value: anytype",
         },
     },
@@ -843,27 +839,25 @@ pub const builtins = [_]Builtin{
     },
     .{
         .name = "@floatCast",
-        .signature = "@floatCast(comptime DestType: type, value: anytype) DestType",
-        .snippet = "@floatCast(${1:comptime DestType: type}, ${2:value: anytype})",
+        .signature = "@floatCast(value: anytype) anytype",
+        .snippet = "@floatCast(${1:value: anytype})",
         .documentation =
-        \\Convert from one float type to another. This cast is safe, but may cause the numeric value to lose precision.
+        \\Convert from one float type to another. This cast is safe, but may cause the numeric value to lose precision. The return type is the inferred result type.
         ,
         .arguments = &.{
-            "comptime DestType: type",
             "value: anytype",
         },
     },
     .{
         .name = "@intFromFloat",
-        .signature = "@intFromFloat(comptime DestType: type, float: anytype) DestType",
-        .snippet = "@intFromFloat(${1:comptime DestType: type}, ${2:float: anytype})",
+        .signature = "@intFromFloat(float: anytype) anytype",
+        .snippet = "@intFromFloat(${1:float: anytype})",
         .documentation =
-        \\Converts the integer part of a floating point number to the destination type.
+        \\Converts the integer part of a floating point number to the inferred result type.
         \\
         \\If the integer part of the floating point number cannot fit in the destination type, it invokes safety-checked [Undefined Behavior](https://ziglang.org/documentation/master/#Undefined-Behavior).
         ,
         .arguments = &.{
-            "comptime DestType: type",
             "float: anytype",
         },
     },
@@ -966,15 +960,15 @@ pub const builtins = [_]Builtin{
     },
     .{
         .name = "@intCast",
-        .signature = "@intCast(comptime DestType: type, int: anytype) DestType",
-        .snippet = "@intCast(${1:comptime DestType: type}, ${2:int: anytype})",
+        .signature = "@intCast(int: anytype) anytype",
+        .snippet = "@intCast(${1:int: anytype})",
         .documentation =
-        \\Converts an integer to another integer while keeping the same numerical value. Attempting to convert a number which is out of range of the destination type results in safety-protected [Undefined Behavior](https://ziglang.org/documentation/master/#Undefined-Behavior).
+        \\Converts an integer to another integer while keeping the same numerical value. The return type is the inferred result type. Attempting to convert a number which is out of range of the destination type results in safety-protected [Undefined Behavior](https://ziglang.org/documentation/master/#Undefined-Behavior).
         \\
         \\```zig
         \\test "integer cast panic" {
         \\    var a: u16 = 0xabcd;
-        \\    var b: u8 = @intCast(u8, a);
+        \\    var b: u8 = @intCast(a);
         \\    _ = b;
         \\}
         \\```
@@ -983,21 +977,19 @@ pub const builtins = [_]Builtin{
         \\If `T` is `comptime_int`, then this is semantically equivalent to [Type Coercion](https://ziglang.org/documentation/master/#Type-Coercion).
         ,
         .arguments = &.{
-            "comptime DestType: type",
             "int: anytype",
         },
     },
     .{
         .name = "@enumFromInt",
-        .signature = "@enumFromInt(comptime DestType: type, integer: anytype) DestType",
-        .snippet = "@enumFromInt(${1:comptime DestType: type}, ${2:integer: anytype})",
+        .signature = "@enumFromInt(integer: anytype) anytype",
+        .snippet = "@enumFromInt(${1:integer: anytype})",
         .documentation =
-        \\Converts an integer into an [enum](https://ziglang.org/documentation/master/#enum) value.
+        \\Converts an integer into an [enum](https://ziglang.org/documentation/master/#enum) value. The return type is the inferred result type.
         \\
         \\Attempting to convert an integer which represents no value in the chosen enum type invokes safety-checked [Undefined Behavior](https://ziglang.org/documentation/master/#Undefined-Behavior).
         ,
         .arguments = &.{
-            "comptime DestType: type",
             "integer: anytype",
         },
     },
@@ -1018,27 +1010,25 @@ pub const builtins = [_]Builtin{
     },
     .{
         .name = "@floatFromInt",
-        .signature = "@floatFromInt(comptime DestType: type, int: anytype) DestType",
-        .snippet = "@floatFromInt(${1:comptime DestType: type}, ${2:int: anytype})",
+        .signature = "@floatFromInt(int: anytype) anytype",
+        .snippet = "@floatFromInt(${1:int: anytype})",
         .documentation =
-        \\Converts an integer to the closest floating point representation. To convert the other way, use [@intFromFloat](https://ziglang.org/documentation/master/#intFromFloat). This cast is always safe.
+        \\Converts an integer to the closest floating point representation. The return type is the inferred result type. To convert the other way, use [@intFromFloat](https://ziglang.org/documentation/master/#intFromFloat). This cast is always safe.
         ,
         .arguments = &.{
-            "comptime DestType: type",
             "int: anytype",
         },
     },
     .{
         .name = "@ptrFromInt",
-        .signature = "@ptrFromInt(comptime DestType: type, address: usize) DestType",
-        .snippet = "@ptrFromInt(${1:comptime DestType: type}, ${2:address: usize})",
+        .signature = "@ptrFromInt(address: usize) anytype",
+        .snippet = "@ptrFromInt(${1:address: usize})",
         .documentation =
-        \\Converts an integer to a [pointer](https://ziglang.org/documentation/master/#Pointers). To convert the other way, use [@intFromPtr](https://ziglang.org/documentation/master/#intFromPtr). Casting an address of 0 to a destination type which in not [optional](https://ziglang.org/documentation/master/#Optional-Pointers) and does not have the `allowzero` attribute will result in a [Pointer Cast Invalid Null](https://ziglang.org/documentation/master/#Pointer-Cast-Invalid-Null) panic when runtime safety checks are enabled.
+        \\Converts an integer to a [pointer](https://ziglang.org/documentation/master/#Pointers). The return type is the inferred result type. To convert the other way, use [@intFromPtr](https://ziglang.org/documentation/master/#intFromPtr). Casting an address of 0 to a destination type which in not [optional](https://ziglang.org/documentation/master/#Optional-Pointers) and does not have the `allowzero` attribute will result in a [Pointer Cast Invalid Null](https://ziglang.org/documentation/master/#Pointer-Cast-Invalid-Null) panic when runtime safety checks are enabled.
         \\
         \\If the destination pointer type does not allow address zero and `address` is zero, this invokes safety-checked [Undefined Behavior](https://ziglang.org/documentation/master/#Undefined-Behavior).
         ,
         .arguments = &.{
-            "comptime DestType: type",
             "address: usize",
         },
     },
@@ -1253,10 +1243,10 @@ pub const builtins = [_]Builtin{
     },
     .{
         .name = "@ptrCast",
-        .signature = "@ptrCast(comptime DestType: type, value: anytype) DestType",
-        .snippet = "@ptrCast(${1:comptime DestType: type}, ${2:value: anytype})",
+        .signature = "@ptrCast(value: anytype) anytype",
+        .snippet = "@ptrCast(${1:value: anytype})",
         .documentation =
-        \\Converts a pointer of one type to a pointer of another type.
+        \\Converts a pointer of one type to a pointer of another type. The return type is the inferred result type.
         \\
         \\[Optional Pointers](https://ziglang.org/documentation/master/#Optional-Pointers) are allowed. Casting an optional pointer which is [null](https://ziglang.org/documentation/master/#null) to a non-optional pointer invokes safety-checked [Undefined Behavior](https://ziglang.org/documentation/master/#Undefined-Behavior).
         \\
@@ -1269,7 +1259,6 @@ pub const builtins = [_]Builtin{
         \\ - Casting a non-slice pointer to a slice, use slicing syntax `ptr[start..end]`.
         ,
         .arguments = &.{
-            "comptime DestType: type",
             "value: anytype",
         },
     },
@@ -1873,10 +1862,10 @@ pub const builtins = [_]Builtin{
     },
     .{
         .name = "@truncate",
-        .signature = "@truncate(comptime T: type, integer: anytype) T",
-        .snippet = "@truncate(${1:comptime T: type}, ${2:integer: anytype})",
+        .signature = "@truncate(integer: anytype) anytype",
+        .snippet = "@truncate(${1:integer: anytype})",
         .documentation =
-        \\This function truncates bits from an integer type, resulting in a smaller or same-sized integer type.
+        \\This function truncates bits from an integer type, resulting in a smaller or same-sized integer type. The return type is the inferred result type.
         \\
         \\This function always truncates the significant bits of the integer, regardless of endianness on the target platform.
         \\
@@ -1887,14 +1876,13 @@ pub const builtins = [_]Builtin{
         \\const expect = std.testing.expect;
         \\test "integer truncation" {
         \\    var a: u16 = 0xabcd;
-        \\    var b: u8 = @truncate(u8, a);
+        \\    var b: u8 = @truncate(a);
         \\    try expect(b == 0xcd);
         \\}
         \\```
         \\Use [@intCast](https://ziglang.org/documentation/master/#intCast) to convert numbers guaranteed to fit the destination type.
         ,
         .arguments = &.{
-            "comptime T: type",
             "integer: anytype",
         },
     },

--- a/src/debug.zig
+++ b/src/debug.zig
@@ -84,7 +84,7 @@ pub const FailingAllocator = struct {
 
         return FailingAllocator{
             .internal_allocator = internal_allocator,
-            .random = std.rand.DefaultPrng.init(@bitCast(u64, seed)),
+            .random = std.rand.DefaultPrng.init(@bitCast(seed)),
             .likelihood = likelihood,
         };
     }
@@ -106,7 +106,7 @@ pub const FailingAllocator = struct {
         log2_ptr_align: u8,
         return_address: usize,
     ) ?[*]u8 {
-        const self = @ptrCast(*FailingAllocator, @alignCast(@alignOf(FailingAllocator), ctx));
+        const self: *FailingAllocator = @ptrCast(@alignCast(ctx));
         if (shouldFail(self)) return null;
         return self.internal_allocator.rawAlloc(len, log2_ptr_align, return_address);
     }
@@ -118,7 +118,7 @@ pub const FailingAllocator = struct {
         new_len: usize,
         ra: usize,
     ) bool {
-        const self = @ptrCast(*FailingAllocator, @alignCast(@alignOf(FailingAllocator), ctx));
+        const self: *FailingAllocator = @ptrCast(@alignCast(ctx));
         if (!self.internal_allocator.rawResize(old_mem, log2_old_align, new_len, ra))
             return false;
         return true;
@@ -130,7 +130,7 @@ pub const FailingAllocator = struct {
         log2_old_align: u8,
         ra: usize,
     ) void {
-        const self = @ptrCast(*FailingAllocator, @alignCast(@alignOf(FailingAllocator), ctx));
+        const self: *FailingAllocator = @ptrCast(@alignCast(ctx));
         self.internal_allocator.rawFree(old_mem, log2_old_align, ra);
     }
 

--- a/src/features/code_actions.zig
+++ b/src/features/code_actions.zig
@@ -419,7 +419,7 @@ const DiagnosticKind = union(enum) {
         inline for (std.meta.fields(T)) |field| {
             if (std.mem.startsWith(u8, message, field.name)) {
                 // is there a better way to achieve this?
-                return @enumFromInt(T, field.value);
+                return @as(T, @enumFromInt(field.value));
             }
         }
 

--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -768,7 +768,7 @@ pub fn addStructInitNodeFields(server: *Server, decl: Analyser.DeclWithHandle, c
         },
         .root => {
             for (decl.handle.tree.rootDecls()) |root_node| {
-                const field = decl.handle.tree.fullContainerField(@intCast(u32, root_node)) orelse continue;
+                const field = decl.handle.tree.fullContainerField(@as(u32, @intCast(root_node))) orelse continue;
                 try completions.append(server.arena.allocator(), .{
                     .label = decl.handle.tree.tokenSlice(field.ast.main_token),
                     .kind = if (field.ast.tuple_like) .EnumMember else .Field,

--- a/src/features/folding_range.zig
+++ b/src/features/folding_range.zig
@@ -135,7 +135,7 @@ pub fn generateFoldingRanges(allocator: std.mem.Allocator, tree: Ast, encoding: 
     var start_doc_comment: ?Ast.TokenIndex = null;
     var end_doc_comment: ?Ast.TokenIndex = null;
     for (token_tags, 0..) |tag, i| {
-        const token = @intCast(Ast.TokenIndex, i);
+        const token: Ast.TokenIndex = @intCast(i);
         switch (tag) {
             .doc_comment,
             .container_doc_comment,
@@ -162,7 +162,7 @@ pub fn generateFoldingRanges(allocator: std.mem.Allocator, tree: Ast, encoding: 
     // TODO add folding range for top level `@Import()`
 
     for (node_tags, 0..) |node_tag, i| {
-        const node = @intCast(Ast.Node.Index, i);
+        const node: Ast.Node.Index = @intCast(i);
 
         switch (node_tag) {
             .root => continue,

--- a/src/features/selection_range.zig
+++ b/src/features/selection_range.zig
@@ -30,7 +30,7 @@ pub fn generateSelectionRanges(
 
         locs.clearRetainingCapacity();
         for (0..handle.tree.nodes.len) |i| {
-            const node = @intCast(Ast.Node.Index, i);
+            const node = @as(Ast.Node.Index, @intCast(i));
             const loc = offsets.nodeToLoc(handle.tree, node);
             if (loc.start <= index and index <= loc.end) {
                 try locs.append(arena, loc);

--- a/src/features/semantic_tokens.zig
+++ b/src/features/semantic_tokens.zig
@@ -152,11 +152,11 @@ const Builder = struct {
         const length = offsets.locLength(self.handle.tree.source, loc, self.encoding);
 
         try self.token_buffer.appendSlice(self.arena, &.{
-            @truncate(u32, delta.line),
-            @truncate(u32, delta.character),
-            @truncate(u32, length),
+            @as(u32, @truncate(delta.line)),
+            @as(u32, @truncate(delta.character)),
+            @as(u32, @truncate(length)),
             @intFromEnum(token_type),
-            @bitCast(u16, token_modifiers),
+            @as(u16, @bitCast(token_modifiers)),
         });
         self.previous_source_index = loc.start;
     }

--- a/src/features/signature_help.zig
+++ b/src/features/signature_help.zig
@@ -68,7 +68,7 @@ pub fn getSignatureInfo(analyser: *Analyser, alloc: std.mem.Allocator, handle: *
                 break :blk i - 1;
             }
         }
-        break :blk @truncate(u32, token_tags.len - 1);
+        break :blk @as(u32, @truncate(token_tags.len - 1));
     };
 
     // We scan the tokens from last to first, adding and removing open and close

--- a/src/legacy_json.zig
+++ b/src/legacy_json.zig
@@ -80,8 +80,8 @@ fn deepCopy(comptime T: type, allocator: Allocator, value: T) !T {
                         try result.append(try deepCopy(ptrInfo.child, allocator, v));
                     }
                     if (ptrInfo.sentinel) |some| {
-                        const sentinel_value = @ptrCast(*align(1) const ptrInfo.child, some).*;
-                        return try result.toOwnedSliceSentinel(sentinel_value);
+                        const sentinel_value: *align(1) const ptrInfo.child = @ptrCast(some);
+                        return try result.toOwnedSliceSentinel(sentinel_value.*);
                     }
                     return try result.toOwnedSlice();
                 },
@@ -129,7 +129,7 @@ pub fn parseFree(comptime T: type, allocator: Allocator, value: T) void {
                             };
                             const field_addr = @intFromPtr(field_ptr);
 
-                            const casted_default = @ptrCast(*const field.type, @alignCast(@alignOf(field.type), default)).*;
+                            const casted_default: *const field.type = @ptrCast(@alignCast(default));
                             const default_ptr = switch (fieldPtrInfo.size) {
                                 .One => casted_default,
                                 .Slice => casted_default.ptr,

--- a/src/main.zig
+++ b/src/main.zig
@@ -17,7 +17,7 @@ const message_logger = std.log.scoped(.message);
 
 var actual_log_level: std.log.Level = switch (zig_builtin.mode) {
     .Debug => .debug,
-    else => @enumFromInt(std.log.Level, @intFromEnum(build_options.log_level)), // temporary fix to build failing on release-safe due to a Zig bug
+    else => @enumFromInt(@intFromEnum(build_options.log_level)), // temporary fix to build failing on release-safe due to a Zig bug
 };
 
 pub const std_options = struct {
@@ -228,7 +228,7 @@ fn parseArgs(allocator: std.mem.Allocator) !ParseArgsResult {
         const KV = struct { []const u8, ArgId };
         var pairs: [fields.len]KV = undefined;
         for (&pairs, fields) |*pair, field| {
-            pair.* = .{ field.name, @enumFromInt(ArgId, field.value) };
+            pair.* = .{ field.name, @as(ArgId, @enumFromInt(field.value)) };
         }
         break :blk pairs[0..];
     });

--- a/src/offsets.zig
+++ b/src/offsets.zig
@@ -12,8 +12,8 @@ pub fn indexToPosition(text: []const u8, index: usize, encoding: Encoding) types
     const line_count = std.mem.count(u8, text[0..last_line_start], "\n");
 
     return .{
-        .line = @intCast(u32, line_count),
-        .character = @intCast(u32, countCodeUnits(text[last_line_start..index], encoding)),
+        .line = @intCast(line_count),
+        .character = @intCast(countCodeUnits(text[last_line_start..index], encoding)),
     };
 }
 
@@ -247,7 +247,7 @@ pub fn convertPositionEncoding(text: []const u8, position: types.Position, from_
 
     return .{
         .line = position.line,
-        .character = @intCast(u32, locLength(text, line_loc, to_encoding)),
+        .character = @intCast(locLength(text, line_loc, to_encoding)),
     };
 }
 
@@ -296,7 +296,7 @@ pub fn advancePosition(text: []const u8, position: types.Position, from_index: u
 
     return .{
         .line = line,
-        .character = @intCast(u32, locLength(text, line_loc, encoding)),
+        .character = @intCast(locLength(text, line_loc, encoding)),
     };
 }
 

--- a/src/stage2/AstGen.zig
+++ b/src/stage2/AstGen.zig
@@ -77,7 +77,7 @@ fn addExtra(astgen: *AstGen, extra: anytype) Allocator.Error!u32 {
 
 fn addExtraAssumeCapacity(astgen: *AstGen, extra: anytype) u32 {
     const fields = std.meta.fields(@TypeOf(extra));
-    const result = @intCast(u32, astgen.extra.items.len);
+    const result = @as(u32, @intCast(astgen.extra.items.len));
     astgen.extra.items.len += fields.len;
     setExtra(astgen, result, extra);
     return result;
@@ -90,11 +90,11 @@ fn setExtra(astgen: *AstGen, index: usize, extra: anytype) void {
         astgen.extra.items[i] = switch (field.type) {
             u32 => @field(extra, field.name),
             Zir.Inst.Ref => @intFromEnum(@field(extra, field.name)),
-            i32 => @bitCast(u32, @field(extra, field.name)),
-            Zir.Inst.Call.Flags => @bitCast(u32, @field(extra, field.name)),
-            Zir.Inst.BuiltinCall.Flags => @bitCast(u32, @field(extra, field.name)),
-            Zir.Inst.SwitchBlock.Bits => @bitCast(u32, @field(extra, field.name)),
-            Zir.Inst.FuncFancy.Bits => @bitCast(u32, @field(extra, field.name)),
+            i32 => @as(u32, @bitCast(@field(extra, field.name))),
+            Zir.Inst.Call.Flags => @as(u32, @bitCast(@field(extra, field.name))),
+            Zir.Inst.BuiltinCall.Flags => @as(u32, @bitCast(@field(extra, field.name))),
+            Zir.Inst.SwitchBlock.Bits => @as(u32, @bitCast(@field(extra, field.name))),
+            Zir.Inst.FuncFancy.Bits => @as(u32, @bitCast(@field(extra, field.name))),
             else => @compileError("bad field type"),
         };
         i += 1;
@@ -102,18 +102,18 @@ fn setExtra(astgen: *AstGen, index: usize, extra: anytype) void {
 }
 
 fn reserveExtra(astgen: *AstGen, size: usize) Allocator.Error!u32 {
-    const result = @intCast(u32, astgen.extra.items.len);
+    const result = @as(u32, @intCast(astgen.extra.items.len));
     try astgen.extra.resize(astgen.gpa, result + size);
     return result;
 }
 
 fn appendRefs(astgen: *AstGen, refs: []const Zir.Inst.Ref) !void {
-    const coerced = @ptrCast([]const u32, refs);
+    const coerced = @as([]const u32, @ptrCast(refs));
     return astgen.extra.appendSlice(astgen.gpa, coerced);
 }
 
 fn appendRefsAssumeCapacity(astgen: *AstGen, refs: []const Zir.Inst.Ref) void {
-    const coerced = @ptrCast([]const u32, refs);
+    const coerced = @as([]const u32, @ptrCast(refs));
     astgen.extra.appendSliceAssumeCapacity(coerced);
 }
 
@@ -183,7 +183,7 @@ pub fn generate(gpa: Allocator, tree: Ast) Allocator.Error!Zir {
             @typeInfo(Zir.Inst.CompileErrors.Item).Struct.fields.len);
 
         astgen.extra.items[err_index] = astgen.addExtraAssumeCapacity(Zir.Inst.CompileErrors{
-            .items_len = @intCast(u32, astgen.compile_errors.items.len),
+            .items_len = @as(u32, @intCast(astgen.compile_errors.items.len)),
         });
 
         for (astgen.compile_errors.items) |item| {
@@ -199,7 +199,7 @@ pub fn generate(gpa: Allocator, tree: Ast) Allocator.Error!Zir {
             astgen.imports.count() * @typeInfo(Zir.Inst.Imports.Item).Struct.fields.len);
 
         astgen.extra.items[imports_index] = astgen.addExtraAssumeCapacity(Zir.Inst.Imports{
-            .imports_len = @intCast(u32, astgen.imports.count()),
+            .imports_len = @as(u32, @intCast(astgen.imports.count())),
         });
 
         var it = astgen.imports.iterator();
@@ -1315,7 +1315,7 @@ fn fnProtoExpr(
                 var param_gz = block_scope.makeSubBlock(scope);
                 defer param_gz.unstack();
                 const param_type = try expr(&param_gz, scope, coerced_type_ri, param_type_node);
-                const param_inst_expected = @intCast(u32, astgen.instructions.len + 1);
+                const param_inst_expected = @as(u32, @intCast(astgen.instructions.len + 1));
                 _ = try param_gz.addBreakWithSrcNode(.break_inline, param_inst_expected, param_type, param_type_node);
                 const main_tokens = tree.nodes.items(.main_token);
                 const name_token = param.name_token orelse main_tokens[param_type_node];
@@ -1449,7 +1449,7 @@ fn arrayInitExpr(
         const array_type_inst = try typeExpr(gz, scope, array_init.ast.type_expr);
         _ = try gz.addPlNode(.validate_array_init_ty, node, Zir.Inst.ArrayInit{
             .ty = array_type_inst,
-            .init_count = @intCast(u32, array_init.ast.elements.len),
+            .init_count = @as(u32, @intCast(array_init.ast.elements.len)),
         });
         break :inst .{
             .array = array_type_inst,
@@ -1514,7 +1514,7 @@ fn arrayInitExprRlNone(
     const astgen = gz.astgen;
 
     const payload_index = try addExtra(astgen, Zir.Inst.MultiOp{
-        .operands_len = @intCast(u32, elements.len),
+        .operands_len = @as(u32, @intCast(elements.len)),
     });
     var extra_index = try reserveExtra(astgen, elements.len);
 
@@ -1539,7 +1539,7 @@ fn arrayInitExprInner(
 
     const len = elements.len + @intFromBool(array_ty_inst != .none);
     const payload_index = try addExtra(astgen, Zir.Inst.MultiOp{
-        .operands_len = @intCast(u32, len),
+        .operands_len = @as(u32, @intCast(len)),
     });
     var extra_index = try reserveExtra(astgen, len);
     if (array_ty_inst != .none) {
@@ -1555,7 +1555,7 @@ fn arrayInitExprInner(
                 .tag = .elem_type_index,
                 .data = .{ .bin = .{
                     .lhs = array_ty_inst,
-                    .rhs = @enumFromInt(Zir.Inst.Ref, i),
+                    .rhs = @as(Zir.Inst.Ref, @enumFromInt(i)),
                 } },
             });
             break :ri ResultInfo{ .rl = .{ .coerced_ty = ty_expr } };
@@ -1600,14 +1600,14 @@ fn arrayInitExprRlPtrInner(
     const astgen = gz.astgen;
 
     const payload_index = try addExtra(astgen, Zir.Inst.Block{
-        .body_len = @intCast(u32, elements.len),
+        .body_len = @as(u32, @intCast(elements.len)),
     });
     var extra_index = try reserveExtra(astgen, elements.len);
 
     for (elements, 0..) |elem_init, i| {
         const elem_ptr = try gz.addPlNode(.elem_ptr_imm, elem_init, Zir.Inst.ElemPtrImm{
             .ptr = result_ptr,
-            .index = @intCast(u32, i),
+            .index = @as(u32, @intCast(i)),
         });
         astgen.extra.items[extra_index] = refToIndex(elem_ptr).?;
         extra_index += 1;
@@ -1757,7 +1757,7 @@ fn structInitExprRlNone(
     const tree = astgen.tree;
 
     const payload_index = try addExtra(astgen, Zir.Inst.StructInitAnon{
-        .fields_len = @intCast(u32, struct_init.ast.fields.len),
+        .fields_len = @as(u32, @intCast(struct_init.ast.fields.len)),
     });
     const field_size = @typeInfo(Zir.Inst.StructInitAnon.Item).Struct.fields.len;
     var extra_index: usize = try reserveExtra(astgen, struct_init.ast.fields.len * field_size);
@@ -1815,7 +1815,7 @@ fn structInitExprRlPtrInner(
     const tree = astgen.tree;
 
     const payload_index = try addExtra(astgen, Zir.Inst.Block{
-        .body_len = @intCast(u32, struct_init.ast.fields.len),
+        .body_len = @as(u32, @intCast(struct_init.ast.fields.len)),
     });
     var extra_index = try reserveExtra(astgen, struct_init.ast.fields.len);
 
@@ -1847,7 +1847,7 @@ fn structInitExprRlTy(
     const tree = astgen.tree;
 
     const payload_index = try addExtra(astgen, Zir.Inst.StructInit{
-        .fields_len = @intCast(u32, struct_init.ast.fields.len),
+        .fields_len = @as(u32, @intCast(struct_init.ast.fields.len)),
     });
     const field_size = @typeInfo(Zir.Inst.StructInit.Item).Struct.fields.len;
     var extra_index: usize = try reserveExtra(astgen, struct_init.ast.fields.len * field_size);
@@ -2086,7 +2086,7 @@ fn breakExpr(parent_gz: *GenZir, parent_scope: *Scope, node: Ast.Node.Index) Inn
                 }
 
                 const operand = try reachableExpr(parent_gz, parent_scope, block_gz.break_result_info, rhs, node);
-                const search_index = @intCast(Zir.Inst.Index, astgen.instructions.len);
+                const search_index = @as(Zir.Inst.Index, @intCast(astgen.instructions.len));
 
                 try genDefers(parent_gz, scope, parent_scope, .normal_only);
 
@@ -2492,17 +2492,17 @@ fn addEnsureResult(gz: *GenZir, maybe_unused_result: Zir.Inst.Ref, statement: As
             .call, .field_call => {
                 const extra_index = gz.astgen.instructions.items(.data)[inst].pl_node.payload_index;
                 const slot = &gz.astgen.extra.items[extra_index];
-                var flags = @bitCast(Zir.Inst.Call.Flags, slot.*);
+                var flags = @as(Zir.Inst.Call.Flags, @bitCast(slot.*));
                 flags.ensure_result_used = true;
-                slot.* = @bitCast(u32, flags);
+                slot.* = @as(u32, @bitCast(flags));
                 break :b true;
             },
             .builtin_call => {
                 const extra_index = gz.astgen.instructions.items(.data)[inst].pl_node.payload_index;
                 const slot = &gz.astgen.extra.items[extra_index];
-                var flags = @bitCast(Zir.Inst.BuiltinCall.Flags, slot.*);
+                var flags = @as(Zir.Inst.BuiltinCall.Flags, @bitCast(slot.*));
                 flags.ensure_result_used = true;
-                slot.* = @bitCast(u32, flags);
+                slot.* = @as(u32, @bitCast(flags));
                 break :b true;
             },
 
@@ -2878,7 +2878,7 @@ fn genDefers(
                                 .index = defer_scope.index,
                                 .len = defer_scope.len,
                             });
-                            const new_index = @intCast(Zir.Inst.Index, gz.astgen.instructions.len);
+                            const new_index = @as(Zir.Inst.Index, @intCast(gz.astgen.instructions.len));
                             gz.astgen.instructions.appendAssumeCapacity(.{
                                 .tag = .defer_err_code,
                                 .data = .{ .defer_err_code = .{
@@ -2957,7 +2957,7 @@ fn deferStmt(
     const sub_scope = if (!have_err_code) &defer_gen.base else blk: {
         try gz.addDbgBlockBegin();
         const ident_name = try gz.astgen.identAsString(payload_token);
-        remapped_err_code = @intCast(Zir.Inst.Index, gz.astgen.instructions.len);
+        remapped_err_code = @as(Zir.Inst.Index, @intCast(gz.astgen.instructions.len));
         try gz.astgen.instructions.append(gz.astgen.gpa, .{
             .tag = .extended,
             .data = .{ .extended = .{
@@ -2997,7 +2997,7 @@ fn deferStmt(
         break :blk gz.astgen.countBodyLenAfterFixups(body) + refs;
     };
 
-    const index = @intCast(u32, gz.astgen.extra.items.len);
+    const index = @as(u32, @intCast(gz.astgen.extra.items.len));
     try gz.astgen.extra.ensureUnusedCapacity(gz.astgen.gpa, body_len);
     if (have_err_code) {
         if (gz.astgen.ref_table.fetchRemove(remapped_err_code)) |kv| {
@@ -3535,7 +3535,7 @@ fn ptrType(
         gz.astgen.extra.appendAssumeCapacity(@intFromEnum(bit_end_ref));
     }
 
-    const new_index = @intCast(Zir.Inst.Index, gz.astgen.instructions.len);
+    const new_index = @as(Zir.Inst.Index, @intCast(gz.astgen.instructions.len));
     const result = indexToRef(new_index);
     gz.astgen.instructions.appendAssumeCapacity(.{ .tag = .ptr_type, .data = .{
         .ptr_type = .{
@@ -3626,7 +3626,7 @@ const WipMembers = struct {
     const max_decl_size = 11;
 
     fn init(gpa: Allocator, payload: *ArrayListUnmanaged(u32), decl_count: u32, field_count: u32, comptime bits_per_field: u32, comptime max_field_size: u32) Allocator.Error!Self {
-        const payload_top = @intCast(u32, payload.items.len);
+        const payload_top = @as(u32, @intCast(payload.items.len));
         const decls_start = payload_top + (decl_count + decls_per_u32 - 1) / decls_per_u32;
         const field_bits_start = decls_start + decl_count * max_decl_size;
         const fields_start = field_bits_start + if (bits_per_field > 0) blk: {
@@ -3681,7 +3681,7 @@ const WipMembers = struct {
     fn appendToDeclSlice(self: *Self, data: []const u32) void {
         assert(self.decls_end + data.len <= self.field_bits_start);
         @memcpy(self.payload.items[self.decls_end..][0..data.len], data);
-        self.decls_end += @intCast(u32, data.len);
+        self.decls_end += @as(u32, @intCast(data.len));
     }
 
     fn appendToField(self: *Self, data: u32) void {
@@ -3694,14 +3694,14 @@ const WipMembers = struct {
         const empty_decl_slots = decls_per_u32 - (self.decl_index % decls_per_u32);
         if (self.decl_index > 0 and empty_decl_slots < decls_per_u32) {
             const index = self.payload_top + self.decl_index / decls_per_u32;
-            self.payload.items[index] >>= @intCast(u5, empty_decl_slots * bits_per_decl);
+            self.payload.items[index] >>= @as(u5, @intCast(empty_decl_slots * bits_per_decl));
         }
         if (bits_per_field > 0) {
             const fields_per_u32 = 32 / bits_per_field;
             const empty_field_slots = fields_per_u32 - (self.field_index % fields_per_u32);
             if (self.field_index > 0 and empty_field_slots < fields_per_u32) {
                 const index = self.field_bits_start + self.field_index / fields_per_u32;
-                self.payload.items[index] >>= @intCast(u5, empty_field_slots * bits_per_field);
+                self.payload.items[index] >>= @as(u5, @intCast(empty_field_slots * bits_per_field));
             }
         }
     }
@@ -3863,7 +3863,7 @@ fn fnDecl(
                 var param_gz = decl_gz.makeSubBlock(scope);
                 defer param_gz.unstack();
                 const param_type = try expr(&param_gz, params_scope, coerced_type_ri, param_type_node);
-                const param_inst_expected = @intCast(u32, astgen.instructions.len + 1);
+                const param_inst_expected = @as(u32, @intCast(astgen.instructions.len + 1));
                 _ = try param_gz.addBreakWithSrcNode(.break_inline, param_inst_expected, param_type, param_type_node);
 
                 const main_tokens = tree.nodes.items(.main_token);
@@ -4078,7 +4078,7 @@ fn fnDecl(
 
     {
         const contents_hash = std.zig.hashSrc(tree.getNodeSource(decl_node));
-        const casted = @bitCast([4]u32, contents_hash);
+        const casted = @as([4]u32, @bitCast(contents_hash));
         wip_members.appendToDeclSlice(&casted);
     }
     {
@@ -4229,7 +4229,7 @@ fn globalVarDecl(
 
     {
         const contents_hash = std.zig.hashSrc(tree.getNodeSource(node));
-        const casted = @bitCast([4]u32, contents_hash);
+        const casted = @as([4]u32, @bitCast(contents_hash));
         wip_members.appendToDeclSlice(&casted);
     }
     {
@@ -4284,7 +4284,7 @@ fn comptimeDecl(
 
     {
         const contents_hash = std.zig.hashSrc(tree.getNodeSource(node));
-        const casted = @bitCast([4]u32, contents_hash);
+        const casted = @as([4]u32, @bitCast(contents_hash));
         wip_members.appendToDeclSlice(&casted);
     }
     {
@@ -4336,7 +4336,7 @@ fn usingnamespaceDecl(
 
     {
         const contents_hash = std.zig.hashSrc(tree.getNodeSource(node));
-        const casted = @bitCast([4]u32, contents_hash);
+        const casted = @as([4]u32, @bitCast(contents_hash));
         wip_members.appendToDeclSlice(&casted);
     }
     {
@@ -4523,7 +4523,7 @@ fn testDecl(
 
     {
         const contents_hash = std.zig.hashSrc(tree.getNodeSource(node));
-        const casted = @bitCast([4]u32, contents_hash);
+        const casted = @as([4]u32, @bitCast(contents_hash));
         wip_members.appendToDeclSlice(&casted);
     }
     {
@@ -4623,7 +4623,7 @@ fn structDeclInner(
     };
 
     const decl_count = try astgen.scanDecls(&namespace, container_decl.ast.members);
-    const field_count = @intCast(u32, container_decl.ast.members.len - decl_count);
+    const field_count = @as(u32, @intCast(container_decl.ast.members.len - decl_count));
 
     const bits_per_field = 4;
     const max_field_size = 5;
@@ -4731,7 +4731,7 @@ fn structDeclInner(
             const old_scratch_len = astgen.scratch.items.len;
             try astgen.scratch.ensureUnusedCapacity(gpa, countBodyLenAfterFixups(astgen, body));
             appendBodyWithFixupsArrayList(astgen, &astgen.scratch, body);
-            wip_members.appendToField(@intCast(u32, astgen.scratch.items.len - old_scratch_len));
+            wip_members.appendToField(@as(u32, @intCast(astgen.scratch.items.len - old_scratch_len)));
             block_scope.instructions.items.len = block_scope.instructions_top;
         } else {
             wip_members.appendToField(@intFromEnum(field_type));
@@ -4749,7 +4749,7 @@ fn structDeclInner(
             const old_scratch_len = astgen.scratch.items.len;
             try astgen.scratch.ensureUnusedCapacity(gpa, countBodyLenAfterFixups(astgen, body));
             appendBodyWithFixupsArrayList(astgen, &astgen.scratch, body);
-            wip_members.appendToField(@intCast(u32, astgen.scratch.items.len - old_scratch_len));
+            wip_members.appendToField(@as(u32, @intCast(astgen.scratch.items.len - old_scratch_len)));
             block_scope.instructions.items.len = block_scope.instructions_top;
         }
 
@@ -4764,7 +4764,7 @@ fn structDeclInner(
             const old_scratch_len = astgen.scratch.items.len;
             try astgen.scratch.ensureUnusedCapacity(gpa, countBodyLenAfterFixups(astgen, body));
             appendBodyWithFixupsArrayList(astgen, &astgen.scratch, body);
-            wip_members.appendToField(@intCast(u32, astgen.scratch.items.len - old_scratch_len));
+            wip_members.appendToField(@as(u32, @intCast(astgen.scratch.items.len - old_scratch_len)));
             block_scope.instructions.items.len = block_scope.instructions_top;
         } else if (member.comptime_token) |comptime_token| {
             return astgen.failTok(comptime_token, "comptime field without default initialization value", .{});
@@ -4777,7 +4777,7 @@ fn structDeclInner(
         .fields_len = field_count,
         .decls_len = decl_count,
         .backing_int_ref = backing_int_ref,
-        .backing_int_body_len = @intCast(u32, backing_int_body_len),
+        .backing_int_body_len = @as(u32, @intCast(backing_int_body_len)),
         .known_non_opv = known_non_opv,
         .known_comptime_only = known_comptime_only,
         .is_tuple = is_tuple,
@@ -4837,7 +4837,7 @@ fn unionDeclInner(
     defer block_scope.unstack();
 
     const decl_count = try astgen.scanDecls(&namespace, members);
-    const field_count = @intCast(u32, members.len - decl_count);
+    const field_count = @as(u32, @intCast(members.len - decl_count));
 
     if (layout != .Auto and (auto_enum_tok != null or arg_node != 0)) {
         const layout_str = if (layout == .Extern) "extern" else "packed";
@@ -5132,7 +5132,7 @@ fn containerDecl(
 
             const bits_per_field = 1;
             const max_field_size = 3;
-            var wip_members = try WipMembers.init(gpa, &astgen.scratch, @intCast(u32, counts.decls), @intCast(u32, counts.total_fields), bits_per_field, max_field_size);
+            var wip_members = try WipMembers.init(gpa, &astgen.scratch, @as(u32, @intCast(counts.decls)), @as(u32, @intCast(counts.total_fields)), bits_per_field, max_field_size);
             defer wip_members.deinit();
 
             for (container_decl.ast.members) |member_node| {
@@ -5190,8 +5190,8 @@ fn containerDecl(
                 .nonexhaustive = nonexhaustive,
                 .tag_type = arg_inst,
                 .body_len = body_len,
-                .fields_len = @intCast(u32, counts.total_fields),
-                .decls_len = @intCast(u32, counts.decls),
+                .fields_len = @as(u32, @intCast(counts.total_fields)),
+                .decls_len = @as(u32, @intCast(counts.decls)),
             });
 
             wip_members.finishBits(bits_per_field);
@@ -5381,7 +5381,7 @@ fn errorSetDecl(gz: *GenZir, ri: ResultInfo, node: Ast.Node.Index) InnerError!Zi
     }
 
     setExtra(astgen, payload_index, Zir.Inst.ErrorSetDecl{
-        .fields_len = @intCast(u32, fields_len),
+        .fields_len = @as(u32, @intCast(fields_len)),
     });
     const result = try gz.addPlNodePayloadIndex(.error_set_decl, node, payload_index);
     return rvalue(gz, ri, result, node);
@@ -6444,7 +6444,7 @@ fn forExpr(
     {
         var capture_token = for_full.payload_token;
         for (for_full.ast.inputs, 0..) |input, i_usize| {
-            const i = @intCast(u32, i_usize);
+            const i = @as(u32, @intCast(i_usize));
             const capture_is_ref = token_tags[capture_token] == .asterisk;
             const ident_tok = capture_token + @intFromBool(capture_is_ref);
             const is_discard = mem.eql(u8, tree.tokenSlice(ident_tok), "_");
@@ -6502,7 +6502,7 @@ fn forExpr(
     // We use a dedicated ZIR instruction to assert the lengths to assist with
     // nicer error reporting as well as fewer ZIR bytes emitted.
     const len: Zir.Inst.Ref = len: {
-        const lens_len = @intCast(u32, lens.len);
+        const lens_len = @as(u32, @intCast(lens.len));
         try astgen.extra.ensureUnusedCapacity(gpa, @typeInfo(Zir.Inst.MultiOp).Struct.fields.len + lens_len);
         const len = try parent_gz.addPlNode(.for_len, node, Zir.Inst.MultiOp{
             .operands_len = lens_len,
@@ -6572,7 +6572,7 @@ fn forExpr(
         var capture_token = for_full.payload_token;
         var capture_sub_scope: *Scope = &then_scope.base;
         for (for_full.ast.inputs, 0..) |input, i_usize| {
-            const i = @intCast(u32, i_usize);
+            const i = @as(u32, @intCast(i_usize));
             const capture_is_ref = token_tags[capture_token] == .asterisk;
             const ident_tok = capture_token + @intFromBool(capture_is_ref);
             const capture_name = tree.tokenSlice(ident_tok);
@@ -6872,7 +6872,7 @@ fn switchExpr(
 
     // If any prong has an inline tag capture, allocate a shared dummy instruction for it
     const tag_inst = if (any_has_tag_capture) tag_inst: {
-        const inst = @intCast(Zir.Inst.Index, astgen.instructions.len);
+        const inst = @as(Zir.Inst.Index, @intCast(astgen.instructions.len));
         try astgen.instructions.append(astgen.gpa, .{
             .tag = .extended,
             .data = .{ .extended = .{
@@ -6965,7 +6965,7 @@ fn switchExpr(
             break :blk &tag_scope.base;
         };
 
-        const header_index = @intCast(u32, payloads.items.len);
+        const header_index = @as(u32, @intCast(payloads.items.len));
         const body_len_index = if (is_multi_case) blk: {
             payloads.items[multi_case_table + multi_case_index] = header_index;
             multi_case_index += 1;
@@ -7055,12 +7055,12 @@ fn switchExpr(
             };
             const body_len = refs_len + astgen.countBodyLenAfterFixups(case_slice);
             try payloads.ensureUnusedCapacity(gpa, body_len);
-            payloads.items[body_len_index] = @bitCast(u32, Zir.Inst.SwitchBlock.ProngInfo{
-                .body_len = @intCast(u28, body_len),
+            payloads.items[body_len_index] = @as(u32, @bitCast(Zir.Inst.SwitchBlock.ProngInfo{
+                .body_len = @as(u28, @intCast(body_len)),
                 .capture = capture,
                 .is_inline = case.inline_token != null,
                 .has_tag_capture = has_tag_capture,
-            });
+            }));
             if (astgen.ref_table.fetchRemove(switch_block)) |kv| {
                 appendPossiblyRefdBodyInst(astgen, payloads, kv.value);
             }
@@ -7087,7 +7087,7 @@ fn switchExpr(
             .has_else = special_prong == .@"else",
             .has_under = special_prong == .under,
             .any_has_tag_capture = any_has_tag_capture,
-            .scalar_cases_len = @intCast(Zir.Inst.SwitchBlock.Bits.ScalarCasesLen, scalar_cases_len),
+            .scalar_cases_len = @as(Zir.Inst.SwitchBlock.Bits.ScalarCasesLen, @intCast(scalar_cases_len)),
         },
     });
 
@@ -7121,7 +7121,7 @@ fn switchExpr(
             end_index += 3 + items_len + 2 * ranges_len;
         }
 
-        const body_len = @bitCast(Zir.Inst.SwitchBlock.ProngInfo, payloads.items[body_len_index]).body_len;
+        const body_len = @as(Zir.Inst.SwitchBlock.ProngInfo, @bitCast(payloads.items[body_len_index])).body_len;
         end_index += body_len;
 
         switch (strat.tag) {
@@ -7560,7 +7560,7 @@ fn tunnelThroughClosure(
                 .src_tok = ns.?.declaring_gz.?.tokenIndexToRelative(token),
             } },
         });
-        gop.value_ptr.* = @intCast(Zir.Inst.Index, gz.astgen.instructions.len - 1);
+        gop.value_ptr.* = @as(Zir.Inst.Index, @intCast(gz.astgen.instructions.len - 1));
     }
 
     // Add an instruction to get the value from the closure into
@@ -7661,7 +7661,7 @@ fn numberLiteral(gz: *GenZir, ri: ResultInfo, node: Ast.Node.Index, source_node:
             };
             // If the value fits into a f64 without losing any precision, store it that way.
             @setFloatMode(.Strict);
-            const smaller_float = @floatCast(f64, float_number);
+            const smaller_float = @as(f64, @floatCast(float_number));
             const bigger_again: f128 = smaller_float;
             if (bigger_again == float_number) {
                 const result = try gz.addFloat(smaller_float);
@@ -7669,12 +7669,12 @@ fn numberLiteral(gz: *GenZir, ri: ResultInfo, node: Ast.Node.Index, source_node:
             }
             // We need to use 128 bits. Break the float into 4 u32 values so we can
             // put it into the `extra` array.
-            const int_bits = @bitCast(u128, float_number);
+            const int_bits = @as(u128, @bitCast(float_number));
             const result = try gz.addPlNode(.float128, node, Zir.Inst.Float128{
-                .piece0 = @truncate(u32, int_bits),
-                .piece1 = @truncate(u32, int_bits >> 32),
-                .piece2 = @truncate(u32, int_bits >> 64),
-                .piece3 = @truncate(u32, int_bits >> 96),
+                .piece0 = @as(u32, @truncate(int_bits)),
+                .piece1 = @as(u32, @truncate(int_bits >> 32)),
+                .piece2 = @as(u32, @truncate(int_bits >> 64)),
+                .piece3 = @as(u32, @truncate(int_bits >> 96)),
             });
             return rvalue(gz, ri, result, source_node);
         },
@@ -7700,22 +7700,22 @@ fn failWithNumberError(astgen: *AstGen, err: std.zig.number_literal.Error, token
             });
         },
         .digit_after_base => return astgen.failTok(token, "expected a digit after base prefix", .{}),
-        .upper_case_base => |i| return astgen.failOff(token, @intCast(u32, i), "base prefix must be lowercase", .{}),
-        .invalid_float_base => |i| return astgen.failOff(token, @intCast(u32, i), "invalid base for float literal", .{}),
-        .repeated_underscore => |i| return astgen.failOff(token, @intCast(u32, i), "repeated digit separator", .{}),
-        .invalid_underscore_after_special => |i| return astgen.failOff(token, @intCast(u32, i), "expected digit before digit separator", .{}),
-        .invalid_digit => |info| return astgen.failOff(token, @intCast(u32, info.i), "invalid digit '{c}' for {s} base", .{ bytes[info.i], @tagName(info.base) }),
-        .invalid_digit_exponent => |i| return astgen.failOff(token, @intCast(u32, i), "invalid digit '{c}' in exponent", .{bytes[i]}),
-        .duplicate_exponent => |i| return astgen.failOff(token, @intCast(u32, i), "duplicate exponent", .{}),
-        .exponent_after_underscore => |i| return astgen.failOff(token, @intCast(u32, i), "expected digit before exponent", .{}),
-        .special_after_underscore => |i| return astgen.failOff(token, @intCast(u32, i), "expected digit before '{c}'", .{bytes[i]}),
-        .trailing_special => |i| return astgen.failOff(token, @intCast(u32, i), "expected digit after '{c}'", .{bytes[i - 1]}),
-        .trailing_underscore => |i| return astgen.failOff(token, @intCast(u32, i), "trailing digit separator", .{}),
+        .upper_case_base => |i| return astgen.failOff(token, @as(u32, @intCast(i)), "base prefix must be lowercase", .{}),
+        .invalid_float_base => |i| return astgen.failOff(token, @as(u32, @intCast(i)), "invalid base for float literal", .{}),
+        .repeated_underscore => |i| return astgen.failOff(token, @as(u32, @intCast(i)), "repeated digit separator", .{}),
+        .invalid_underscore_after_special => |i| return astgen.failOff(token, @as(u32, @intCast(i)), "expected digit before digit separator", .{}),
+        .invalid_digit => |info| return astgen.failOff(token, @as(u32, @intCast(info.i)), "invalid digit '{c}' for {s} base", .{ bytes[info.i], @tagName(info.base) }),
+        .invalid_digit_exponent => |i| return astgen.failOff(token, @as(u32, @intCast(i)), "invalid digit '{c}' in exponent", .{bytes[i]}),
+        .duplicate_exponent => |i| return astgen.failOff(token, @as(u32, @intCast(i)), "duplicate exponent", .{}),
+        .exponent_after_underscore => |i| return astgen.failOff(token, @as(u32, @intCast(i)), "expected digit before exponent", .{}),
+        .special_after_underscore => |i| return astgen.failOff(token, @as(u32, @intCast(i)), "expected digit before '{c}'", .{bytes[i]}),
+        .trailing_special => |i| return astgen.failOff(token, @as(u32, @intCast(i)), "expected digit after '{c}'", .{bytes[i - 1]}),
+        .trailing_underscore => |i| return astgen.failOff(token, @as(u32, @intCast(i)), "trailing digit separator", .{}),
         .duplicate_period => unreachable, // Validated by tokenizer
         .invalid_character => unreachable, // Validated by tokenizer
         .invalid_exponent_sign => |i| {
             assert(bytes.len >= 2 and bytes[0] == '0' and bytes[1] == 'x'); // Validated by tokenizer
-            return astgen.failOff(token, @intCast(u32, i), "sign '{c}' cannot follow digit '{c}' in hex base", .{ bytes[i], bytes[i - 1] });
+            return astgen.failOff(token, @as(u32, @intCast(i)), "sign '{c}' cannot follow digit '{c}' in hex base", .{ bytes[i], bytes[i - 1] });
         },
     }
 }
@@ -7782,7 +7782,7 @@ fn asmExpr(
             if (output_type_bits != 0) {
                 return astgen.failNode(output_node, "inline assembly allows up to one output value", .{});
             }
-            output_type_bits |= @as(u32, 1) << @intCast(u5, i);
+            output_type_bits |= @as(u32, 1) << @as(u5, @intCast(i));
             const out_type_node = node_datas[output_node].lhs;
             const out_type_inst = try typeExpr(gz, scope, out_type_node);
             outputs[i] = .{
@@ -7991,8 +7991,8 @@ fn typeOf(
     const body = typeof_scope.instructionsSlice();
     const body_len = astgen.countBodyLenAfterFixups(body);
     astgen.setExtra(payload_index, Zir.Inst.TypeOfPeer{
-        .body_len = @intCast(u32, body_len),
-        .body_index = @intCast(u32, astgen.extra.items.len),
+        .body_len = @as(u32, @intCast(body_len)),
+        .body_index = @as(u32, @intCast(astgen.extra.items.len)),
         .src_node = gz.nodeIndexToRelative(node),
     });
     try astgen.extra.ensureUnusedCapacity(gpa, body_len);
@@ -8337,7 +8337,7 @@ fn builtinCall(
                 .node = gz.nodeIndexToRelative(node),
                 .operand = operand,
             });
-            const new_index = @intCast(Zir.Inst.Index, gz.astgen.instructions.len);
+            const new_index = @as(Zir.Inst.Index, @intCast(gz.astgen.instructions.len));
             gz.astgen.instructions.appendAssumeCapacity(.{
                 .tag = .extended,
                 .data = .{ .extended = .{
@@ -9015,7 +9015,7 @@ fn callExpr(
     }
     assert(node != 0);
 
-    const call_index = @intCast(Zir.Inst.Index, astgen.instructions.len);
+    const call_index = @as(Zir.Inst.Index, @intCast(astgen.instructions.len));
     const call_inst = Zir.indexToRef(call_index);
     try gz.astgen.instructions.append(astgen.gpa, undefined);
     try gz.instructions.append(astgen.gpa, call_index);
@@ -9039,7 +9039,7 @@ fn callExpr(
         try astgen.scratch.ensureUnusedCapacity(astgen.gpa, countBodyLenAfterFixups(astgen, body));
         appendBodyWithFixupsArrayList(astgen, &astgen.scratch, body);
 
-        astgen.scratch.items[scratch_index] = @intCast(u32, astgen.scratch.items.len - scratch_top);
+        astgen.scratch.items[scratch_index] = @as(u32, @intCast(astgen.scratch.items.len - scratch_top));
         scratch_index += 1;
     }
 
@@ -9057,8 +9057,8 @@ fn callExpr(
                 .callee = callee_obj,
                 .flags = .{
                     .pop_error_return_trace = !propagate_error_trace,
-                    .packed_modifier = @intCast(Zir.Inst.Call.Flags.PackedModifier, @intFromEnum(modifier)),
-                    .args_len = @intCast(Zir.Inst.Call.Flags.PackedArgsLen, call.ast.params.len),
+                    .packed_modifier = @as(Zir.Inst.Call.Flags.PackedModifier, @intCast(@intFromEnum(modifier))),
+                    .args_len = @as(Zir.Inst.Call.Flags.PackedArgsLen, @intCast(call.ast.params.len)),
                 },
             });
             if (call.ast.params.len != 0) {
@@ -9078,8 +9078,8 @@ fn callExpr(
                 .field_name_start = callee_field.field_name_start,
                 .flags = .{
                     .pop_error_return_trace = !propagate_error_trace,
-                    .packed_modifier = @intCast(Zir.Inst.Call.Flags.PackedModifier, @intFromEnum(modifier)),
-                    .args_len = @intCast(Zir.Inst.Call.Flags.PackedArgsLen, call.ast.params.len),
+                    .packed_modifier = @as(Zir.Inst.Call.Flags.PackedModifier, @intCast(@intFromEnum(modifier))),
+                    .args_len = @as(Zir.Inst.Call.Flags.PackedArgsLen, @intCast(call.ast.params.len)),
                 },
             });
             if (call.ast.params.len != 0) {
@@ -10450,7 +10450,7 @@ fn failWithStrLitError(astgen: *AstGen, err: std.zig.string_literal.Error, token
         .invalid_escape_character => |bad_index| {
             return astgen.failOff(
                 token,
-                offset + @intCast(u32, bad_index),
+                offset + @as(u32, @intCast(bad_index)),
                 "invalid escape character: '{c}'",
                 .{raw_string[bad_index]},
             );
@@ -10458,7 +10458,7 @@ fn failWithStrLitError(astgen: *AstGen, err: std.zig.string_literal.Error, token
         .expected_hex_digit => |bad_index| {
             return astgen.failOff(
                 token,
-                offset + @intCast(u32, bad_index),
+                offset + @as(u32, @intCast(bad_index)),
                 "expected hex digit, found '{c}'",
                 .{raw_string[bad_index]},
             );
@@ -10466,7 +10466,7 @@ fn failWithStrLitError(astgen: *AstGen, err: std.zig.string_literal.Error, token
         .empty_unicode_escape_sequence => |bad_index| {
             return astgen.failOff(
                 token,
-                offset + @intCast(u32, bad_index),
+                offset + @as(u32, @intCast(bad_index)),
                 "empty unicode escape sequence",
                 .{},
             );
@@ -10474,7 +10474,7 @@ fn failWithStrLitError(astgen: *AstGen, err: std.zig.string_literal.Error, token
         .expected_hex_digit_or_rbrace => |bad_index| {
             return astgen.failOff(
                 token,
-                offset + @intCast(u32, bad_index),
+                offset + @as(u32, @intCast(bad_index)),
                 "expected hex digit or '}}', found '{c}'",
                 .{raw_string[bad_index]},
             );
@@ -10482,7 +10482,7 @@ fn failWithStrLitError(astgen: *AstGen, err: std.zig.string_literal.Error, token
         .invalid_unicode_codepoint => |bad_index| {
             return astgen.failOff(
                 token,
-                offset + @intCast(u32, bad_index),
+                offset + @as(u32, @intCast(bad_index)),
                 "unicode escape does not correspond to a valid codepoint",
                 .{},
             );
@@ -10490,7 +10490,7 @@ fn failWithStrLitError(astgen: *AstGen, err: std.zig.string_literal.Error, token
         .expected_lbrace => |bad_index| {
             return astgen.failOff(
                 token,
-                offset + @intCast(u32, bad_index),
+                offset + @as(u32, @intCast(bad_index)),
                 "expected '{{', found '{c}",
                 .{raw_string[bad_index]},
             );
@@ -10498,7 +10498,7 @@ fn failWithStrLitError(astgen: *AstGen, err: std.zig.string_literal.Error, token
         .expected_rbrace => |bad_index| {
             return astgen.failOff(
                 token,
-                offset + @intCast(u32, bad_index),
+                offset + @as(u32, @intCast(bad_index)),
                 "expected '}}', found '{c}",
                 .{raw_string[bad_index]},
             );
@@ -10506,7 +10506,7 @@ fn failWithStrLitError(astgen: *AstGen, err: std.zig.string_literal.Error, token
         .expected_single_quote => |bad_index| {
             return astgen.failOff(
                 token,
-                offset + @intCast(u32, bad_index),
+                offset + @as(u32, @intCast(bad_index)),
                 "expected single quote ('), found '{c}",
                 .{raw_string[bad_index]},
             );
@@ -10514,7 +10514,7 @@ fn failWithStrLitError(astgen: *AstGen, err: std.zig.string_literal.Error, token
         .invalid_character => |bad_index| {
             return astgen.failOff(
                 token,
-                offset + @intCast(u32, bad_index),
+                offset + @as(u32, @intCast(bad_index)),
                 "invalid byte in string or character literal: '{c}'",
                 .{raw_string[bad_index]},
             );
@@ -10549,14 +10549,14 @@ fn appendErrorNodeNotes(
 ) Allocator.Error!void {
     @setCold(true);
     const string_bytes = &astgen.string_bytes;
-    const msg = @intCast(u32, string_bytes.items.len);
+    const msg = @as(u32, @intCast(string_bytes.items.len));
     try string_bytes.writer(astgen.gpa).print(format ++ "\x00", args);
     const notes_index: u32 = if (notes.len != 0) blk: {
         const notes_start = astgen.extra.items.len;
         try astgen.extra.ensureTotalCapacity(astgen.gpa, notes_start + 1 + notes.len);
-        astgen.extra.appendAssumeCapacity(@intCast(u32, notes.len));
+        astgen.extra.appendAssumeCapacity(@as(u32, @intCast(notes.len)));
         astgen.extra.appendSliceAssumeCapacity(notes);
-        break :blk @intCast(u32, notes_start);
+        break :blk @as(u32, @intCast(notes_start));
     } else 0;
     try astgen.compile_errors.append(astgen.gpa, .{
         .msg = msg,
@@ -10641,14 +10641,14 @@ fn appendErrorTokNotesOff(
     @setCold(true);
     const gpa = astgen.gpa;
     const string_bytes = &astgen.string_bytes;
-    const msg = @intCast(u32, string_bytes.items.len);
+    const msg = @as(u32, @intCast(string_bytes.items.len));
     try string_bytes.writer(gpa).print(format ++ "\x00", args);
     const notes_index: u32 = if (notes.len != 0) blk: {
         const notes_start = astgen.extra.items.len;
         try astgen.extra.ensureTotalCapacity(gpa, notes_start + 1 + notes.len);
-        astgen.extra.appendAssumeCapacity(@intCast(u32, notes.len));
+        astgen.extra.appendAssumeCapacity(@as(u32, @intCast(notes.len)));
         astgen.extra.appendSliceAssumeCapacity(notes);
-        break :blk @intCast(u32, notes_start);
+        break :blk @as(u32, @intCast(notes_start));
     } else 0;
     try astgen.compile_errors.append(gpa, .{
         .msg = msg,
@@ -10677,7 +10677,7 @@ fn errNoteTokOff(
 ) Allocator.Error!u32 {
     @setCold(true);
     const string_bytes = &astgen.string_bytes;
-    const msg = @intCast(u32, string_bytes.items.len);
+    const msg = @as(u32, @intCast(string_bytes.items.len));
     try string_bytes.writer(astgen.gpa).print(format ++ "\x00", args);
     return astgen.addExtra(Zir.Inst.CompileErrors.Item{
         .msg = msg,
@@ -10696,7 +10696,7 @@ fn errNoteNode(
 ) Allocator.Error!u32 {
     @setCold(true);
     const string_bytes = &astgen.string_bytes;
-    const msg = @intCast(u32, string_bytes.items.len);
+    const msg = @as(u32, @intCast(string_bytes.items.len));
     try string_bytes.writer(astgen.gpa).print(format ++ "\x00", args);
     return astgen.addExtra(Zir.Inst.CompileErrors.Item{
         .msg = msg,
@@ -10710,7 +10710,7 @@ fn errNoteNode(
 fn identAsString(astgen: *AstGen, ident_token: Ast.TokenIndex) !u32 {
     const gpa = astgen.gpa;
     const string_bytes = &astgen.string_bytes;
-    const str_index = @intCast(u32, string_bytes.items.len);
+    const str_index = @as(u32, @intCast(string_bytes.items.len));
     try astgen.appendIdentStr(ident_token, string_bytes);
     const key: []const u8 = string_bytes.items[str_index..];
     const gop = try astgen.string_table.getOrPutContextAdapted(gpa, key, StringIndexAdapter{
@@ -10756,7 +10756,7 @@ fn docCommentAsStringFromFirst(
 
     const gpa = astgen.gpa;
     const string_bytes = &astgen.string_bytes;
-    const str_index = @intCast(u32, string_bytes.items.len);
+    const str_index = @as(u32, @intCast(string_bytes.items.len));
     const token_starts = astgen.tree.tokens.items(.start);
     const token_tags = astgen.tree.tokens.items(.tag);
 
@@ -10799,7 +10799,7 @@ const IndexSlice = struct { index: u32, len: u32 };
 fn strLitAsString(astgen: *AstGen, str_lit_token: Ast.TokenIndex) !IndexSlice {
     const gpa = astgen.gpa;
     const string_bytes = &astgen.string_bytes;
-    const str_index = @intCast(u32, string_bytes.items.len);
+    const str_index = @as(u32, @intCast(string_bytes.items.len));
     const token_bytes = astgen.tree.tokenSlice(str_lit_token);
     try astgen.parseStrLit(str_lit_token, string_bytes, token_bytes, 0);
     const key = string_bytes.items[str_index..];
@@ -10812,7 +10812,7 @@ fn strLitAsString(astgen: *AstGen, str_lit_token: Ast.TokenIndex) !IndexSlice {
         string_bytes.shrinkRetainingCapacity(str_index);
         return IndexSlice{
             .index = gop.key_ptr.*,
-            .len = @intCast(u32, key.len),
+            .len = @as(u32, @intCast(key.len)),
         };
     } else {
         gop.key_ptr.* = str_index;
@@ -10822,7 +10822,7 @@ fn strLitAsString(astgen: *AstGen, str_lit_token: Ast.TokenIndex) !IndexSlice {
         try string_bytes.append(gpa, 0);
         return IndexSlice{
             .index = str_index,
-            .len = @intCast(u32, key.len),
+            .len = @as(u32, @intCast(key.len)),
         };
     }
 }
@@ -10859,15 +10859,15 @@ fn strLitNodeAsString(astgen: *AstGen, node: Ast.Node.Index) !IndexSlice {
     const len = string_bytes.items.len - str_index;
     try string_bytes.append(gpa, 0);
     return IndexSlice{
-        .index = @intCast(u32, str_index),
-        .len = @intCast(u32, len),
+        .index = @as(u32, @intCast(str_index)),
+        .len = @as(u32, @intCast(len)),
     };
 }
 
 fn testNameString(astgen: *AstGen, str_lit_token: Ast.TokenIndex) !u32 {
     const gpa = astgen.gpa;
     const string_bytes = &astgen.string_bytes;
-    const str_index = @intCast(u32, string_bytes.items.len);
+    const str_index = @as(u32, @intCast(string_bytes.items.len));
     const token_bytes = astgen.tree.tokenSlice(str_lit_token);
     try string_bytes.append(gpa, 0); // Indicates this is a test.
     try astgen.parseStrLit(str_lit_token, string_bytes, token_bytes, 0);
@@ -11219,7 +11219,7 @@ const GenZir = struct {
     }
 
     fn nodeIndexToRelative(gz: GenZir, node_index: Ast.Node.Index) i32 {
-        return @bitCast(i32, node_index) - @bitCast(i32, gz.decl_node_index);
+        return @as(i32, @bitCast(node_index)) - @as(i32, @bitCast(gz.decl_node_index));
     }
 
     fn tokenIndexToRelative(gz: GenZir, token: Ast.TokenIndex) u32 {
@@ -11376,7 +11376,7 @@ const GenZir = struct {
         const astgen = gz.astgen;
         const gpa = astgen.gpa;
         const ret_ref = if (args.ret_ref == .void_type) .none else args.ret_ref;
-        const new_index = @intCast(Zir.Inst.Index, astgen.instructions.len);
+        const new_index = @as(Zir.Inst.Index, @intCast(astgen.instructions.len));
 
         try astgen.instructions.ensureUnusedCapacity(gpa, 1);
 
@@ -11394,8 +11394,8 @@ const GenZir = struct {
             const block = node_datas[fn_decl].rhs;
             const rbrace_start = token_starts[tree.lastToken(block)];
             astgen.advanceSourceCursor(rbrace_start);
-            const rbrace_line = @intCast(u32, astgen.source_line - gz.decl_line);
-            const rbrace_column = @intCast(u32, astgen.source_column);
+            const rbrace_line = @as(u32, @intCast(astgen.source_line - gz.decl_line));
+            const rbrace_column = @as(u32, @intCast(astgen.source_column));
 
             const columns = args.lbrace_column | (rbrace_column << 16);
             src_locs_buffer[0] = args.lbrace_line;
@@ -11631,18 +11631,18 @@ const GenZir = struct {
             astgen.extra.appendAssumeCapacity(@intFromEnum(args.init));
         }
 
-        const new_index = @intCast(Zir.Inst.Index, astgen.instructions.len);
+        const new_index = @as(Zir.Inst.Index, @intCast(astgen.instructions.len));
         astgen.instructions.appendAssumeCapacity(.{
             .tag = .extended,
             .data = .{ .extended = .{
                 .opcode = .variable,
-                .small = @bitCast(u16, Zir.Inst.ExtendedVar.Small{
+                .small = @as(u16, @bitCast(Zir.Inst.ExtendedVar.Small{
                     .has_lib_name = args.lib_name != 0,
                     .has_align = args.align_inst != .none,
                     .has_init = args.init != .none,
                     .is_extern = args.is_extern,
                     .is_threadlocal = args.is_threadlocal,
-                }),
+                })),
                 .operand = payload_index,
             } },
         });
@@ -11662,7 +11662,7 @@ const GenZir = struct {
         try gz.instructions.ensureUnusedCapacity(gpa, 1);
         try gz.astgen.instructions.ensureUnusedCapacity(gpa, 1);
 
-        const new_index = @intCast(Zir.Inst.Index, gz.astgen.instructions.len);
+        const new_index = @as(Zir.Inst.Index, @intCast(gz.astgen.instructions.len));
         gz.astgen.instructions.appendAssumeCapacity(.{
             .tag = tag,
             .data = .{ .bool_br = .{
@@ -11688,12 +11688,12 @@ const GenZir = struct {
         try astgen.instructions.ensureUnusedCapacity(gpa, 1);
         try astgen.string_bytes.ensureUnusedCapacity(gpa, @sizeOf(std.math.big.Limb) * limbs.len);
 
-        const new_index = @intCast(Zir.Inst.Index, astgen.instructions.len);
+        const new_index = @as(Zir.Inst.Index, @intCast(astgen.instructions.len));
         astgen.instructions.appendAssumeCapacity(.{
             .tag = .int_big,
             .data = .{ .str = .{
-                .start = @intCast(u32, astgen.string_bytes.items.len),
-                .len = @intCast(u32, limbs.len),
+                .start = @as(u32, @intCast(astgen.string_bytes.items.len)),
+                .len = @as(u32, @intCast(limbs.len)),
             } },
         });
         gz.instructions.appendAssumeCapacity(new_index);
@@ -11733,7 +11733,7 @@ const GenZir = struct {
         src_node: Ast.Node.Index,
     ) !Zir.Inst.Index {
         assert(operand != .none);
-        const new_index = @intCast(Zir.Inst.Index, gz.astgen.instructions.len);
+        const new_index = @as(Zir.Inst.Index, @intCast(gz.astgen.instructions.len));
         try gz.astgen.instructions.append(gz.astgen.gpa, .{
             .tag = tag,
             .data = .{ .un_node = .{
@@ -11756,7 +11756,7 @@ const GenZir = struct {
         try gz.astgen.instructions.ensureUnusedCapacity(gpa, 1);
 
         const payload_index = try gz.astgen.addExtra(extra);
-        const new_index = @intCast(Zir.Inst.Index, gz.astgen.instructions.len);
+        const new_index = @as(Zir.Inst.Index, @intCast(gz.astgen.instructions.len));
         gz.astgen.instructions.appendAssumeCapacity(.{
             .tag = tag,
             .data = .{ .pl_node = .{
@@ -11808,12 +11808,12 @@ const GenZir = struct {
         const payload_index = gz.astgen.addExtraAssumeCapacity(Zir.Inst.Param{
             .name = name,
             .doc_comment = doc_comment_index,
-            .body_len = @intCast(u32, body_len),
+            .body_len = @as(u32, @intCast(body_len)),
         });
         gz.astgen.appendBodyWithFixups(param_body);
         param_gz.unstack();
 
-        const new_index = @intCast(Zir.Inst.Index, gz.astgen.instructions.len);
+        const new_index = @as(Zir.Inst.Index, @intCast(gz.astgen.instructions.len));
         gz.astgen.instructions.appendAssumeCapacity(.{
             .tag = tag,
             .data = .{ .pl_tok = .{
@@ -11841,7 +11841,7 @@ const GenZir = struct {
         try gz.astgen.instructions.ensureUnusedCapacity(gpa, 1);
 
         const payload_index = try gz.astgen.addExtra(extra);
-        const new_index = @intCast(Zir.Inst.Index, gz.astgen.instructions.len);
+        const new_index = @as(Zir.Inst.Index, @intCast(gz.astgen.instructions.len));
         gz.astgen.instructions.appendAssumeCapacity(.{
             .tag = .extended,
             .data = .{ .extended = .{
@@ -11873,12 +11873,12 @@ const GenZir = struct {
         const payload_index = astgen.addExtraAssumeCapacity(Zir.Inst.NodeMultiOp{
             .src_node = gz.nodeIndexToRelative(node),
         });
-        const new_index = @intCast(Zir.Inst.Index, astgen.instructions.len);
+        const new_index = @as(Zir.Inst.Index, @intCast(astgen.instructions.len));
         astgen.instructions.appendAssumeCapacity(.{
             .tag = .extended,
             .data = .{ .extended = .{
                 .opcode = opcode,
-                .small = @intCast(u16, operands.len),
+                .small = @as(u16, @intCast(operands.len)),
                 .operand = payload_index,
             } },
         });
@@ -11898,12 +11898,12 @@ const GenZir = struct {
 
         try gz.instructions.ensureUnusedCapacity(gpa, 1);
         try astgen.instructions.ensureUnusedCapacity(gpa, 1);
-        const new_index = @intCast(Zir.Inst.Index, astgen.instructions.len);
+        const new_index = @as(Zir.Inst.Index, @intCast(astgen.instructions.len));
         astgen.instructions.appendAssumeCapacity(.{
             .tag = .extended,
             .data = .{ .extended = .{
                 .opcode = opcode,
-                .small = @intCast(u16, trailing_len),
+                .small = @as(u16, @intCast(trailing_len)),
                 .operand = payload_index,
             } },
         });
@@ -11936,7 +11936,7 @@ const GenZir = struct {
         abs_tok_index: Ast.TokenIndex,
     ) !Zir.Inst.Index {
         const astgen = gz.astgen;
-        const new_index = @intCast(Zir.Inst.Index, astgen.instructions.len);
+        const new_index = @as(Zir.Inst.Index, @intCast(astgen.instructions.len));
         assert(operand != .none);
         try astgen.instructions.append(astgen.gpa, .{
             .tag = tag,
@@ -12019,7 +12019,7 @@ const GenZir = struct {
             .operand_src_node = Zir.Inst.Break.no_src_node,
         };
         const payload_index = try gz.astgen.addExtra(extra);
-        const new_index = @intCast(Zir.Inst.Index, gz.astgen.instructions.len);
+        const new_index = @as(Zir.Inst.Index, @intCast(gz.astgen.instructions.len));
         gz.astgen.instructions.appendAssumeCapacity(.{
             .tag = tag,
             .data = .{ .@"break" = .{
@@ -12045,7 +12045,7 @@ const GenZir = struct {
             .operand_src_node = Zir.Inst.Break.no_src_node,
         };
         const payload_index = try gz.astgen.addExtra(extra);
-        const new_index = @intCast(Zir.Inst.Index, gz.astgen.instructions.len);
+        const new_index = @as(Zir.Inst.Index, @intCast(gz.astgen.instructions.len));
         gz.astgen.instructions.appendAssumeCapacity(.{
             .tag = tag,
             .data = .{ .@"break" = .{
@@ -12072,7 +12072,7 @@ const GenZir = struct {
             .operand_src_node = gz.nodeIndexToRelative(operand_src_node),
         };
         const payload_index = try gz.astgen.addExtra(extra);
-        const new_index = @intCast(Zir.Inst.Index, gz.astgen.instructions.len);
+        const new_index = @as(Zir.Inst.Index, @intCast(gz.astgen.instructions.len));
         gz.astgen.instructions.appendAssumeCapacity(.{
             .tag = tag,
             .data = .{ .@"break" = .{
@@ -12099,7 +12099,7 @@ const GenZir = struct {
             .operand_src_node = gz.nodeIndexToRelative(operand_src_node),
         };
         const payload_index = try gz.astgen.addExtra(extra);
-        const new_index = @intCast(Zir.Inst.Index, gz.astgen.instructions.len);
+        const new_index = @as(Zir.Inst.Index, @intCast(gz.astgen.instructions.len));
         gz.astgen.instructions.appendAssumeCapacity(.{
             .tag = tag,
             .data = .{ .@"break" = .{
@@ -12191,7 +12191,7 @@ const GenZir = struct {
             .data = .{ .extended = .{
                 .opcode = opcode,
                 .small = undefined,
-                .operand = @bitCast(u32, gz.nodeIndexToRelative(src_node)),
+                .operand = @as(u32, @bitCast(gz.nodeIndexToRelative(src_node))),
             } },
         });
     }
@@ -12234,7 +12234,7 @@ const GenZir = struct {
         const is_comptime: u4 = @intFromBool(args.is_comptime);
         const small: u16 = has_type | (has_align << 1) | (is_const << 2) | (is_comptime << 3);
 
-        const new_index = @intCast(Zir.Inst.Index, astgen.instructions.len);
+        const new_index = @as(Zir.Inst.Index, @intCast(astgen.instructions.len));
         astgen.instructions.appendAssumeCapacity(.{
             .tag = .extended,
             .data = .{ .extended = .{
@@ -12288,12 +12288,12 @@ const GenZir = struct {
         //  * 0b000000XX_XXX00000 - `inputs_len`.
         //  * 0b0XXXXX00_00000000 - `clobbers_len`.
         //  * 0bX0000000_00000000 - is volatile
-        const small: u16 = @intCast(u16, args.outputs.len) |
-            @intCast(u16, args.inputs.len << 5) |
-            @intCast(u16, args.clobbers.len << 10) |
+        const small: u16 = @as(u16, @intCast(args.outputs.len)) |
+            @as(u16, @intCast(args.inputs.len << 5)) |
+            @as(u16, @intCast(args.clobbers.len << 10)) |
             (@as(u16, @intFromBool(args.is_volatile)) << 15);
 
-        const new_index = @intCast(Zir.Inst.Index, astgen.instructions.len);
+        const new_index = @as(Zir.Inst.Index, @intCast(astgen.instructions.len));
         astgen.instructions.appendAssumeCapacity(.{
             .tag = .extended,
             .data = .{ .extended = .{
@@ -12310,7 +12310,7 @@ const GenZir = struct {
     /// Does *not* append the block instruction to the scope.
     /// Leaves the `payload_index` field undefined.
     fn makeBlockInst(gz: *GenZir, tag: Zir.Inst.Tag, node: Ast.Node.Index) !Zir.Inst.Index {
-        const new_index = @intCast(Zir.Inst.Index, gz.astgen.instructions.len);
+        const new_index = @as(Zir.Inst.Index, @intCast(gz.astgen.instructions.len));
         const gpa = gz.astgen.gpa;
         try gz.astgen.instructions.append(gpa, .{
             .tag = tag,
@@ -12327,7 +12327,7 @@ const GenZir = struct {
     fn addCondBr(gz: *GenZir, tag: Zir.Inst.Tag, node: Ast.Node.Index) !Zir.Inst.Index {
         const gpa = gz.astgen.gpa;
         try gz.instructions.ensureUnusedCapacity(gpa, 1);
-        const new_index = @intCast(Zir.Inst.Index, gz.astgen.instructions.len);
+        const new_index = @as(Zir.Inst.Index, @intCast(gz.astgen.instructions.len));
         try gz.astgen.instructions.append(gpa, .{
             .tag = tag,
             .data = .{ .pl_node = .{
@@ -12354,11 +12354,11 @@ const GenZir = struct {
         const gpa = astgen.gpa;
 
         try astgen.extra.ensureUnusedCapacity(gpa, 6);
-        const payload_index = @intCast(u32, astgen.extra.items.len);
+        const payload_index = @as(u32, @intCast(astgen.extra.items.len));
 
         if (args.src_node != 0) {
             const node_offset = gz.nodeIndexToRelative(args.src_node);
-            astgen.extra.appendAssumeCapacity(@bitCast(u32, node_offset));
+            astgen.extra.appendAssumeCapacity(@as(u32, @bitCast(node_offset)));
         }
         if (args.fields_len != 0) {
             astgen.extra.appendAssumeCapacity(args.fields_len);
@@ -12376,7 +12376,7 @@ const GenZir = struct {
             .tag = .extended,
             .data = .{ .extended = .{
                 .opcode = .struct_decl,
-                .small = @bitCast(u16, Zir.Inst.StructDecl.Small{
+                .small = @as(u16, @bitCast(Zir.Inst.StructDecl.Small{
                     .has_src_node = args.src_node != 0,
                     .has_fields_len = args.fields_len != 0,
                     .has_decls_len = args.decls_len != 0,
@@ -12386,7 +12386,7 @@ const GenZir = struct {
                     .is_tuple = args.is_tuple,
                     .name_strategy = gz.anon_name_strategy,
                     .layout = args.layout,
-                }),
+                })),
                 .operand = payload_index,
             } },
         });
@@ -12405,11 +12405,11 @@ const GenZir = struct {
         const gpa = astgen.gpa;
 
         try astgen.extra.ensureUnusedCapacity(gpa, 5);
-        const payload_index = @intCast(u32, astgen.extra.items.len);
+        const payload_index = @as(u32, @intCast(astgen.extra.items.len));
 
         if (args.src_node != 0) {
             const node_offset = gz.nodeIndexToRelative(args.src_node);
-            astgen.extra.appendAssumeCapacity(@bitCast(u32, node_offset));
+            astgen.extra.appendAssumeCapacity(@as(u32, @bitCast(node_offset)));
         }
         if (args.tag_type != .none) {
             astgen.extra.appendAssumeCapacity(@intFromEnum(args.tag_type));
@@ -12427,7 +12427,7 @@ const GenZir = struct {
             .tag = .extended,
             .data = .{ .extended = .{
                 .opcode = .union_decl,
-                .small = @bitCast(u16, Zir.Inst.UnionDecl.Small{
+                .small = @as(u16, @bitCast(Zir.Inst.UnionDecl.Small{
                     .has_src_node = args.src_node != 0,
                     .has_tag_type = args.tag_type != .none,
                     .has_body_len = args.body_len != 0,
@@ -12436,7 +12436,7 @@ const GenZir = struct {
                     .name_strategy = gz.anon_name_strategy,
                     .layout = args.layout,
                     .auto_enum_tag = args.auto_enum_tag,
-                }),
+                })),
                 .operand = payload_index,
             } },
         });
@@ -12454,11 +12454,11 @@ const GenZir = struct {
         const gpa = astgen.gpa;
 
         try astgen.extra.ensureUnusedCapacity(gpa, 5);
-        const payload_index = @intCast(u32, astgen.extra.items.len);
+        const payload_index = @as(u32, @intCast(astgen.extra.items.len));
 
         if (args.src_node != 0) {
             const node_offset = gz.nodeIndexToRelative(args.src_node);
-            astgen.extra.appendAssumeCapacity(@bitCast(u32, node_offset));
+            astgen.extra.appendAssumeCapacity(@as(u32, @bitCast(node_offset)));
         }
         if (args.tag_type != .none) {
             astgen.extra.appendAssumeCapacity(@intFromEnum(args.tag_type));
@@ -12476,7 +12476,7 @@ const GenZir = struct {
             .tag = .extended,
             .data = .{ .extended = .{
                 .opcode = .enum_decl,
-                .small = @bitCast(u16, Zir.Inst.EnumDecl.Small{
+                .small = @as(u16, @bitCast(Zir.Inst.EnumDecl.Small{
                     .has_src_node = args.src_node != 0,
                     .has_tag_type = args.tag_type != .none,
                     .has_body_len = args.body_len != 0,
@@ -12484,7 +12484,7 @@ const GenZir = struct {
                     .has_decls_len = args.decls_len != 0,
                     .name_strategy = gz.anon_name_strategy,
                     .nonexhaustive = args.nonexhaustive,
-                }),
+                })),
                 .operand = payload_index,
             } },
         });
@@ -12498,11 +12498,11 @@ const GenZir = struct {
         const gpa = astgen.gpa;
 
         try astgen.extra.ensureUnusedCapacity(gpa, 2);
-        const payload_index = @intCast(u32, astgen.extra.items.len);
+        const payload_index = @as(u32, @intCast(astgen.extra.items.len));
 
         if (args.src_node != 0) {
             const node_offset = gz.nodeIndexToRelative(args.src_node);
-            astgen.extra.appendAssumeCapacity(@bitCast(u32, node_offset));
+            astgen.extra.appendAssumeCapacity(@as(u32, @bitCast(node_offset)));
         }
         if (args.decls_len != 0) {
             astgen.extra.appendAssumeCapacity(args.decls_len);
@@ -12511,11 +12511,11 @@ const GenZir = struct {
             .tag = .extended,
             .data = .{ .extended = .{
                 .opcode = .opaque_decl,
-                .small = @bitCast(u16, Zir.Inst.OpaqueDecl.Small{
+                .small = @as(u16, @bitCast(Zir.Inst.OpaqueDecl.Small{
                     .has_src_node = args.src_node != 0,
                     .has_decls_len = args.decls_len != 0,
                     .name_strategy = gz.anon_name_strategy,
-                }),
+                })),
                 .operand = payload_index,
             } },
         });
@@ -12530,7 +12530,7 @@ const GenZir = struct {
         try gz.instructions.ensureUnusedCapacity(gpa, 1);
         try gz.astgen.instructions.ensureUnusedCapacity(gpa, 1);
 
-        const new_index = @intCast(Zir.Inst.Index, gz.astgen.instructions.len);
+        const new_index = @as(Zir.Inst.Index, @intCast(gz.astgen.instructions.len));
         gz.astgen.instructions.appendAssumeCapacity(inst);
         gz.instructions.appendAssumeCapacity(new_index);
         return new_index;
@@ -12541,7 +12541,7 @@ const GenZir = struct {
         try gz.instructions.ensureUnusedCapacity(gpa, 1);
         try gz.astgen.instructions.ensureUnusedCapacity(gpa, 1);
 
-        const new_index = @intCast(Zir.Inst.Index, gz.astgen.instructions.len);
+        const new_index = @as(Zir.Inst.Index, @intCast(gz.astgen.instructions.len));
         gz.astgen.instructions.len += 1;
         gz.instructions.appendAssumeCapacity(new_index);
         return new_index;
@@ -12593,7 +12593,7 @@ const GenZir = struct {
             return;
         }
 
-        const new_index = @intCast(Zir.Inst.Index, gz.astgen.instructions.len);
+        const new_index = @as(Zir.Inst.Index, @intCast(gz.astgen.instructions.len));
         try gz.astgen.instructions.append(gpa, .{ .tag = .dbg_block_end, .data = undefined });
         try gz.instructions.append(gpa, new_index);
     }
@@ -12602,7 +12602,7 @@ const GenZir = struct {
 /// This can only be for short-lived references; the memory becomes invalidated
 /// when another string is added.
 fn nullTerminatedString(astgen: AstGen, index: usize) [*:0]const u8 {
-    return @ptrCast([*:0]const u8, astgen.string_bytes.items.ptr) + index;
+    return @as([*:0]const u8, @ptrCast(astgen.string_bytes.items.ptr)) + index;
 }
 
 /// Local variables shadowing detection, including function parameters.
@@ -12881,7 +12881,7 @@ fn isInferred(astgen: *AstGen, ref: Zir.Inst.Ref) bool {
         .extended => {
             const zir_data = astgen.instructions.items(.data);
             if (zir_data[inst].extended.opcode != .alloc) return false;
-            const small = @bitCast(Zir.Inst.AllocExtended.Small, zir_data[inst].extended.small);
+            const small = @as(Zir.Inst.AllocExtended.Small, @bitCast(zir_data[inst].extended.small));
             return !small.has_type;
         },
 
@@ -12925,7 +12925,7 @@ fn countBodyLenAfterFixups(astgen: *AstGen, body: []const Zir.Inst.Index) u32 {
             check_inst = ref_inst;
         }
     }
-    return @intCast(u32, count);
+    return @as(u32, @intCast(count));
 }
 
 fn emitDbgStmt(gz: *GenZir, lc: LineColumn) !void {
@@ -12957,7 +12957,7 @@ fn lowerAstErrors(astgen: *AstGen) !void {
 
     if (token_tags[parse_err.token + @intFromBool(parse_err.token_is_prev)] == .invalid) {
         const tok = parse_err.token + @intFromBool(parse_err.token_is_prev);
-        const bad_off = @intCast(u32, tree.tokenSlice(parse_err.token + @intFromBool(parse_err.token_is_prev)).len);
+        const bad_off = @as(u32, @intCast(tree.tokenSlice(parse_err.token + @intFromBool(parse_err.token_is_prev)).len));
         const byte_abs = token_starts[parse_err.token + @intFromBool(parse_err.token_is_prev)] + bad_off;
         try notes.append(gpa, try astgen.errNoteTokOff(tok, bad_off, "invalid byte: '{'}'", .{
             std.zig.fmtEscapes(tree.source[byte_abs..][0..1]),

--- a/src/stage2/Module.zig
+++ b/src/stage2/Module.zig
@@ -23,7 +23,7 @@ pub const SrcLoc = struct {
     }
 
     pub fn declRelativeToNodeIndex(src_loc: SrcLoc, offset: i32) Ast.TokenIndex {
-        return @bitCast(Ast.Node.Index, offset + @bitCast(i32, src_loc.parent_decl_node));
+        return @as(Ast.Node.Index, @bitCast(offset + @as(i32, @bitCast(src_loc.parent_decl_node))));
     }
 
     pub const Span = struct {
@@ -42,7 +42,7 @@ pub const SrcLoc = struct {
             .token_abs => |tok_index| {
                 const tree = src_loc.handle.tree;
                 const start = tree.tokens.items(.start)[tok_index];
-                const end = start + @intCast(u32, tree.tokenSlice(tok_index).len);
+                const end = start + @as(u32, @intCast(tree.tokenSlice(tok_index).len));
                 return Span{ .start = start, .end = end, .main = start };
             },
             .node_abs => |node| {
@@ -53,14 +53,14 @@ pub const SrcLoc = struct {
                 const tree = src_loc.handle.tree;
                 const tok_index = src_loc.declSrcToken();
                 const start = tree.tokens.items(.start)[tok_index] + byte_off;
-                const end = start + @intCast(u32, tree.tokenSlice(tok_index).len);
+                const end = start + @as(u32, @intCast(tree.tokenSlice(tok_index).len));
                 return Span{ .start = start, .end = end, .main = start };
             },
             .token_offset => |tok_off| {
                 const tree = src_loc.handle.tree;
                 const tok_index = src_loc.declSrcToken() + tok_off;
                 const start = tree.tokens.items(.start)[tok_index];
-                const end = start + @intCast(u32, tree.tokenSlice(tok_index).len);
+                const end = start + @as(u32, @intCast(tree.tokenSlice(tok_index).len));
                 return Span{ .start = start, .end = end, .main = start };
             },
             .node_offset => |node_off| {
@@ -110,7 +110,7 @@ pub const SrcLoc = struct {
                 }
                 const tok_index = full.ast.mut_token + 1; // the name token
                 const start = tree.tokens.items(.start)[tok_index];
-                const end = start + @intCast(u32, tree.tokenSlice(tok_index).len);
+                const end = start + @as(u32, @intCast(tree.tokenSlice(tok_index).len));
                 return Span{ .start = start, .end = end, .main = start };
             },
             .node_offset_var_decl_align => |node_off| {
@@ -183,7 +183,7 @@ pub const SrcLoc = struct {
                     else => tree.firstToken(node) - 2,
                 };
                 const start = tree.tokens.items(.start)[tok_index];
-                const end = start + @intCast(u32, tree.tokenSlice(tok_index).len);
+                const end = start + @as(u32, @intCast(tree.tokenSlice(tok_index).len));
                 return Span{ .start = start, .end = end, .main = start };
             },
             .node_offset_deref_ptr => |node_off| {
@@ -243,7 +243,7 @@ pub const SrcLoc = struct {
                 // that contains this input.
                 const node_tags = tree.nodes.items(.tag);
                 for (node_tags, 0..) |node_tag, node_usize| {
-                    const node = @intCast(Ast.Node.Index, node_usize);
+                    const node = @as(Ast.Node.Index, @intCast(node_usize));
                     switch (node_tag) {
                         .for_simple, .@"for" => {
                             const for_full = tree.fullFor(node).?;
@@ -352,7 +352,7 @@ pub const SrcLoc = struct {
                 };
                 const start = tree.tokens.items(.start)[start_tok];
                 const end_start = tree.tokens.items(.start)[end_tok];
-                const end = end_start + @intCast(u32, tree.tokenSlice(end_tok).len);
+                const end = end_start + @as(u32, @intCast(tree.tokenSlice(end_tok).len));
                 return Span{ .start = start, .end = end, .main = start };
             },
             .node_offset_fn_type_align => |node_off| {
@@ -412,7 +412,7 @@ pub const SrcLoc = struct {
                 const tree = src_loc.handle.tree;
                 const token_tags = tree.tokens.items(.tag);
                 const main_token = tree.nodes.items(.main_token)[src_loc.parent_decl_node];
-                const tok_index = @bitCast(Ast.TokenIndex, token_off + @bitCast(i32, main_token));
+                const tok_index = @as(Ast.TokenIndex, @bitCast(token_off + @as(i32, @bitCast(main_token))));
 
                 var first_tok = tok_index;
                 while (true) switch (token_tags[first_tok - 1]) {
@@ -441,7 +441,7 @@ pub const SrcLoc = struct {
                 const full = tree.fullFnProto(&buf, parent_node).?;
                 const tok_index = full.lib_name.?;
                 const start = tree.tokens.items(.start)[tok_index];
-                const end = start + @intCast(u32, tree.tokenSlice(tok_index).len);
+                const end = start + @as(u32, @intCast(tree.tokenSlice(tok_index).len));
                 return Span{ .start = start, .end = end, .main = start };
             },
 
@@ -633,7 +633,7 @@ pub const SrcLoc = struct {
             end_tok = main;
         }
         const start_off = token_starts[start_tok];
-        const end_off = token_starts[end_tok] + @intCast(u32, tree.tokenSlice(end_tok).len);
+        const end_off = token_starts[end_tok] + @as(u32, @intCast(tree.tokenSlice(end_tok).len));
         return Span{ .start = start_off, .end = end_off, .main = token_starts[main] };
     }
 };

--- a/src/stage2/Zir.zig
+++ b/src/stage2/Zir.zig
@@ -71,12 +71,12 @@ pub fn extraData(code: Zir, comptime T: type, index: usize) struct { data: T, en
     inline for (fields) |field| {
         @field(result, field.name) = switch (field.type) {
             u32 => code.extra[i],
-            Inst.Ref => @enumFromInt(Inst.Ref, code.extra[i]),
-            i32 => @bitCast(i32, code.extra[i]),
-            Inst.Call.Flags => @bitCast(Inst.Call.Flags, code.extra[i]),
-            Inst.BuiltinCall.Flags => @bitCast(Inst.BuiltinCall.Flags, code.extra[i]),
-            Inst.SwitchBlock.Bits => @bitCast(Inst.SwitchBlock.Bits, code.extra[i]),
-            Inst.FuncFancy.Bits => @bitCast(Inst.FuncFancy.Bits, code.extra[i]),
+            Inst.Ref => @as(Inst.Ref, @enumFromInt(code.extra[i])),
+            i32 => @as(i32, @bitCast(code.extra[i])),
+            Inst.Call.Flags => @as(Inst.Call.Flags, @bitCast(code.extra[i])),
+            Inst.BuiltinCall.Flags => @as(Inst.BuiltinCall.Flags, @bitCast(code.extra[i])),
+            Inst.SwitchBlock.Bits => @as(Inst.SwitchBlock.Bits, @bitCast(code.extra[i])),
+            Inst.FuncFancy.Bits => @as(Inst.FuncFancy.Bits, @bitCast(code.extra[i])),
             else => @compileError("bad field type"),
         };
         i += 1;
@@ -98,7 +98,7 @@ pub fn nullTerminatedString(code: Zir, index: usize) [:0]const u8 {
 
 pub fn refSlice(code: Zir, start: usize, len: usize) []Inst.Ref {
     const raw_slice = code.extra[start..][0..len];
-    return @ptrCast([]Inst.Ref, raw_slice);
+    return @as([]Inst.Ref, @ptrCast(raw_slice));
 }
 
 pub fn hasCompileErrors(code: Zir) bool {
@@ -2973,7 +2973,7 @@ pub const Inst = struct {
                 (@as(u128, self.piece1) << 32) |
                 (@as(u128, self.piece2) << 64) |
                 (@as(u128, self.piece3) << 96);
-            return @bitCast(f128, int_bits);
+            return @as(f128, @bitCast(int_bits));
         }
     };
 
@@ -3209,15 +3209,15 @@ pub const DeclIterator = struct {
         }
         it.decl_i += 1;
 
-        const flags = @truncate(u4, it.cur_bit_bag);
+        const flags = @as(u4, @truncate(it.cur_bit_bag));
         it.cur_bit_bag >>= 4;
 
-        const sub_index = @intCast(u32, it.extra_index);
+        const sub_index = @as(u32, @intCast(it.extra_index));
         it.extra_index += 5; // src_hash(4) + line(1)
         const name = it.zir.nullTerminatedString(it.zir.extra[it.extra_index]);
         it.extra_index += 3; // name(1) + value(1) + doc_comment(1)
-        it.extra_index += @truncate(u1, flags >> 2);
-        it.extra_index += @truncate(u1, flags >> 3);
+        it.extra_index += @as(u1, @truncate(flags >> 2));
+        it.extra_index += @as(u1, @truncate(flags >> 3));
 
         return Item{
             .sub_index = sub_index,
@@ -3239,7 +3239,7 @@ pub fn declIterator(zir: Zir, decl_inst: u32) DeclIterator {
             const extended = datas[decl_inst].extended;
             switch (extended.opcode) {
                 .struct_decl => {
-                    const small = @bitCast(Inst.StructDecl.Small, extended.small);
+                    const small = @as(Inst.StructDecl.Small, @bitCast(extended.small));
                     var extra_index: usize = extended.operand;
                     extra_index += @intFromBool(small.has_src_node);
                     extra_index += @intFromBool(small.has_fields_len);
@@ -3262,7 +3262,7 @@ pub fn declIterator(zir: Zir, decl_inst: u32) DeclIterator {
                     return declIteratorInner(zir, extra_index, decls_len);
                 },
                 .enum_decl => {
-                    const small = @bitCast(Inst.EnumDecl.Small, extended.small);
+                    const small = @as(Inst.EnumDecl.Small, @bitCast(extended.small));
                     var extra_index: usize = extended.operand;
                     extra_index += @intFromBool(small.has_src_node);
                     extra_index += @intFromBool(small.has_tag_type);
@@ -3277,7 +3277,7 @@ pub fn declIterator(zir: Zir, decl_inst: u32) DeclIterator {
                     return declIteratorInner(zir, extra_index, decls_len);
                 },
                 .union_decl => {
-                    const small = @bitCast(Inst.UnionDecl.Small, extended.small);
+                    const small = @as(Inst.UnionDecl.Small, @bitCast(extended.small));
                     var extra_index: usize = extended.operand;
                     extra_index += @intFromBool(small.has_src_node);
                     extra_index += @intFromBool(small.has_tag_type);
@@ -3292,7 +3292,7 @@ pub fn declIterator(zir: Zir, decl_inst: u32) DeclIterator {
                     return declIteratorInner(zir, extra_index, decls_len);
                 },
                 .opaque_decl => {
-                    const small = @bitCast(Inst.OpaqueDecl.Small, extended.small);
+                    const small = @as(Inst.OpaqueDecl.Small, @bitCast(extended.small));
                     var extra_index: usize = extended.operand;
                     extra_index += @intFromBool(small.has_src_node);
                     const decls_len = if (small.has_decls_len) decls_len: {
@@ -3488,7 +3488,7 @@ fn findDeclsSwitch(
 
     const special_prong = extra.data.bits.specialProng();
     if (special_prong != .none) {
-        const body_len = @truncate(u31, zir.extra[extra_index]);
+        const body_len = @as(u31, @truncate(zir.extra[extra_index]));
         extra_index += 1;
         const body = zir.extra[extra_index..][0..body_len];
         extra_index += body.len;
@@ -3501,7 +3501,7 @@ fn findDeclsSwitch(
         var scalar_i: usize = 0;
         while (scalar_i < scalar_cases_len) : (scalar_i += 1) {
             extra_index += 1;
-            const body_len = @truncate(u31, zir.extra[extra_index]);
+            const body_len = @as(u31, @truncate(zir.extra[extra_index]));
             extra_index += 1;
             const body = zir.extra[extra_index..][0..body_len];
             extra_index += body_len;
@@ -3516,7 +3516,7 @@ fn findDeclsSwitch(
             extra_index += 1;
             const ranges_len = zir.extra[extra_index];
             extra_index += 1;
-            const body_len = @truncate(u31, zir.extra[extra_index]);
+            const body_len = @as(u31, @truncate(zir.extra[extra_index]));
             extra_index += 1;
             const items = zir.refSlice(extra_index, items_len);
             extra_index += items_len;
@@ -3598,7 +3598,7 @@ pub fn getFnInfo(zir: Zir, fn_inst: Inst.Index) FnInfo {
                     ret_ty_ref = .void_type;
                 },
                 1 => {
-                    ret_ty_ref = @enumFromInt(Inst.Ref, zir.extra[extra_index]);
+                    ret_ty_ref = @as(Inst.Ref, @enumFromInt(zir.extra[extra_index]));
                     extra_index += 1;
                 },
                 else => {
@@ -3652,7 +3652,7 @@ pub fn getFnInfo(zir: Zir, fn_inst: Inst.Index) FnInfo {
                 ret_ty_body = zir.extra[extra_index..][0..body_len];
                 extra_index += ret_ty_body.len;
             } else if (extra.data.bits.has_ret_ty_ref) {
-                ret_ty_ref = @enumFromInt(Inst.Ref, zir.extra[extra_index]);
+                ret_ty_ref = @as(Inst.Ref, @enumFromInt(zir.extra[extra_index]));
                 extra_index += 1;
             }
 
@@ -3696,7 +3696,7 @@ pub fn getFnInfo(zir: Zir, fn_inst: Inst.Index) FnInfo {
 pub const ref_start_index: u32 = @intFromEnum(Inst.Ref.ref_start_index);
 
 pub fn indexToRef(inst: Inst.Index) Inst.Ref {
-    return @enumFromInt(Inst.Ref, ref_start_index + inst);
+    return @as(Inst.Ref, @enumFromInt(ref_start_index + inst));
 }
 
 pub fn refToIndex(inst: Inst.Ref) ?Inst.Index {

--- a/src/tracy.zig
+++ b/src/tracy.zig
@@ -163,7 +163,7 @@ pub fn TracyAllocator(comptime name: ?[:0]const u8) type {
         }
 
         fn allocFn(ptr: *anyopaque, len: usize, ptr_align: u8, ret_addr: usize) ?[*]u8 {
-            const self = @ptrCast(*Self, @alignCast(@alignOf(Self), ptr));
+            const self: *Self = @ptrCast(@alignCast(ptr));
             const result = self.parent_allocator.rawAlloc(len, ptr_align, ret_addr);
             if (result) |data| {
                 if (len != 0) {
@@ -180,7 +180,7 @@ pub fn TracyAllocator(comptime name: ?[:0]const u8) type {
         }
 
         fn resizeFn(ptr: *anyopaque, buf: []u8, buf_align: u8, new_len: usize, ret_addr: usize) bool {
-            const self = @ptrCast(*Self, @alignCast(@alignOf(Self), ptr));
+            const self: *Self = @ptrCast(@alignCast(ptr));
             if (self.parent_allocator.rawResize(buf, buf_align, new_len, ret_addr)) {
                 if (name) |n| {
                     freeNamed(buf.ptr, n);
@@ -199,7 +199,7 @@ pub fn TracyAllocator(comptime name: ?[:0]const u8) type {
         }
 
         fn freeFn(ptr: *anyopaque, buf: []u8, buf_align: u8, ret_addr: usize) void {
-            const self = @ptrCast(*Self, @alignCast(@alignOf(Self), ptr));
+            const self: *Self = @ptrCast(@alignCast(ptr));
             self.parent_allocator.rawFree(buf, buf_align, ret_addr);
             // this condition is to handle free being called on an empty slice that was never even allocated
             // example case: `std.process.getSelfExeSharedLibPaths` can return `&[_][:0]u8{}`

--- a/tests/context.zig
+++ b/tests/context.zig
@@ -136,7 +136,7 @@ pub const Context = struct {
 
         // assertions
         try std.testing.expectEqualStrings("2.0", response.get("jsonrpc").?.string);
-        try std.testing.expectEqual(self.request_id, @intCast(u32, response.get("id").?.integer));
+        try std.testing.expectEqual(self.request_id, @as(u32, @intCast(response.get("id").?.integer)));
         try std.testing.expect(!response.contains("error"));
 
         const result_json = try std.json.stringifyAlloc(allocator, response.get("result").?, .{});

--- a/tests/language_features/cimport.zig
+++ b/tests/language_features/cimport.zig
@@ -91,7 +91,7 @@ fn testConvertCInclude(cimport_source: []const u8, expected: []const u8) !void {
 
             if (!std.mem.eql(u8, offsets.tokenToSlice(tree, token), "@cImport")) continue;
 
-            break :blk @intCast(Ast.Node.Index, i);
+            break :blk @intCast(i);
         }
         return error.TestUnexpectedResult; // source doesn't contain a cImport
     };

--- a/tests/language_features/comptime_interpreter.zig
+++ b/tests/language_features/comptime_interpreter.zig
@@ -377,7 +377,7 @@ const Context = struct {
             };
         }
 
-        const namespace = @enumFromInt(ComptimeInterpreter.Namespace.Index, 0); // root namespace
+        const namespace: ComptimeInterpreter.Namespace.Index = @enumFromInt(0); // root namespace
         const result = (try self.interpreter.call(namespace, func_node, args, .{})).result;
 
         const val = self.interpreter.ip.indexToKey(result.value.index);
@@ -390,7 +390,7 @@ const Context = struct {
     }
 
     pub fn interpret(self: *Context, node: Ast.Node.Index) !KV {
-        const namespace = @enumFromInt(ComptimeInterpreter.Namespace.Index, 0); // root namespace
+        const namespace: ComptimeInterpreter.Namespace.Index = @enumFromInt(0); // root namespace
         const result = try (try self.interpreter.interpret(node, namespace, .{})).getValue();
 
         const val = self.interpreter.ip.indexToKey(result.index);
@@ -406,7 +406,7 @@ const Context = struct {
         const handle = self.interpreter.getHandle();
         for (handle.tree.nodes.items(.tag), 0..) |tag, i| {
             if (tag != .fn_decl) continue;
-            const node = @intCast(Ast.Node.Index, i);
+            const node: Ast.Node.Index = @intCast(i);
             var buffer: [1]Ast.Node.Index = undefined;
             const fn_decl = handle.tree.fullFnProto(&buffer, node).?;
             const fn_name = offsets.tokenToSlice(handle.tree, fn_decl.name_token.?);

--- a/tests/lsp_features/inlay_hints.zig
+++ b/tests/lsp_features/inlay_hints.zig
@@ -69,9 +69,6 @@ test "inlayhints - function self parameter" {
 
 test "inlayhints - builtin call" {
     try testInlayHints(
-        \\const _ = @intCast(<DestType>u32,<int>5);
-    );
-    try testInlayHints(
         \\const _ = @memcpy(<dest>"",<source>"");
     );
 

--- a/tests/lsp_features/semantic_tokens.zig
+++ b/tests/lsp_features/semantic_tokens.zig
@@ -1048,8 +1048,8 @@ fn testSemanticTokens(source: [:0]const u8, expected_tokens: []const TokenData) 
         const delta_line = token_data[0];
         const delta_start = token_data[1];
         const length = token_data[2];
-        const token_type = @enumFromInt(zls.semantic_tokens.TokenType, token_data[3]);
-        const token_modifiers = @bitCast(zls.semantic_tokens.TokenModifiers, @intCast(u16, token_data[4]));
+        const token_type: zls.semantic_tokens.TokenType = @enumFromInt(token_data[3]);
+        const token_modifiers: zls.semantic_tokens.TokenModifiers = @bitCast(@as(u16, @intCast(token_data[4])));
 
         position.line += delta_line;
         position.character = delta_start + if (delta_line == 0) position.character else 0;


### PR DESCRIPTION
This PR updates zls to be compatible with zig master after the change which removes the type parameter from cast builtins.

It depends on PRs in dependencies:
- [x] https://github.com/ziglibs/tres/pull/15
- [x] https://github.com/ziglibs/diffz/pull/15
- [x] https://github.com/ziglibs/known-folders/pull/36
- [x] https://github.com/zigtools/sus/pull/16