### PR TITLE
More bugfixes

### DIFF
--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -155,6 +155,11 @@ fn nodeToCompletion(
         };
         return try declToCompletion(context, result);
     }
+    if (doc_comments == null) {
+        if (try analyser.resolveTypeOfNode(node_handle)) |resolved_type| {
+            doc_comments = try resolved_type.docComments(arena);
+        }
+    }
 
     const doc = try completionDoc(
         server,

--- a/src/features/goto.zig
+++ b/src/features/goto.zig
@@ -20,26 +20,13 @@ pub fn gotoDefinitionSymbol(
     const tracy_zone = tracy.trace(@src());
     defer tracy_zone.end();
 
-    var handle = decl_handle.handle;
-
-    const name_token = switch (decl_handle.decl.*) {
-        .ast_node => |node| block: {
-            if (resolve_alias) {
-                if (try analyser.resolveVarDeclAlias(.{ .node = node, .handle = handle })) |result| {
-                    handle = result.handle;
-
-                    break :block result.nameToken();
-                }
-            }
-
-            break :block Analyser.getDeclNameToken(handle.tree, node) orelse return null;
-        },
-        else => decl_handle.nameToken(),
-    };
+    const token_handle = try decl_handle.definitionToken(analyser, resolve_alias);
+    const token = token_handle.token;
+    const handle = token_handle.handle;
 
     return types.Location{
         .uri = handle.uri,
-        .range = offsets.tokenToRange(handle.tree, name_token, offset_encoding),
+        .range = offsets.tokenToRange(handle.tree, token, offset_encoding),
     };
 }
 

--- a/src/features/hover.zig
+++ b/src/features/hover.zig
@@ -95,6 +95,9 @@ pub fn hoverSymbol(
 
     var resolved_type_str: []const u8 = "unknown";
     if (try decl_handle.resolveType(analyser)) |resolved_type| {
+        if (doc_str == null) {
+            doc_str = try resolved_type.docComments(arena);
+        }
         try analyser.referencedTypes(
             resolved_type,
             &resolved_type_str,


### PR DESCRIPTION
## Fix snippets of aliased functions

Closes #1327

> Commit 53b40b3 from #1319 has broken snippet insertion for aliased functions.
> 
> Before that commit completion of `std.ArrayHashMap` results in `std.ArrayHashMap(comptime K: type, comptime V: type, comptime Context: type, comptime store_hash: bool)` after that commit it results in `std.ArrayHashMap`.

## Show `//!` doc comments in hover and completions

Closes #304

> In `Something.zig`:
> 
> ```zig
> //! top level comment
> 
> /// inner comment
> a: i32
> ```
> 
> In `main.zig`:
> 
> ```zig
> const Something = @import("Something.zig");
> pub fn main() void {
>   const some = Something { .a = 2 }; // Something has no documentation
>   some.a; // Has top level documentation and inner documentation 
> }
> ```

(#308 removed the top level comment for members)

## Make Go to Definition fully resolve `const Foo = @import("Foo.zig")`

Also fix broken Go to Declaration caused by Server API redesign in #1311

Closes #322

> ```zig
> const std = @import("std");
> const fs = std.fs;
> ```
> 
> Consider clicking on the `.fs`, this opens `zig/lib/std/std.zig` to a line that says `const fs = @import("fs.zig");`.
> 
> The request here is to make it so that when the definition being goto'd is an `@import("file.zig");`, open `file.zig` instead.