### PR TITLE
Fix type string resolution for named extern/packed structs

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -3346,7 +3346,7 @@ fn addReferencedTypes(
             .tagged_union_enum_tag_trailing,
             => {
                 // NOTE: This is a hacky nightmare but it works :P
-                const token = main_tokens[p];
+                const token = tree.firstToken(p);
                 if (token_tags[token - 2] == .identifier and token_tags[token - 1] == .equal) {
                     const str = tree.tokenSlice(token - 2);
                     if (needs_type_reference) {


### PR DESCRIPTION
Closes #1292

`tree.nodes.items(.main_token)[p]` gives the `struct` token, so instead let's use `tree.firstToken(p)` to get the `extern` or `packed` token.