### PR TITLE
Hover: Add links to referenced types when possible

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -1095,9 +1095,9 @@ fn resolveTypeOfNodeUncached(analyser: *Analyser, node_handle: NodeWithHandle) e
 
             var either = std.ArrayListUnmanaged(Type.EitherEntry){};
             if (try analyser.resolveTypeOfNodeInternal(.{ .handle = handle, .node = if_node.ast.then_expr })) |t|
-                try either.append(analyser.arena.allocator(), .{ .type_with_handle = t, .descriptor = tree.getNodeSource(if_node.ast.cond_expr) });
+                try either.append(analyser.arena.allocator(), .{ .type_with_handle = t, .descriptor = offsets.nodeToSlice(tree, if_node.ast.cond_expr) });
             if (try analyser.resolveTypeOfNodeInternal(.{ .handle = handle, .node = if_node.ast.else_expr })) |t|
-                try either.append(analyser.arena.allocator(), .{ .type_with_handle = t, .descriptor = try std.fmt.allocPrint(analyser.arena.allocator(), "!({s})", .{tree.getNodeSource(if_node.ast.cond_expr)}) });
+                try either.append(analyser.arena.allocator(), .{ .type_with_handle = t, .descriptor = try std.fmt.allocPrint(analyser.arena.allocator(), "!({s})", .{offsets.nodeToSlice(tree, if_node.ast.cond_expr)}) });
 
             return TypeWithHandle{
                 .type = .{ .data = .{ .either = try either.toOwnedSlice(analyser.arena.allocator()) }, .is_type_val = false },
@@ -1117,7 +1117,7 @@ fn resolveTypeOfNodeUncached(analyser: *Analyser, node_handle: NodeWithHandle) e
                 var descriptor = std.ArrayListUnmanaged(u8){};
 
                 for (switch_case.ast.values, 0..) |values, index| {
-                    try descriptor.appendSlice(analyser.arena.allocator(), tree.getNodeSource(values));
+                    try descriptor.appendSlice(analyser.arena.allocator(), offsets.nodeToSlice(tree, values));
                     if (index != switch_case.ast.values.len - 1) try descriptor.appendSlice(analyser.arena.allocator(), ", ");
                 }
 
@@ -3145,7 +3145,7 @@ fn addReferencedTypesFromNode(
     referenced_types: *std.ArrayList(ReferencedType),
 ) error{OutOfMemory}!void {
     const type_handle = try analyser.resolveTypeOfNode(node_handle) orelse return;
-    const type_str = node_handle.handle.tree.getNodeSource(node_handle.node);
+    const type_str = offsets.nodeToSlice(node_handle.handle.tree, node_handle.node);
     _ = try analyser.addReferencedTypes(type_str, type_handle, true, referenced_types);
 }
 

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -3110,16 +3110,11 @@ fn makeScopeInternal(context: ScopeContext, tree: Ast, node_idx: Ast.Node.Index)
 
 pub const ReferencedType = struct {
     str: []const u8,
-    uri: []const u8,
-    loc: types.Position,
+    handle: *const DocumentStore.Handle,
+    token: Ast.TokenIndex,
 
     fn init(str: []const u8, handle: *const DocumentStore.Handle, token: Ast.TokenIndex) ReferencedType {
-        const loc = offsets.tokenToPosition(handle.tree, token, .@"utf-8");
-        return .{
-            .str = str,
-            .uri = handle.uri,
-            .loc = loc,
-        };
+        return .{ .str = str, .handle = handle, .token = token };
     }
 };
 

--- a/src/features/hover.zig
+++ b/src/features/hover.zig
@@ -35,14 +35,14 @@ pub fn hoverSymbol(server: *Server, decl_handle: Analyser.DeclWithHandle, markup
 
             if (tree.fullVarDecl(node)) |var_decl| {
                 if (var_decl.ast.type_node != 0)
-                    type_str = tree.getNodeSource(var_decl.ast.type_node);
+                    type_str = offsets.nodeToSlice(tree, var_decl.ast.type_node);
 
                 break :def Analyser.getVariableSignature(tree, var_decl);
             } else if (tree.fullFnProto(&buf, node)) |fn_proto| {
                 break :def Analyser.getFunctionSignature(tree, fn_proto);
             } else if (tree.fullContainerField(node)) |field| {
                 std.debug.assert(field.ast.type_expr != 0);
-                type_str = tree.getNodeSource(field.ast.type_expr);
+                type_str = offsets.nodeToSlice(tree, field.ast.type_expr);
 
                 break :def Analyser.getContainerFieldSignature(tree, field);
             } else {
@@ -53,7 +53,7 @@ pub fn hoverSymbol(server: *Server, decl_handle: Analyser.DeclWithHandle, markup
             const param = pay.param;
 
             std.debug.assert(param.type_expr != 0);
-            type_str = tree.getNodeSource(param.type_expr);
+            type_str = offsets.nodeToSlice(tree, param.type_expr);
 
             if (param.first_doc_comment) |doc_comments| {
                 doc_str = try Analyser.collectDocComments(server.arena.allocator(), handle.tree, doc_comments, markup_kind, false);

--- a/src/features/hover.zig
+++ b/src/features/hover.zig
@@ -75,7 +75,8 @@ pub fn hoverSymbol(server: *Server, decl_handle: Analyser.DeclWithHandle, markup
         for (referenced_types, 0..) |ref, index| {
             if (index > 0)
                 try writer.print(" | ", .{});
-            try writer.print("Go to [{s}]({s}#L{d})", .{ ref.str, ref.uri, ref.loc.line + 1 });
+            const loc = offsets.tokenToPosition(ref.handle.tree, ref.token, server.offset_encoding);
+            try writer.print("Go to [{s}]({s}#L{d})", .{ ref.str, ref.handle.uri, loc.line + 1 });
         }
     } else {
         try writer.print("{s} ({s})", .{ def_str, resolved_type_str });

--- a/src/features/hover.zig
+++ b/src/features/hover.zig
@@ -52,8 +52,8 @@ pub fn hoverSymbol(server: *Server, decl_handle: Analyser.DeclWithHandle, markup
         .param_payload => |pay| def: {
             const param = pay.param;
 
-            std.debug.assert(param.type_expr != 0);
-            type_str = offsets.nodeToSlice(tree, param.type_expr);
+            if (param.type_expr != 0) // zero for `anytype` and extern C varargs `...`
+                type_str = offsets.nodeToSlice(tree, param.type_expr);
 
             if (param.first_doc_comment) |doc_comments| {
                 doc_str = try Analyser.collectDocComments(server.arena.allocator(), handle.tree, doc_comments, markup_kind, false);


### PR DESCRIPTION
Inspired by rust-analyzer, this PR adds "Go to &lt;type&gt;" in hover pop-ups:

<img width="368" alt="pointer" src="https://github.com/zigtools/zls/assets/70830482/fbe1fbb7-296b-4162-b499-5544caef0bad">

<img width="937" alt="function" src="https://github.com/zigtools/zls/assets/70830482/2da77e6c-f467-4dc0-9576-0b2d697dbc93">

<img width="344" alt="chain" src="https://github.com/zigtools/zls/assets/70830482/9c1a187b-0ff7-4efd-8a76-d7b3ab7adcfd">