### PR TITLE
Hover improvements

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -3164,6 +3164,7 @@ fn addReferencedTypes(
     const node_tags = tree.nodes.items(.tag);
     const token_tags = tree.tokens.items(.tag);
     const main_tokens = tree.nodes.items(.main_token);
+    const datas = tree.nodes.items(.data);
 
     switch (type_handle.type.data) {
         .pointer,
@@ -3250,6 +3251,29 @@ fn addReferencedTypes(
 
                 try analyser.addReferencedTypesFromNode(
                     .{ .node = ptr_type.ast.child_type, .handle = handle },
+                    referenced_types,
+                );
+
+                return offsets.nodeToSlice(tree, p);
+            },
+
+            .optional_type => {
+                try analyser.addReferencedTypesFromNode(
+                    .{ .node = datas[p].lhs, .handle = handle },
+                    referenced_types,
+                );
+
+                return offsets.nodeToSlice(tree, p);
+            },
+
+            .error_union => {
+                try analyser.addReferencedTypesFromNode(
+                    .{ .node = datas[p].lhs, .handle = handle },
+                    referenced_types,
+                );
+
+                try analyser.addReferencedTypesFromNode(
+                    .{ .node = datas[p].rhs, .handle = handle },
                     referenced_types,
                 );
 


### PR DESCRIPTION
Follow up to #1281

## Resolve underlying type recursively

<img width="397" alt="new recursive underlying" src="https://github.com/zigtools/zls/assets/70830482/f2aa76e4-ef14-4bcc-82da-af6766b70692">

<details><summary>Before</summary>

<img width="397" alt="old recursive underlying" src="https://github.com/zigtools/zls/assets/70830482/8dad4e85-5bae-4ce3-8a98-342f9ca5c5e1">

</details>

## Avoid duplicate "Go to &lt;type&gt;"

<img width="936" alt="new duplicates" src="https://github.com/zigtools/zls/assets/70830482/055c3060-9749-4e7d-8c1b-229f4b832f2a">

<details><summary>Before</summary>

<img width="939" alt="old duplicates" src="https://github.com/zigtools/zls/assets/70830482/c44f196d-5dae-4a67-a1c8-f645d172d696">

</details>

## Add hover info for optional type and error union

<img width="321" alt="optional type" src="https://github.com/zigtools/zls/assets/70830482/c93e5e6a-efec-4a57-b59e-5681082dbbbc">

<img width="345" alt="error union" src="https://github.com/zigtools/zls/assets/70830482/b631b1a0-2da6-4455-9507-6015ffbfa190">

## Simplify resolved `if`/`switch` type when branches return same type

<img width="577" alt="page allocator" src="https://github.com/zigtools/zls/assets/70830482/a71dfe1f-57d9-4082-b07f-463c4469b9d9">

## Resolve type to alias for "Go to &lt;type&gt;" when possible

<img width="598" alt="new function" src="https://github.com/zigtools/zls/assets/70830482/5038c5f8-f77d-4b71-8b50-cea0dc527784">

<img width="208" alt="new variable" src="https://github.com/zigtools/zls/assets/70830482/ee9dcf8f-1ffc-405b-886f-ead2b06fdd44">

<details><summary>Before</summary>

<img width="597" alt="old function" src="https://github.com/zigtools/zls/assets/70830482/2a081de9-4f27-4ed5-a316-0f97fd450646">

<img width="208" alt="old variable" src="https://github.com/zigtools/zls/assets/70830482/67edb724-6952-431d-af5b-5ccc2f5cee83">

</details>

For reference, `Ast.Node.Index` is defined as `const Index = u32;`

This changes the behavior of "Go to std.mem.Allocator". Instead of opening `std/mem/Allocator.zig`, now it will open `std/mem.zig` and go to the line that has `const Allocator = @import("mem/Allocator.zig");`

<img width="643" alt="allocator parameter" src="https://github.com/zigtools/zls/assets/70830482/92c43e60-3fea-4de1-966b-8bbed4cae3c5">

<img width="455" alt="allocator alias" src="https://github.com/zigtools/zls/assets/70830482/accc86b8-fd06-4e82-8ba2-1c426e4410a1">
