### PR TITLE
Various improvements

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -106,7 +106,7 @@ pub fn collectDocComments(allocator: std.mem.Allocator, tree: Ast, doc_comments:
     while (true) : (curr_line_tok += 1) {
         const comm = tokens[curr_line_tok];
         if ((container_doc and comm == .container_doc_comment) or (!container_doc and comm == .doc_comment)) {
-            try lines.append(std.mem.trim(u8, tree.tokenSlice(curr_line_tok)[3..], &std.ascii.whitespace));
+            try lines.append(tree.tokenSlice(curr_line_tok)[3..]);
         } else break;
     }
 

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -1779,8 +1779,12 @@ pub const TypeWithHandle = struct {
         if (self.type.is_type_val) {
             if (try analyser.lookupSymbolContainer(node_handle, symbol, .variable)) |decl|
                 return decl;
+            if (self.isEnumType() or self.isTaggedUnion())
+                return analyser.lookupSymbolContainer(node_handle, symbol, .field);
             return null;
         }
+        if (self.isEnumType())
+            return analyser.lookupSymbolContainer(node_handle, symbol, .variable);
         if (try analyser.lookupSymbolContainer(node_handle, symbol, .field)) |decl|
             return decl;
         return analyser.lookupSymbolContainer(node_handle, symbol, .variable);

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -2564,7 +2564,10 @@ pub const DeclWithHandle = struct {
                 .type = .{ .data = .array_index, .is_type_val = false },
                 .handle = self.handle,
             },
-            .label_decl => return null,
+            .label_decl => |decl| try analyser.resolveTypeOfNodeInternal(.{
+                .node = decl.block,
+                .handle = self.handle,
+            }),
             .switch_payload => |pay| {
                 if (pay.items.len == 0) return null;
                 // TODO Peer type resolution, we just use the first item for now.

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -3144,6 +3144,13 @@ pub fn resolveExpressionTypeFromAncestors(
                 .handle = handle,
             });
         }
+    } else if (tree.fullContainerField(ancestors[0])) |container_field| {
+        if (node == container_field.ast.value_expr) {
+            return try analyser.resolveTypeOfNode(.{
+                .node = ancestors[0],
+                .handle = handle,
+            });
+        }
     } else if (tree.fullIf(ancestors[0])) |if_node| {
         if (node == if_node.ast.then_expr or node == if_node.ast.else_expr) {
             return try analyser.resolveExpressionType(

--- a/src/ast.zig
+++ b/src/ast.zig
@@ -1005,6 +1005,19 @@ pub fn paramSlice(tree: Ast, param: Ast.full.FnProto.Param) []const u8 {
     return tree.source[start..end];
 }
 
+pub fn isTaggedUnion(tree: Ast, node: Ast.Node.Index) bool {
+    const main_tokens = tree.nodes.items(.main_token);
+    const tags = tree.tokens.items(.tag);
+    if (tags[main_tokens[node]] != .keyword_union)
+        return false;
+
+    var buf: [2]Ast.Node.Index = undefined;
+    const decl = tree.fullContainerDecl(&buf, node) orelse
+        return false;
+
+    return decl.ast.enum_token != null or decl.ast.arg != 0;
+}
+
 pub fn isContainer(tree: Ast, node: Ast.Node.Index) bool {
     return switch (tree.nodes.items(.tag)[node]) {
         .container_decl,

--- a/src/debug.zig
+++ b/src/debug.zig
@@ -65,7 +65,7 @@ pub fn printDocumentScope(doc_scope: analysis.DocumentScope) void {
 
         var decl_it = scope.decls.iterator();
         while (decl_it.next()) |entry| {
-            std.debug.print("    - {s:<8} {}\n", .{ entry.key_ptr.*, entry.value_ptr.* });
+            std.debug.print("    - {s:<8} {}\n", .{ entry.key_ptr.name, entry.value_ptr.* });
         }
     }
 }

--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -977,7 +977,10 @@ fn resolveContainer(
             }
         },
         .field_access => |loc| fa: {
-            const decls = try analyser.getSymbolFieldAccesses(arena, handle, loc.end, loc) orelse break :fa;
+            const name_loc = Analyser.identifierLocFromPosition(loc.end, handle) orelse break :fa;
+            const name = offsets.locToSlice(handle.text, name_loc);
+            const held_loc = offsets.locMerge(loc, name_loc);
+            const decls = try analyser.getSymbolFieldAccesses(arena, handle, loc.end, held_loc, name) orelse break :fa;
             for (decls) |decl| {
                 const decl_node = switch (decl.decl.*) {
                     .ast_node => |ast_node| ast_node,

--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -47,8 +47,6 @@ fn typeToCompletion(
                 });
             }
         },
-        .error_union => {},
-        .multi_pointer => {},
         .pointer => |t| {
             if (server.config.operator_completions) {
                 try list.append(arena, .{
@@ -74,7 +72,6 @@ fn typeToCompletion(
             null,
             either_descriptor,
         ),
-        .primitive, .array_index => {},
         .@"comptime" => |co| try analyser_completions.dotCompletions(
             arena,
             list,
@@ -87,6 +84,7 @@ fn typeToCompletion(
             for (bruh) |a|
                 try typeToCompletion(server, analyser, arena, list, .{ .original = a.type_with_handle }, orig_handle, a.descriptor);
         },
+        else => {},
     }
 }
 

--- a/src/features/hover.zig
+++ b/src/features/hover.zig
@@ -136,11 +136,14 @@ pub fn hoverDefinitionLabel(
     handle: *const DocumentStore.Handle,
     pos_index: usize,
     markup_kind: types.MarkupKind,
+    offset_encoding: offsets.Encoding,
 ) error{OutOfMemory}!?types.Hover {
     const tracy_zone = tracy.trace(@src());
     defer tracy_zone.end();
 
-    const decl = (try Analyser.getLabelGlobal(pos_index, handle)) orelse return null;
+    const name_loc = Analyser.identifierLocFromPosition(pos_index, handle) orelse return null;
+    const name = offsets.locToSlice(handle.text, name_loc);
+    const decl = (try Analyser.getLabelGlobal(pos_index, handle, name)) orelse return null;
 
     return .{
         .contents = .{
@@ -149,6 +152,7 @@ pub fn hoverDefinitionLabel(
                 .value = (try hoverSymbol(analyser, arena, decl, markup_kind, null)) orelse return null,
             },
         },
+        .range = offsets.locToRange(handle.text, name_loc, offset_encoding),
     };
 }
 
@@ -158,14 +162,15 @@ pub fn hoverDefinitionBuiltin(
     handle: *const DocumentStore.Handle,
     pos_index: usize,
     markup_kind: types.MarkupKind,
+    offset_encoding: offsets.Encoding,
 ) error{OutOfMemory}!?types.Hover {
     _ = analyser;
     _ = markup_kind;
     const tracy_zone = tracy.trace(@src());
     defer tracy_zone.end();
 
-    const name = Analyser.identifierFromPosition(pos_index, handle.*);
-    if (name.len == 0) return null;
+    const name_loc = Analyser.identifierLocFromPosition(pos_index, handle) orelse return null;
+    const name = offsets.locToSlice(handle.text, name_loc);
 
     const builtin = for (data.builtins) |builtin| {
         if (std.mem.eql(u8, builtin.name[1..], name)) {
@@ -207,6 +212,7 @@ pub fn hoverDefinitionBuiltin(
                 .value = contents.items,
             },
         },
+        .range = offsets.locToRange(handle.text, name_loc, offset_encoding),
     };
 }
 
@@ -216,11 +222,14 @@ pub fn hoverDefinitionGlobal(
     handle: *const DocumentStore.Handle,
     pos_index: usize,
     markup_kind: types.MarkupKind,
+    offset_encoding: offsets.Encoding,
 ) error{OutOfMemory}!?types.Hover {
     const tracy_zone = tracy.trace(@src());
     defer tracy_zone.end();
 
-    const decl = (try analyser.getSymbolGlobal(pos_index, handle)) orelse return null;
+    const name_loc = Analyser.identifierLocFromPosition(pos_index, handle) orelse return null;
+    const name = offsets.locToSlice(handle.text, name_loc);
+    const decl = (try analyser.getSymbolGlobal(pos_index, handle, name)) orelse return null;
 
     return .{
         .contents = .{
@@ -229,6 +238,7 @@ pub fn hoverDefinitionGlobal(
                 .value = (try hoverSymbol(analyser, arena, decl, markup_kind, null)) orelse return null,
             },
         },
+        .range = offsets.locToRange(handle.text, name_loc, offset_encoding),
     };
 }
 
@@ -238,11 +248,14 @@ pub fn hoverDefinitionEnumLiteral(
     handle: *const DocumentStore.Handle,
     source_index: usize,
     markup_kind: types.MarkupKind,
+    offset_encoding: offsets.Encoding,
 ) error{OutOfMemory}!?types.Hover {
     const tracy_zone = tracy.trace(@src());
     defer tracy_zone.end();
 
-    const decl = (try analyser.getSymbolEnumLiteral(arena, handle, source_index)) orelse return null;
+    const name_loc = Analyser.identifierLocFromPosition(source_index, handle) orelse return null;
+    const name = offsets.locToSlice(handle.text, name_loc);
+    const decl = (try analyser.getSymbolEnumLiteral(arena, handle, source_index, name)) orelse return null;
 
     return .{
         .contents = .{
@@ -251,6 +264,7 @@ pub fn hoverDefinitionEnumLiteral(
                 .value = (try hoverSymbol(analyser, arena, decl, markup_kind, null)) orelse return null,
             },
         },
+        .range = offsets.locToRange(handle.text, name_loc, offset_encoding),
     };
 }
 
@@ -261,11 +275,15 @@ pub fn hoverDefinitionFieldAccess(
     source_index: usize,
     loc: offsets.Loc,
     markup_kind: types.MarkupKind,
+    offset_encoding: offsets.Encoding,
 ) error{OutOfMemory}!?types.Hover {
     const tracy_zone = tracy.trace(@src());
     defer tracy_zone.end();
 
-    const decls = (try analyser.getSymbolFieldAccesses(arena, handle, source_index, loc)) orelse return null;
+    const name_loc = Analyser.identifierLocFromPosition(source_index, handle) orelse return null;
+    const name = offsets.locToSlice(handle.text, name_loc);
+    const held_loc = offsets.locMerge(loc, name_loc);
+    const decls = (try analyser.getSymbolFieldAccesses(arena, handle, source_index, held_loc, name)) orelse return null;
 
     var content = std.ArrayListUnmanaged(types.MarkedString){};
 
@@ -281,18 +299,26 @@ pub fn hoverDefinitionFieldAccess(
         .contents = .{
             .array_of_MarkedString = try content.toOwnedSlice(arena),
         },
+        .range = offsets.locToRange(handle.text, name_loc, offset_encoding),
     };
 }
 
-pub fn hover(analyser: *Analyser, arena: std.mem.Allocator, handle: *const DocumentStore.Handle, source_index: usize, markup_kind: types.MarkupKind) !?types.Hover {
+pub fn hover(
+    analyser: *Analyser,
+    arena: std.mem.Allocator,
+    handle: *const DocumentStore.Handle,
+    source_index: usize,
+    markup_kind: types.MarkupKind,
+    offset_encoding: offsets.Encoding,
+) !?types.Hover {
     const pos_context = try Analyser.getPositionContext(arena, handle.text, source_index, true);
 
     const response = switch (pos_context) {
-        .builtin => try hoverDefinitionBuiltin(analyser, arena, handle, source_index, markup_kind),
-        .var_access => try hoverDefinitionGlobal(analyser, arena, handle, source_index, markup_kind),
-        .field_access => |loc| try hoverDefinitionFieldAccess(analyser, arena, handle, source_index, loc, markup_kind),
-        .label => try hoverDefinitionLabel(analyser, arena, handle, source_index, markup_kind),
-        .enum_literal => try hoverDefinitionEnumLiteral(analyser, arena, handle, source_index, markup_kind),
+        .builtin => try hoverDefinitionBuiltin(analyser, arena, handle, source_index, markup_kind, offset_encoding),
+        .var_access => try hoverDefinitionGlobal(analyser, arena, handle, source_index, markup_kind, offset_encoding),
+        .field_access => |loc| try hoverDefinitionFieldAccess(analyser, arena, handle, source_index, loc, markup_kind, offset_encoding),
+        .label => try hoverDefinitionLabel(analyser, arena, handle, source_index, markup_kind, offset_encoding),
+        .enum_literal => try hoverDefinitionEnumLiteral(analyser, arena, handle, source_index, markup_kind, offset_encoding),
         else => null,
     };
 

--- a/src/features/inlay_hints.zig
+++ b/src/features/inlay_hints.zig
@@ -250,17 +250,9 @@ fn writeCallNodeHint(builder: *Builder, call: Ast.full.Call) !void {
             // than trying to re-tokenize and re-parse it
             if (try builder.analyser.getFieldAccessType(handle, rhs_loc.end, &tokenizer)) |result| {
                 const container_handle = result.unwrapped orelse result.original;
-                switch (container_handle.type.data) {
-                    .other => |container_handle_node| {
-                        if (try builder.analyser.lookupSymbolContainer(
-                            .{ .node = container_handle_node, .handle = container_handle.handle },
-                            tree.tokenSlice(rhsToken),
-                            true,
-                        )) |decl_handle| {
-                            try writeCallHint(builder, call, decl_handle);
-                        }
-                    },
-                    else => {},
+                const symbol = tree.tokenSlice(rhsToken);
+                if (try container_handle.lookupSymbol(builder.analyser, symbol)) |decl_handle| {
+                    try writeCallHint(builder, call, decl_handle);
                 }
             }
         },

--- a/src/features/references.zig
+++ b/src/features/references.zig
@@ -122,16 +122,8 @@ const Builder = struct {
                     (try builder.analyser.resolveTypeOfNode(.{ .node = datas[node].lhs, .handle = handle })) orelse return,
                 );
 
-                const left_type_node = switch (left_type.type.data) {
-                    .other => |n| n,
-                    else => return,
-                };
-
-                const child = (try builder.analyser.lookupSymbolContainer(
-                    .{ .node = left_type_node, .handle = left_type.handle },
-                    offsets.tokenToSlice(tree, datas[node].rhs),
-                    !left_type.type.is_type_val,
-                )) orelse return;
+                const symbol = offsets.tokenToSlice(tree, datas[node].rhs);
+                const child = (try left_type.lookupSymbol(builder.analyser, symbol)) orelse return;
 
                 if (builder.decl_handle.eql(child)) {
                     try builder.add(handle, datas[node].rhs);
@@ -341,16 +333,8 @@ const CallBuilder = struct {
                             (try builder.analyser.resolveTypeOfNode(.{ .node = datas[called_node].lhs, .handle = handle })) orelse return,
                         );
 
-                        const left_type_node = switch (left_type.type.data) {
-                            .other => |n| n,
-                            else => return,
-                        };
-
-                        const child = (try builder.analyser.lookupSymbolContainer(
-                            .{ .node = left_type_node, .handle = left_type.handle },
-                            offsets.tokenToSlice(tree, datas[called_node].rhs),
-                            !left_type.type.is_type_val,
-                        )) orelse return;
+                        const symbol = offsets.tokenToSlice(tree, datas[called_node].rhs);
+                        const child = (try left_type.lookupSymbol(builder.analyser, symbol)) orelse return;
 
                         if (builder.decl_handle.eql(child)) {
                             try builder.add(handle, node);

--- a/src/features/semantic_tokens.zig
+++ b/src/features/semantic_tokens.zig
@@ -841,15 +841,7 @@ fn writeNodeTokens(builder: *Builder, node: Ast.Node.Index) error{OutOfMemory}!v
             const lhs_type = try builder.analyser.resolveFieldAccessLhsType(
                 (try builder.analyser.resolveTypeOfNode(.{ .node = data.lhs, .handle = handle })) orelse return,
             );
-            const left_type_node = switch (lhs_type.type.data) {
-                .other => |n| n,
-                else => return,
-            };
-            if (try builder.analyser.lookupSymbolContainer(
-                .{ .node = left_type_node, .handle = lhs_type.handle },
-                tree.tokenSlice(data.rhs),
-                !lhs_type.type.is_type_val,
-            )) |decl_type| {
+            if (try lhs_type.lookupSymbol(builder.analyser, tree.tokenSlice(data.rhs))) |decl_type| {
                 switch (decl_type.decl.*) {
                     .ast_node => |decl_node| {
                         if (decl_type.handle.tree.nodes.items(.tag)[decl_node].isContainerField()) {

--- a/src/features/signature_help.zig
+++ b/src/features/signature_help.zig
@@ -267,11 +267,7 @@ pub fn getSignatureInfo(analyser: *Analyser, arena: std.mem.Allocator, handle: *
                     const name = offsets.locToSlice(handle.text, name_loc);
 
                     const skip_self_param = !type_handle.type.is_type_val;
-                    const decl_handle = (try analyser.lookupSymbolContainer(
-                        .{ .node = node, .handle = type_handle.handle },
-                        name,
-                        true,
-                    )) orelse {
+                    const decl_handle = (try type_handle.lookupSymbol(analyser, name)) orelse {
                         try symbol_stack.append(arena, .l_paren);
                         continue;
                     };

--- a/src/features/signature_help.zig
+++ b/src/features/signature_help.zig
@@ -260,11 +260,11 @@ pub fn getSignatureInfo(analyser: *Analyser, arena: std.mem.Allocator, handle: *
                         );
                     }
 
-                    const name = Analyser.identifierFromPosition(expr_end - 1, handle.*);
-                    if (name.len == 0) {
+                    const name_loc = Analyser.identifierLocFromPosition(expr_end - 1, handle) orelse {
                         try symbol_stack.append(arena, .l_paren);
                         continue;
-                    }
+                    };
+                    const name = offsets.locToSlice(handle.text, name_loc);
 
                     const skip_self_param = !type_handle.type.is_type_val;
                     const decl_handle = (try analyser.lookupSymbolContainer(

--- a/tests/lsp_features/definition.zig
+++ b/tests/lsp_features/definition.zig
@@ -61,5 +61,6 @@ fn testDefinition(source: []const u8) !void {
     };
 
     const response = try ctx.server.sendRequestSync(ctx.arena.allocator(), "textDocument/definition", params) orelse return error.UnresolvedDefinition;
-    try std.testing.expectEqual(def_range_lsp, response.Definition.Location.range);
+    try std.testing.expectEqual(@as(usize, 1), response.array_of_DefinitionLink.len);
+    try std.testing.expectEqual(def_range_lsp, response.array_of_DefinitionLink[0].targetSelectionRange);
 }


### PR DESCRIPTION
## Show type when hovering over block label

<img width="529" alt="Screenshot" src="https://github.com/zigtools/zls/assets/70830482/26b32ee7-efe7-4e5b-97c3-aba6d17b4d4b">

## Resolve type of implicitly void variant of tagged union

<img width="374" alt="Screenshot" src="https://github.com/zigtools/zls/assets/70830482/1d638ea9-0bfd-4fac-a060-b63dd67a146d">

## Fix semantic highlighting for `MyEnum.value`/`MyTaggedUnion.value`

<img width="144" alt="Screenshot 2023-07-16 at 10 48 35 AM" src="https://github.com/zigtools/zls/assets/70830482/48fbbf34-3934-4cca-8625-67fde51f11ac">

<details><summary>Before</summary>

<img width="146" alt="Screenshot 2023-07-16 at 10 48 51 AM" src="https://github.com/zigtools/zls/assets/70830482/748e7085-7e8d-4050-8634-ed799e1de225">

</details>

```zig
const E = enum { foo, bar };
const U = union(E) { foo: f32, bar: void };

const std = @import("std");
pub fn main() !void {
    const efoo = E.foo;
    const ufoo = U.foo;
    const bar = @as(U, U.bar);
    std.debug.print("{}\n{}\n{}\n", .{
        @TypeOf(efoo), // => E
        @TypeOf(ufoo), // => E
        @TypeOf(bar), // => U
    });
}
```

## Resolve type of enum literal in container field init

<img width="464" alt="Screenshot" src="https://github.com/zigtools/zls/assets/70830482/6181bb92-fc84-4663-bd2b-d2ac810911d7">

## Preserve whitespace in doc comments

<img width="959" alt="Screenshot" src="https://github.com/zigtools/zls/assets/70830482/cc65c46d-ad4c-41c1-818c-bd0549cb54d2">

<details><summary>Before</summary>

<img width="959" alt="Screenshot" src="https://github.com/zigtools/zls/assets/70830482/d67b3035-dc6c-4e5c-9602-bdaf7bc18708">

</details>

## Highlight entire identifier on hover/goto

<img width="529" alt="Screenshot" src="https://github.com/zigtools/zls/assets/70830482/b7e023d4-ecbd-4d69-8d0e-d051019621cf">

<img width="307" alt="Screenshot" src="https://github.com/zigtools/zls/assets/70830482/1bf39de6-81b7-499a-96e3-ea0609ca18b1">

<details><summary>Before</summary>

<img width="530" alt="Screenshot" src="https://github.com/zigtools/zls/assets/70830482/2317e36b-5c45-4919-8531-a7c13222f3cb">

<img width="310" alt="Screenshot" src="https://github.com/zigtools/zls/assets/70830482/44a1b081-9ede-4498-aff7-14398b2c43d6">

</details>

## Fix symbol lookup for var with same name as field and vice versa

<img width="634" alt="Screenshot" src="https://github.com/zigtools/zls/assets/70830482/b6cffa0d-53e0-4a5d-86bc-d23a5ef534b9">

<details><summary>Before</summary>

<img width="311" alt="Screenshot" src="https://github.com/zigtools/zls/assets/70830482/7e5457a1-c5aa-45be-8300-2364cdcfdcdd">

</details>

## Add hover for `MyEnum.value`/`MyTaggedUnion.value`

<img width="161" alt="Screenshot" src="https://github.com/zigtools/zls/assets/70830482/c50b4f75-ebd2-4b9e-8be2-48110919a2fa">

## Fix type resolution for `MyTaggedUnion.value`

```zig
const Foo = union(enum) {
    bar,
    const baz: i32 = 123;
};

const foobar = Foo.bar; // @typeInfo(Foo).Union.tag_type.?
const foobaz = Foo.baz; // i32

const std = @import("std");
pub fn main() !void {
    std.debug.print("{}\n", .{@TypeOf(foobar)});
}
```