### PR TITLE
ignore unknown fields while parsing

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -1496,7 +1496,12 @@ pub fn processMessage(server: *Server, message: Message) Error!void {
             const params: ParamsType = if (ParamsType == void)
                 void{}
             else
-                std.json.parseFromValueLeaky(ParamsType, server.arena.allocator(), message.params.?, .{}) catch |err| {
+                std.json.parseFromValueLeaky(
+                    ParamsType,
+                    server.arena.allocator(),
+                    message.params.?,
+                    .{ .ignore_unknown_fields = true },
+                ) catch |err| {
                     log.err("failed to parse params from {s}: {}", .{ method, err });
                     if (@errorReturnTrace()) |trace| {
                         std.debug.dumpStackTrace(trace.*);


### PR DESCRIPTION
neovim seems to have introduced its own LSP Specification that includes addition properties like [`hierarchicalWorkspaceSymbolSupport`](https://github.com/neovim/neovim/blob/9176b5e10a6b32ff65c8ba3f532e3bd55c168ec6/runtime/lua/vim/lsp/protocol.lua#L847)