### PR TITLE
Add hover info for generic types

### DIFF
--- a/src/features/hover.zig
+++ b/src/features/hover.zig
@@ -35,9 +35,19 @@ pub fn hoverSymbol(server: *Server, decl_handle: Analyser.DeclWithHandle, markup
             var buf: [1]Ast.Node.Index = undefined;
 
             if (tree.fullVarDecl(node)) |var_decl| {
-                if (var_decl.ast.type_node != 0)
+                var struct_init_buf: [2]Ast.Node.Index = undefined;
+                var type_node: Ast.Node.Index = 0;
+
+                if (var_decl.ast.type_node != 0) {
+                    type_node = var_decl.ast.type_node;
+                } else if (tree.fullStructInit(&struct_init_buf, var_decl.ast.init_node)) |struct_init| {
+                    if (struct_init.ast.type_expr != 0)
+                        type_node = struct_init.ast.type_expr;
+                }
+
+                if (type_node != 0)
                     try server.analyser.referencedTypesFromNode(
-                        .{ .node = var_decl.ast.type_node, .handle = handle },
+                        .{ .node = type_node, .handle = handle },
                         &reference_collector,
                     );
 


### PR DESCRIPTION
<img width="872" alt="generic type with non-type parameter" src="https://github.com/zigtools/zls/assets/70830482/a2761798-b7dc-4f5a-b755-3aab16529ae8">

<img width="631" alt="generic variable" src="https://github.com/zigtools/zls/assets/70830482/172156d9-026b-4c1a-bcc9-d03c6cc03cbb">

<img width="611" alt="generic function" src="https://github.com/zigtools/zls/assets/70830482/31f6b767-3733-4bc1-ab06-69ead9ec52b6">

<img width="570" alt="struct init" src="https://github.com/zigtools/zls/assets/70830482/27822846-c243-49fe-aadb-698237547bf5">
