### PR TITLE
Revert #1284

### DIFF
--- a/src/features/hover.zig
+++ b/src/features/hover.zig
@@ -30,7 +30,7 @@ pub fn hoverSymbol(server: *Server, decl_handle: Analyser.DeclWithHandle, markup
             if (try server.analyser.resolveVarDeclAlias(.{ .node = node, .handle = handle })) |result| {
                 return try hoverSymbol(server, result, markup_kind);
             }
-            doc_str = try Analyser.getDocComments(server.arena.allocator(), tree, node);
+            doc_str = try Analyser.getDocComments(server.arena.allocator(), tree, node, markup_kind);
 
             var buf: [1]Ast.Node.Index = undefined;
 
@@ -76,13 +76,13 @@ pub fn hoverSymbol(server: *Server, decl_handle: Analyser.DeclWithHandle, markup
                 );
 
             if (param.first_doc_comment) |doc_comments| {
-                doc_str = try Analyser.collectDocComments(server.arena.allocator(), handle.tree, doc_comments, false);
+                doc_str = try Analyser.collectDocComments(server.arena.allocator(), handle.tree, doc_comments, markup_kind, false);
             }
 
             break :def ast.paramSlice(tree, param);
         },
         .error_token => |token| def: {
-            doc_str = try Analyser.getDocCommentsBeforeToken(server.arena.allocator(), tree, token);
+            doc_str = try Analyser.getDocCommentsBeforeToken(server.arena.allocator(), tree, token, markup_kind);
             break :def tree.tokenSlice(decl_handle.nameToken());
         },
         .pointer_payload,

--- a/src/features/signature_help.zig
+++ b/src/features/signature_help.zig
@@ -14,7 +14,7 @@ const data = @import("../data/data.zig");
 fn fnProtoToSignatureInfo(analyser: *Analyser, alloc: std.mem.Allocator, commas: u32, skip_self_param: bool, handle: *const DocumentStore.Handle, fn_node: Ast.Node.Index, proto: Ast.full.FnProto) !types.SignatureInformation {
     const tree = handle.tree;
     const label = Analyser.getFunctionSignature(tree, proto);
-    const proto_comments = (try Analyser.getDocComments(alloc, tree, fn_node)) orelse "";
+    const proto_comments = (try Analyser.getDocComments(alloc, tree, fn_node, .markdown)) orelse "";
 
     const arg_idx = if (skip_self_param) blk: {
         const has_self_param = try analyser.hasSelfParam(handle, proto);
@@ -25,7 +25,7 @@ fn fnProtoToSignatureInfo(analyser: *Analyser, alloc: std.mem.Allocator, commas:
     var param_it = proto.iterate(&tree);
     while (ast.nextFnParam(&param_it)) |param| {
         const param_comments = if (param.first_doc_comment) |dc|
-            try Analyser.collectDocComments(alloc, tree, dc, false)
+            try Analyser.collectDocComments(alloc, tree, dc, .markdown, false)
         else
             "";
 


### PR DESCRIPTION
As zig comments are not markdown it turns out #1284 is not a good idea as it means that comments that look fine in source code just run together when zls renders them, example `std.HashMapUnmanaged`:

Comment
```
/// A HashMap based on open addressing and linear probing.
/// A lookup or modification typically occurs only 2 cache misses.
/// No order is guaranteed and any modification invalidates live iterators.
/// It achieves good performance with quite high load factors (by default,
/// grow is triggered at 80% full) and only one byte of overhead per element.
/// The struct itself is only 16 bytes for a small footprint. This comes at
/// the price of handling size with u32, which should be reasonable enough
/// for almost all uses.
/// Deletions are achieved with tombstones.
```

On master
![image](https://github.com/zigtools/zls/assets/2286349/da8c75da-c9df-4edd-86e2-f84aedc6cf56)

With this revert applied
![image](https://github.com/zigtools/zls/assets/2286349/f830e046-8195-43f9-9381-bb2c20a9c168)
