### PR TITLE
Enable hover for `var @"foo-bar"`

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -3242,20 +3242,29 @@ pub fn resolveExpressionTypeFromAncestors(
 }
 
 pub fn identifierFromPosition(pos_index: usize, handle: DocumentStore.Handle) []const u8 {
-    if (pos_index + 1 >= handle.text.len) return "";
+    const loc = identifierLocFromPosition(pos_index, &handle) orelse return "";
+    return offsets.locToSlice(handle.text, loc);
+}
+
+pub fn identifierLocFromPosition(pos_index: usize, handle: *const DocumentStore.Handle) ?std.zig.Token.Loc {
+    if (pos_index + 1 >= handle.text.len) return null;
     var start_idx = pos_index;
 
     while (start_idx > 0 and Analyser.isSymbolChar(handle.text[start_idx - 1])) {
         start_idx -= 1;
     }
 
+    const token_index = offsets.sourceIndexToTokenIndex(handle.tree, start_idx);
+    if (handle.tree.tokens.items(.tag)[token_index] == .identifier)
+        return offsets.tokenToLoc(handle.tree, token_index);
+
     var end_idx = pos_index;
     while (end_idx < handle.text.len and Analyser.isSymbolChar(handle.text[end_idx])) {
         end_idx += 1;
     }
 
-    if (end_idx <= start_idx) return "";
-    return handle.text[start_idx..end_idx];
+    if (end_idx <= start_idx) return null;
+    return .{ .start = start_idx, .end = end_idx };
 }
 
 pub fn getLabelGlobal(pos_index: usize, handle: *const DocumentStore.Handle) error{OutOfMemory}!?DeclWithHandle {
@@ -3309,10 +3318,11 @@ pub fn getSymbolFieldAccesses(
     const tracy_zone = tracy.trace(@src());
     defer tracy_zone.end();
 
-    const name = identifierFromPosition(source_index, handle.*);
+    const name_loc = identifierLocFromPosition(source_index, handle) orelse return null;
+    const name = offsets.locToSlice(handle.text, name_loc);
     if (name.len == 0) return null;
 
-    const held_range = try arena.dupeZ(u8, offsets.locToSlice(handle.text, loc));
+    const held_range = try arena.dupeZ(u8, offsets.locToSlice(handle.text, offsets.locMerge(loc, name_loc)));
     var tokenizer = std.zig.Tokenizer.init(held_range);
 
     var decls_with_handles = std.ArrayListUnmanaged(DeclWithHandle){};

--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -1075,9 +1075,9 @@ fn resolveContainer(
 /// If the identifier is a `fn_name`, `fn_arg_index` is the index of the fn's param
 fn getIdentifierTokenIndexAndFnArgIndex(
     tree: Ast,
-    dot_index: usize,
+    dot_index: Ast.TokenIndex,
     fn_arg_index_out: *usize,
-) ?usize {
+) ?Ast.TokenIndex {
     // at least 3 tokens should be present, `x{.`
     if (dot_index < 2) return null;
     const token_tags = tree.tokens.items(.tag);

--- a/src/offsets.zig
+++ b/src/offsets.zig
@@ -54,7 +54,7 @@ pub fn positionToIndex(text: []const u8, position: types.Position, encoding: Enc
     return line_start_index + line_byte_length;
 }
 
-pub fn sourceIndexToTokenIndex(tree: Ast, source_index: usize) usize {
+pub fn sourceIndexToTokenIndex(tree: Ast, source_index: usize) Ast.TokenIndex {
     std.debug.assert(source_index < tree.source.len);
 
     const tokens_start = tree.tokens.items(.start);
@@ -111,7 +111,7 @@ pub fn sourceIndexToTokenIndex(tree: Ast, source_index: usize) usize {
         break;
     }
 
-    return upper_index;
+    return @intCast(upper_index);
 }
 
 pub fn tokenToIndex(tree: Ast, token_index: Ast.TokenIndex) usize {


### PR DESCRIPTION
For example:

```zig
var @"foo-bar" = "foo";

const Foobar = struct { @"foo \" bar": i32 };
var foobar = Foobar{ .@"foo \" bar" = 123 };
```

**Warning:** Other than that there doesn't seem to be any noticeable slowdown on my potato, I don't know what effect this has on performance... Guidance on how to benchmark this would be much appreciated!