### PR TITLE
expand var decl alias resolution

### DIFF
--- a/tests/lsp_features/inlay_hints.zig
+++ b/tests/lsp_features/inlay_hints.zig
@@ -67,6 +67,14 @@ test "inlayhints - function self parameter" {
     );
 }
 
+test "inlayhints - resolve alias" {
+    try testInlayHints(
+        \\fn foo(alpha: u32) void {}
+        \\const bar = foo;
+        \\const _ = bar(<alpha>5);
+    );
+}
+
 test "inlayhints - builtin call" {
     try testInlayHints(
         \\const _ = @memcpy(<dest>"",<source>"");


### PR DESCRIPTION
fixes #1240
For some reason, var decl alias resolution had some artificial restrictions like requiring that var decl name is the same as the right side of the field access.
Here is an example from [llvm.zig](https://github.com/ziglang/zig/blob/7322aa118376a635ab077ca833dd152639953337/src/codegen/llvm.zig#L4020) that shows how removing some constraints affects hover and inlay hints.

Before:
![Screenshot from 2023-06-26 19-59-08](https://github.com/zigtools/zls/assets/19954306/f8fff459-65df-42e4-a7db-daa0f06820a3)
After:
![Screenshot from 2023-06-26 19-58-42](https://github.com/zigtools/zls/assets/19954306/0369ebb6-103d-4d58-885d-cf1a0ecdc27c)