### PR TITLE
More hover improvements

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -502,8 +502,7 @@ fn resolveReturnType(analyser: *Analyser, fn_decl: Ast.full.FnProto, handle: *co
     const child_type = (try analyser.resolveTypeOfNodeInternal(ret)) orelse
         return null;
 
-    const is_inferred_error = tree.tokens.items(.tag)[tree.firstToken(return_type) - 1] == .bang;
-    if (is_inferred_error) {
+    if (ast.hasInferredError(tree, fn_decl)) {
         const child_type_node = switch (child_type.type.data) {
             .other => |n| n,
             else => return null,
@@ -3328,7 +3327,10 @@ fn addReferencedTypes(
                         try writer.print(", ", .{});
                     try writer.print("{s}", .{param_type_str orelse return null});
                 }
-                try writer.print(") {s}", .{return_type_str orelse return null});
+                try writer.print(") ", .{});
+                if (ast.hasInferredError(tree, fn_proto))
+                    try writer.print("!", .{});
+                try writer.print("{s}", .{return_type_str orelse return null});
                 return str.items;
             },
 

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -3275,6 +3275,7 @@ fn addReferencedTypes(
             .container_decl_trailing,
             .container_decl_two,
             .container_decl_two_trailing,
+            .error_set_decl,
             .tagged_union,
             .tagged_union_trailing,
             .tagged_union_two,
@@ -3283,12 +3284,17 @@ fn addReferencedTypes(
             .tagged_union_enum_tag_trailing,
             => {
                 // NOTE: This is a hacky nightmare but it works :P
-                const token = main_tokens[p] - 2;
-                if (token_tags[token] != .identifier) return null;
-                const str = tree.tokenSlice(token);
-                if (is_referenced_type)
-                    try referenced_types.put(ReferencedType.init(type_str orelse str, handle, token), {});
-                return str;
+                const token = main_tokens[p];
+                if (token_tags[token - 2] == .identifier and token_tags[token - 1] == .equal) {
+                    const str = tree.tokenSlice(token - 2);
+                    if (is_referenced_type)
+                        try referenced_types.put(ReferencedType.init(type_str orelse str, handle, token - 2), {});
+                    return str;
+                }
+                if (token_tags[token - 1] == .keyword_return) {
+                    return null;
+                }
+                return offsets.nodeToSlice(tree, p);
             },
 
             .fn_proto,

--- a/src/ast.zig
+++ b/src/ast.zig
@@ -980,6 +980,11 @@ pub fn lastToken(tree: Ast, node: Ast.Node.Index) Ast.TokenIndex {
     };
 }
 
+pub fn hasInferredError(tree: Ast, fn_proto: Ast.full.FnProto) bool {
+    const token_tags = tree.tokens.items(.tag);
+    return token_tags[tree.firstToken(fn_proto.ast.return_type) - 1] == .bang;
+}
+
 pub fn paramFirstToken(tree: Ast, param: Ast.full.FnProto.Param) Ast.TokenIndex {
     return param.first_doc_comment orelse
         param.comptime_noalias orelse

--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -48,7 +48,7 @@ fn typeToCompletion(
             }
         },
         .error_union => {},
-        .pointer => |n| {
+        .pointer => |t| {
             if (server.config.operator_completions) {
                 try list.append(allocator, .{
                     .label = "*",
@@ -57,16 +57,7 @@ fn typeToCompletion(
                     .insertTextFormat = .PlainText,
                 });
             }
-            try nodeToCompletion(
-                server,
-                list,
-                .{ .node = n, .handle = type_handle.handle },
-                null,
-                orig_handle,
-                type_handle.type.is_type_val,
-                null,
-                either_descriptor,
-            );
+            try typeToCompletion(server, list, .{ .original = t.* }, orig_handle, null);
         },
         .other => |n| try nodeToCompletion(
             server,


### PR DESCRIPTION
## Fix hover with anonymous types in function headers and container fields

<img width="269" alt="anonymous" src="https://github.com/zigtools/zls/assets/70830482/597cc506-c1fe-4b94-bcb8-91e3a29a54d7">

<details><summary>Before</summary>

<img width="265" alt="anonymous" src="https://github.com/zigtools/zls/assets/70830482/9b3c13e4-463d-4c4d-abc2-a524a21f29b1">

</details>

## Add missing `!` in resolved function string when error set is inferred

<img width="1023" alt="inferred" src="https://github.com/zigtools/zls/assets/70830482/e9f2ea4a-0efc-4ca8-af44-16598bcd3b65">

<details><summary>Before</summary>

<img width="1023" alt="inferred" src="https://github.com/zigtools/zls/assets/70830482/233859ed-2ca2-4c4c-ba73-640a24674a13">

</details>

## Improve type analysis involving `&foo`, `foo[bar]`, or `!Foo`

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td>

```zig
const pointer_example = struct {
    const foo: i32 = undefined;
    const bar = &foo;  // unknown
    const baz = bar.*; // unknown
};

const slice_example = struct {
    const foo: [1]i32 = undefined;
    const bar = foo[0..0];  // i32
    const fizz = bar[0];    // unknown
    const buzz = bar[0..0]; // unknown
};

const error_union_example = struct {
    fn foo() !i32 {}
    fn bar() void {
        const fizz = foo();    // unknown
        const buzz = try fizz; // unknown
        _ = buzz;
    }
};
```

</td>
<td>

```zig
const pointer_example = struct {
    const foo: i32 = undefined;
    const bar = &foo;  // *i32
    const baz = bar.*; // i32
};

const slice_example = struct {
    const foo: [1]i32 = undefined;
    const bar = foo[0..0];  // []i32
    const fizz = bar[0];    // i32
    const buzz = bar[0..0]; // []i32
};

const error_union_example = struct {
    fn foo() !i32 {}
    fn bar() void {
        const fizz = foo();    // !i32
        const buzz = try fizz; // i32
        _ = buzz;
    }
};
```

</td>
</tr>
</table>

## Add hover info for string and number literals

<img width="206" alt="integer" src="https://github.com/zigtools/zls/assets/70830482/e66637b2-68dd-4bfc-af22-fc440d6829c5">
<img width="202" alt="char" src="https://github.com/zigtools/zls/assets/70830482/936984fd-813d-4cd6-9782-86148986b92e">
<img width="221" alt="string" src="https://github.com/zigtools/zls/assets/70830482/e23fd047-6277-455a-849c-a202e8e2a5c7">
<img width="220" alt="multiline" src="https://github.com/zigtools/zls/assets/70830482/eca6ef2e-4c89-4e31-bec4-2a08b849a1c3">
