### PR TITLE
Enable hover for `.foo` in `&.{ .foo, .bar }`

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -1154,6 +1154,11 @@ fn resolveTypeOfNodeUncached(analyser: *Analyser, node_handle: NodeWithHandle) e
         .@"try",
         .address_of,
         => {
+            if (node_tags[node].isContainerField()) {
+                const container_type = innermostContainer(handle, offsets.tokenToIndex(tree, tree.firstToken(node)));
+                if (container_type.isEnumType())
+                    return container_type.instanceTypeVal();
+            }
             const base = .{ .node = datas[node].lhs, .handle = handle };
             const base_type = (try analyser.resolveTypeOfNodeInternal(base)) orelse
                 return null;

--- a/src/features/hover.zig
+++ b/src/features/hover.zig
@@ -55,11 +55,13 @@ pub fn hoverSymbol(server: *Server, decl_handle: Analyser.DeclWithHandle, markup
             } else if (tree.fullFnProto(&buf, node)) |fn_proto| {
                 break :def Analyser.getFunctionSignature(tree, fn_proto);
             } else if (tree.fullContainerField(node)) |field| {
-                std.debug.assert(field.ast.type_expr != 0);
-                try server.analyser.referencedTypesFromNode(
-                    .{ .node = field.ast.type_expr, .handle = handle },
-                    &reference_collector,
-                );
+                var converted = field;
+                converted.convertToNonTupleLike(tree.nodes);
+                if (converted.ast.type_expr != 0)
+                    try server.analyser.referencedTypesFromNode(
+                        .{ .node = converted.ast.type_expr, .handle = handle },
+                        &reference_collector,
+                    );
 
                 break :def Analyser.getContainerFieldSignature(tree, field);
             } else {


### PR DESCRIPTION
Follow-up to #1307 and #1315

<img width="502" alt="Screenshot" src="https://github.com/zigtools/zls/assets/70830482/9da6b637-3c34-4d24-8db0-94f0f7c5aced">

<img width="324" alt="Screenshot" src="https://github.com/zigtools/zls/assets/70830482/d273d2d1-70e0-44b2-b8ca-13b495c2ffad">

<img width="615" alt="Screenshot" src="https://github.com/zigtools/zls/assets/70830482/f311bab1-fa4f-4c74-9149-7b40384cdcb6">

<img width="372" alt="Screenshot" src="https://github.com/zigtools/zls/assets/70830482/d8ea4037-1145-4236-8b24-798d8ccb7ffe">