### PR TITLE
Some hover improvements

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -308,6 +308,7 @@ pub fn getSymbolGlobal(
 
     return try server.analyser.lookupSymbolGlobalAdvanced(handle, name, pos_index, .{
         .skip_container_fields = false,
+        .skip_labels = false,
     });
 }
 
@@ -1079,7 +1080,7 @@ pub fn generalReferencesHandler(server: *Server, request: GeneralReferencesReque
         else => true,
     };
 
-    const locations = if (pos_context == .label)
+    const locations = if (decl.decl.* == .label_decl)
         try references.labelReferences(allocator, decl, server.offset_encoding, include_decl)
     else
         try references.symbolReferences(

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -259,8 +259,19 @@ pub fn hasSelfParam(analyser: *Analyser, handle: *const DocumentStore.Handle, fu
 }
 
 pub fn getVariableSignature(tree: Ast, var_decl: Ast.full.VarDecl) []const u8 {
+    const end_token = blk: {
+        if (var_decl.ast.init_node == 0)
+            break :blk var_decl.ast.mut_token + 1;
+        var buf: [2]Ast.Node.Index = undefined;
+        if (tree.fullContainerDecl(&buf, var_decl.ast.init_node)) |container_decl| {
+            if (container_decl.ast.enum_token) |enum_token|
+                break :blk enum_token + 1;
+            break :blk container_decl.ast.main_token;
+        }
+        break :blk ast.lastToken(tree, var_decl.ast.init_node);
+    };
     const start = offsets.tokenToIndex(tree, var_decl.ast.mut_token);
-    const end = offsets.tokenToLoc(tree, ast.lastToken(tree, var_decl.ast.init_node)).end;
+    const end = offsets.tokenToLoc(tree, end_token).end;
     return tree.source[start..end];
 }
 

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -3641,6 +3641,7 @@ fn addReferencedTypes(
             .container_decl_two,
             .container_decl_two_trailing,
             .error_set_decl,
+            .merge_error_sets,
             .tagged_union,
             .tagged_union_trailing,
             .tagged_union_two,

--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -221,7 +221,7 @@ fn nodeToCompletion(
                 .label = handle.tree.tokenSlice(var_decl.ast.mut_token + 1),
                 .kind = if (is_const) .Constant else .Variable,
                 .documentation = doc,
-                .detail = Analyser.getVariableSignature(tree, var_decl),
+                .detail = try Analyser.getVariableSignature(allocator, tree, var_decl),
                 .insertText = tree.tokenSlice(var_decl.ast.mut_token + 1),
                 .insertTextFormat = .PlainText,
             });

--- a/src/features/hover.zig
+++ b/src/features/hover.zig
@@ -51,7 +51,7 @@ pub fn hoverSymbol(server: *Server, decl_handle: Analyser.DeclWithHandle, markup
                         &reference_collector,
                     );
 
-                break :def Analyser.getVariableSignature(tree, var_decl);
+                break :def try Analyser.getVariableSignature(server.arena.allocator(), tree, var_decl);
             } else if (tree.fullFnProto(&buf, node)) |fn_proto| {
                 break :def Analyser.getFunctionSignature(tree, fn_proto);
             } else if (tree.fullContainerField(node)) |field| {

--- a/src/features/hover.zig
+++ b/src/features/hover.zig
@@ -111,12 +111,12 @@ pub fn hoverSymbol(server: *Server, decl_handle: Analyser.DeclWithHandle, markup
         if (doc_str) |doc|
             try writer.print("\n{s}", .{doc});
         if (referenced_types.len > 0)
-            try writer.print("\n\n", .{});
+            try writer.print("\n\n" ++ "Go to ", .{});
         for (referenced_types, 0..) |ref, index| {
             if (index > 0)
                 try writer.print(" | ", .{});
             const loc = offsets.tokenToPosition(ref.handle.tree, ref.token, server.offset_encoding);
-            try writer.print("Go to [{s}]({s}#L{d})", .{ ref.str, ref.handle.uri, loc.line + 1 });
+            try writer.print("[{s}]({s}#L{d})", .{ ref.str, ref.handle.uri, loc.line + 1 });
         }
     } else {
         try writer.print("{s} ({s})", .{ def_str, resolved_type_str });

--- a/src/offsets.zig
+++ b/src/offsets.zig
@@ -152,6 +152,10 @@ pub fn tokenToSlice(tree: Ast, token_index: Ast.TokenIndex) []const u8 {
     return locToSlice(tree.source, tokenToLoc(tree, token_index));
 }
 
+pub fn tokensToSlice(tree: Ast, first_token: Ast.TokenIndex, last_token: Ast.TokenIndex) []const u8 {
+    return locToSlice(tree.source, tokensToLoc(tree, first_token, last_token));
+}
+
 pub fn tokenToPosition(tree: Ast, token_index: Ast.TokenIndex, encoding: Encoding) types.Position {
     const start = tokenToIndex(tree, token_index);
     return indexToPosition(tree.source, start, encoding);


### PR DESCRIPTION
## Show "Go to Foo | Bar" instead of "Go to Foo | Go to Bar"

<img width="798" alt="Screenshot" src="https://github.com/zigtools/zls/assets/70830482/be55b0ac-7d53-4c5a-8ddf-457fe4d69d99">

<details><summary>Before</summary>

<img width="795" alt="Screenshot" src="https://github.com/zigtools/zls/assets/70830482/a5dbcdf4-b655-42bd-b7d3-faacc78f55de">

</details>

## Omit container body

Closes #1301

<img width="224" alt="Screenshot" src="https://github.com/zigtools/zls/assets/70830482/4a7a35d8-732f-437f-937c-be855b6e7a7f">

## Enable hover and Go to References for loop label declaration

<img width="282" alt="Screenshot" src="https://github.com/zigtools/zls/assets/70830482/eb1af954-7d59-4dd8-8444-5a8bcc9a1125">

<img width="1284" alt="Screenshot" src="https://github.com/zigtools/zls/assets/70830482/679be1be-c0e6-4858-93ec-e4282c378f0c">

## Resolve types of primitive values, enum literals, and error values

<img width="283" alt="Screenshot 2023-07-08" src="https://github.com/zigtools/zls/assets/70830482/4b890fb7-acae-4734-aa85-11d539193506">

```zig
const std = @import("std");
pub fn main() void {
    const tru = true;
    std.log.info("{}", .{@TypeOf(tru)}); // bool
    const fals = false;
    std.log.info("{}", .{@TypeOf(fals)}); // bool
    const nul = null;
    std.log.info("{}", .{@TypeOf(nul)}); // @TypeOf(null)
    const undef = undefined;
    std.log.info("{}", .{@TypeOf(undef)}); // @TypeOf(undefined)
    const enum_lit = .foo;
    std.log.info("{}", .{@TypeOf(enum_lit)}); // @TypeOf(.enum_literal)
    const err = error.Foo;
    std.log.info("{}", .{@TypeOf(err)}); // error{Foo}
}
```

## Enable hover for merged error sets

<img width="747" alt="Screenshot" src="https://github.com/zigtools/zls/assets/70830482/57e0c102-eeb9-4f59-8145-893dfb3ed07f">

<img width="906" alt="Screenshot" src="https://github.com/zigtools/zls/assets/70830482/6b077b48-0740-4304-a00c-58951515a58e">
