### PR TITLE
enable inlay hints for single-argument builtins

### DIFF
--- a/src/features/inlay_hints.zig
+++ b/src/features/inlay_hints.zig
@@ -14,7 +14,6 @@ const Config = @import("../Config.zig");
 const data = @import("../data/data.zig");
 
 /// don't show inlay hints for the given builtin functions
-/// builtins with one parameter are skipped automatically
 /// this option is rare and is therefore build-only and
 /// non-configurable at runtime
 pub const inlay_hints_exclude_builtins: []const u8 = &.{};
@@ -275,7 +274,7 @@ fn writeNodeInlayHint(
             var buffer: [2]Ast.Node.Index = undefined;
             const params = ast.builtinCallParams(tree, node, &buffer).?;
 
-            if (!builder.config.inlay_hints_show_builtin or params.len <= 1) break :blk;
+            if (!builder.config.inlay_hints_show_builtin or params.len == 0) break :blk;
 
             const name = tree.tokenSlice(main_tokens[node]);
 


### PR DESCRIPTION
This should resolve #1276, and as a side-effect might make `inlay_hints_exclude_builtins` less rare (in particular, people might like to exclude `@import`), and perhaps motivate increasing its configurability.