### PR TITLE
Implement hover and goto for enum literals

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -311,6 +311,18 @@ pub fn getSymbolGlobal(
     });
 }
 
+pub fn getSymbolEnumLiteral(
+    server: *Server,
+    source_index: usize,
+    handle: *const DocumentStore.Handle,
+) error{OutOfMemory}!?Analyser.DeclWithHandle {
+    const tracy_zone = tracy.trace(@src());
+    defer tracy_zone.end();
+
+    const nodes = try ast.nodesOverlappingIndex(server.arena.allocator(), handle.tree, source_index);
+    return try server.analyser.lookupSymbolEnumLiteral(handle, nodes);
+}
+
 /// Multiple when using branched types
 pub fn getSymbolFieldAccesses(
     server: *Server,

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -219,7 +219,6 @@ pub fn isInstanceCall(
     func: Ast.full.FnProto,
 ) !bool {
     return call_handle.tree.tokens.items(.tag)[call.ast.lparen - 2] == .period and
-        call.ast.params.len + 1 == func.ast.params.len and
         try analyser.hasSelfParam(func_handle, func);
 }
 

--- a/src/features/goto.zig
+++ b/src/features/goto.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const Ast = std.zig.Ast;
 const log = std.log.scoped(.zls_goto);
 
+const ast = @import("../ast.zig");
 const types = @import("../lsp.zig");
 const offsets = @import("../offsets.zig");
 const URI = @import("../uri.zig");
@@ -65,6 +66,18 @@ pub fn gotoDefinitionGlobal(
 
     const decl = (try server.getSymbolGlobal(pos_index, handle)) orelse return null;
     return try gotoDefinitionSymbol(server, decl, resolve_alias);
+}
+
+pub fn gotoDefinitionEnumLiteral(
+    server: *Server,
+    source_index: usize,
+    handle: *const DocumentStore.Handle,
+) error{OutOfMemory}!?types.Location {
+    const tracy_zone = tracy.trace(@src());
+    defer tracy_zone.end();
+
+    const decl = (try server.getSymbolEnumLiteral(source_index, handle)) orelse return null;
+    return try gotoDefinitionSymbol(server, decl, false);
 }
 
 pub fn gotoDefinitionBuiltin(
@@ -191,6 +204,7 @@ pub fn goto(
         .embedfile_string_literal,
         => .{ .Location = (try gotoDefinitionString(server, pos_context, handle)) orelse return null },
         .label => .{ .Location = (try gotoDefinitionLabel(server, source_index, handle)) orelse return null },
+        .enum_literal => .{ .Location = (try gotoDefinitionEnumLiteral(server, source_index, handle)) orelse return null },
         else => null,
     };
 }

--- a/src/features/inlay_hints.zig
+++ b/src/features/inlay_hints.zig
@@ -99,9 +99,7 @@ fn writeCallHint(builder: *Builder, call: Ast.full.Call, decl_handle: Analyser.D
         try params.append(builder.arena, param);
     }
 
-    const has_self_param = tree.tokens.items(.tag)[call.ast.lparen - 2] == .period and
-        call.ast.params.len + 1 == params.items.len and
-        try builder.analyser.hasSelfParam(decl_handle.handle, fn_proto);
+    const has_self_param = try builder.analyser.isInstanceCall(handle, call, decl_handle.handle, fn_proto);
 
     const parameters = params.items[@intFromBool(has_self_param)..];
     const arguments = call.ast.params;

--- a/src/features/inlay_hints.zig
+++ b/src/features/inlay_hints.zig
@@ -99,7 +99,8 @@ fn writeCallHint(builder: *Builder, call: Ast.full.Call, decl_handle: Analyser.D
         try params.append(builder.arena, param);
     }
 
-    const has_self_param = try builder.analyser.isInstanceCall(handle, call, decl_handle.handle, fn_proto);
+    const has_self_param = call.ast.params.len + 1 == params.items.len and
+        try builder.analyser.isInstanceCall(handle, call, decl_handle.handle, fn_proto);
 
     const parameters = params.items[@intFromBool(has_self_param)..];
     const arguments = call.ast.params;


### PR DESCRIPTION
<img width="261" alt="switch case" src="https://github.com/zigtools/zls/assets/70830482/46ae65aa-1650-48cf-a38c-692ac8814f47">

<img width="497" alt="equality" src="https://github.com/zigtools/zls/assets/70830482/6b6a32b3-80c5-4626-b364-440219df6f25">

<img width="677" alt="builtin identifier" src="https://github.com/zigtools/zls/assets/70830482/9bc200c1-17be-4723-a883-c95d86fdc152">

```zig
const Foo = enum {
    /// Foo.
    foo,
};

// variable/constant declaration
const a: Foo = .foo;

// if-else expression
const b: Foo = if (true) .foo else .foo;

// for-else expression
const c: Foo = inline for (0..0) |_|
{} else .foo;

// while-else expression
const d: Foo = inline while (false)
{} else .foo;

// function call arguments
const e = bar(.foo, .foo);
fn bar(foo1: Foo, foo2: Foo) [2]Foo {
    return [_]Foo{ foo1, foo2 };
}

// variable assignment
const f: Foo = blk: {
    var foo: Foo = undefined;
    foo = .foo;
    break :blk foo;
};

// binary operand
const g = a == .foo;
const h = .foo != a;

// loop/block break
const i: Foo = inline for (0..1) |_|
{
    break .foo;
};

const j: Foo = blk: inline while (true)
{
    break :blk .foo;
};

const k: Foo = blk: {
    if (true) break :blk .foo;
};

const print = @import("std").debug.print;
pub fn main() void {
    for (.{ a, b, c, d } ++ e ++ .{f}) |foo| print(".{s}, ", .{@tagName(foo)});
    for ([_]bool{ g, h }) |boolean| print("{}, ", .{boolean});
    for ([_]Foo{ i, j, k }) |foo| print(".{s}, ", .{@tagName(foo)});
    print("\n", .{});
}
```

## Todo

- Understand enum type resolution better
- Resolve type of enum value as the enum itself
- Investigate why hovering over `.@"utf-32"` only highlights either `utf` or `32` but not `utf-32` as a whole