### PR TITLE
Fix rendering of multi-line doc comments

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -46,7 +46,7 @@ pub fn invalidate(self: *Analyser) void {
 }
 
 /// Gets a declaration's doc comments. Caller owns returned memory.
-pub fn getDocComments(allocator: std.mem.Allocator, tree: Ast, node: Ast.Node.Index, format: types.MarkupKind) !?[]const u8 {
+pub fn getDocComments(allocator: std.mem.Allocator, tree: Ast, node: Ast.Node.Index) !?[]const u8 {
     const base = tree.nodes.items(.main_token)[node];
     const base_kind = tree.nodes.items(.tag)[node];
     const tokens = tree.tokens.items(.tag);
@@ -54,7 +54,7 @@ pub fn getDocComments(allocator: std.mem.Allocator, tree: Ast, node: Ast.Node.In
     switch (base_kind) {
         // As far as I know, this does not actually happen yet, but it
         // may come in useful.
-        .root => return try collectDocComments(allocator, tree, 0, format, true),
+        .root => return try collectDocComments(allocator, tree, 0, true),
         .fn_proto,
         .fn_proto_one,
         .fn_proto_simple,
@@ -68,7 +68,7 @@ pub fn getDocComments(allocator: std.mem.Allocator, tree: Ast, node: Ast.Node.In
         .container_field,
         => {
             if (getDocCommentTokenIndex(tokens, base)) |doc_comment_index|
-                return try collectDocComments(allocator, tree, doc_comment_index, format, false);
+                return try collectDocComments(allocator, tree, doc_comment_index, false);
         },
         else => {},
     }
@@ -97,7 +97,7 @@ pub fn getDocCommentTokenIndex(tokens: []const std.zig.Token.Tag, base_token: As
     } else idx + 1;
 }
 
-pub fn collectDocComments(allocator: std.mem.Allocator, tree: Ast, doc_comments: Ast.TokenIndex, format: types.MarkupKind, container_doc: bool) ![]const u8 {
+pub fn collectDocComments(allocator: std.mem.Allocator, tree: Ast, doc_comments: Ast.TokenIndex, container_doc: bool) ![]const u8 {
     var lines = std.ArrayList([]const u8).init(allocator);
     defer lines.deinit();
     const tokens = tree.tokens.items(.tag);
@@ -2755,7 +2755,7 @@ fn makeInnerScope(
         {
             if (std.mem.eql(u8, name, "_")) continue;
 
-            const doc = try getDocComments(allocator, tree, decl, .markdown);
+            const doc = try getDocComments(allocator, tree, decl);
             errdefer if (doc) |d| allocator.free(d);
             var gop_res = try context.doc_scope.enum_completions.getOrPut(allocator, .{
                 .label = name,

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -110,7 +110,7 @@ pub fn collectDocComments(allocator: std.mem.Allocator, tree: Ast, doc_comments:
         } else break;
     }
 
-    return try std.mem.join(allocator, if (format == .markdown) "  \n" else "\n", lines.items);
+    return try std.mem.join(allocator, "\n", lines.items);
 }
 
 /// Gets a function's keyword, name, arguments and return value.

--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -126,20 +126,16 @@ fn nodeToCompletion(
         allocator,
         handle.tree,
         node,
-        doc_kind,
     )) |doc_comments| .{ .MarkupContent = types.MarkupContent{
         .kind = doc_kind,
         .value = if (either_descriptor) |ed|
             try std.fmt.allocPrint(allocator, "`Conditionally available: {s}`\n\n{s}", .{ ed, doc_comments })
         else
             doc_comments,
-    } } else (if (either_descriptor) |ed|
-        .{ .MarkupContent = types.MarkupContent{
-            .kind = doc_kind,
-            .value = try std.fmt.allocPrint(allocator, "`Conditionally available: {s}`", .{ed}),
-        } }
-    else
-        null);
+    } } else (if (either_descriptor) |ed| .{ .MarkupContent = types.MarkupContent{
+        .kind = doc_kind,
+        .value = try std.fmt.allocPrint(allocator, "`Conditionally available: {s}`", .{ed}),
+    } } else null);
 
     if (ast.isContainer(handle.tree, node)) {
         const context = DeclToCompletionContext{
@@ -365,9 +361,9 @@ fn declToCompletion(context: DeclToCompletionContext, decl_handle: Analyser.Decl
             const doc: Documentation = if (param.first_doc_comment) |doc_comments| .{ .MarkupContent = types.MarkupContent{
                 .kind = doc_kind,
                 .value = if (context.either_descriptor) |ed|
-                    try std.fmt.allocPrint(allocator, "`Conditionally available: {s}`\n\n{s}", .{ ed, try Analyser.collectDocComments(allocator, tree, doc_comments, doc_kind, false) })
+                    try std.fmt.allocPrint(allocator, "`Conditionally available: {s}`\n\n{s}", .{ ed, try Analyser.collectDocComments(allocator, tree, doc_comments, false) })
                 else
-                    try Analyser.collectDocComments(allocator, tree, doc_comments, doc_kind, false),
+                    try Analyser.collectDocComments(allocator, tree, doc_comments, false),
             } } else null;
 
             try context.completions.append(allocator, .{

--- a/src/features/hover.zig
+++ b/src/features/hover.zig
@@ -30,7 +30,7 @@ pub fn hoverSymbol(server: *Server, decl_handle: Analyser.DeclWithHandle, markup
             if (try server.analyser.resolveVarDeclAlias(.{ .node = node, .handle = handle })) |result| {
                 return try hoverSymbol(server, result, markup_kind);
             }
-            doc_str = try Analyser.getDocComments(server.arena.allocator(), tree, node, markup_kind);
+            doc_str = try Analyser.getDocComments(server.arena.allocator(), tree, node);
 
             var buf: [1]Ast.Node.Index = undefined;
 
@@ -69,7 +69,7 @@ pub fn hoverSymbol(server: *Server, decl_handle: Analyser.DeclWithHandle, markup
                 );
 
             if (param.first_doc_comment) |doc_comments| {
-                doc_str = try Analyser.collectDocComments(server.arena.allocator(), handle.tree, doc_comments, markup_kind, false);
+                doc_str = try Analyser.collectDocComments(server.arena.allocator(), handle.tree, doc_comments, false);
             }
 
             break :def ast.paramSlice(tree, param);

--- a/src/features/signature_help.zig
+++ b/src/features/signature_help.zig
@@ -14,7 +14,7 @@ const data = @import("../data/data.zig");
 fn fnProtoToSignatureInfo(analyser: *Analyser, alloc: std.mem.Allocator, commas: u32, skip_self_param: bool, handle: *const DocumentStore.Handle, fn_node: Ast.Node.Index, proto: Ast.full.FnProto) !types.SignatureInformation {
     const tree = handle.tree;
     const label = Analyser.getFunctionSignature(tree, proto);
-    const proto_comments = (try Analyser.getDocComments(alloc, tree, fn_node, .markdown)) orelse "";
+    const proto_comments = (try Analyser.getDocComments(alloc, tree, fn_node)) orelse "";
 
     const arg_idx = if (skip_self_param) blk: {
         const has_self_param = try analyser.hasSelfParam(handle, proto);
@@ -25,7 +25,7 @@ fn fnProtoToSignatureInfo(analyser: *Analyser, alloc: std.mem.Allocator, commas:
     var param_it = proto.iterate(&tree);
     while (ast.nextFnParam(&param_it)) |param| {
         const param_comments = if (param.first_doc_comment) |dc|
-            try Analyser.collectDocComments(alloc, tree, dc, .markdown, false)
+            try Analyser.collectDocComments(alloc, tree, dc, false)
         else
             "";
 


### PR DESCRIPTION
The proposed change removes line breaks in multi-line doc comments to ensure they are rendered as a single continuous text.

## Before

```zig
/// This is a
/// text.
```

rendered as

```
This is a
text.
```

## After

```
This is a text.
```