### PR TITLE
Search for r_brace at the AST level, not the source code level.

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -3787,13 +3787,7 @@ fn makeScopeAt(
         => {
             const first_token = tree.firstToken(node_idx);
             const last_token = ast.lastToken(tree, node_idx);
-
-            // the last token may not always be the closing brace because of broken ast
-            // so we look at most 16 characters ahead to find the closing brace
-            // TODO this should automatically be done by `ast.lastToken`
-            var end_index = offsets.tokenToLoc(tree, last_token).start;
-            const lookahead_buffer = tree.source[end_index..@min(tree.source.len, end_index + 16)];
-            end_index += std.mem.indexOfScalar(u8, lookahead_buffer, '}') orelse 0;
+            const end_index = offsets.tokenToLoc(tree, last_token).end;
 
             const scope_index = try context.pushScope(
                 .{

--- a/src/ast.zig
+++ b/src/ast.zig
@@ -55,7 +55,10 @@ fn fullPtrTypeComponents(tree: Ast, info: full.PtrType.Components) full.PtrType 
     return result;
 }
 
-fn findMatchingRBrace(token_tags: []const TokenTag, l_brace: Ast.TokenIndex) Ast.TokenIndex {
+/// Given an l_brace, find the corresponding r_brace.
+/// If no corresponding r_brace is found, return null.
+/// Useful for finding the extent of a block/scope if the syntax is valid.
+fn findMatchingRBrace(token_tags: []const TokenTag, l_brace: Ast.TokenIndex) ?Ast.TokenIndex {
     std.debug.assert(token_tags[l_brace] == TokenTag.l_brace);
 
     const start = l_brace + 1;
@@ -75,10 +78,7 @@ fn findMatchingRBrace(token_tags: []const TokenTag, l_brace: Ast.TokenIndex) Ast
         }
     }
 
-    std.debug.assert(depth == 0);
-    std.debug.assert(token_tags[start + offset] == std.zig.Token.Tag.r_brace);
-
-    return start + offset;
+    return if (depth == 0) start + offset else null;
 }
 
 pub fn ptrTypeSimple(tree: Ast, node: Node.Index) full.PtrType {

--- a/src/ast.zig
+++ b/src/ast.zig
@@ -604,15 +604,11 @@ pub fn lastToken(tree: Ast, node: Ast.Node.Index) Ast.TokenIndex {
             }
             n = tree.extra_data[params.end - 1]; // last parameter
         },
+        .switch_comma,
         .@"switch" => {
-            const cases = tree.extraData(datas[n].rhs, Node.SubRange);
-            if (cases.end - cases.start == 0) {
-                end_offset += 3; // rparen, lbrace, rbrace
-                n = datas[n].lhs; // condition expression
-            } else {
-                end_offset += 1; // for the rbrace
-                n = tree.extra_data[cases.end - 1]; // last case
-            }
+            const lhs = datas[n].lhs;
+            const l_brace = tree.lastToken(lhs) + 2; //lparen + rbrace
+            return findMatchingRBrace(token_tags, l_brace);
         },
         .container_decl_arg,
         .container_decl_arg_trailing,
@@ -640,7 +636,6 @@ pub fn lastToken(tree: Ast, node: Ast.Node.Index) Ast.TokenIndex {
         },
         .array_init_comma,
         .struct_init_comma,
-        .switch_comma,
         => {
             if (datas[n].rhs != 0) {
                 const members = tree.extraData(datas[n].rhs, Node.SubRange);

--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -318,6 +318,31 @@ test "completion - struct" {
         .{ .label = "alpha", .kind = .Field, .detail = "alpha: u32" },
         .{ .label = "beta", .kind = .Field, .detail = "beta: []const u8" },
     });
+
+    try testCompletion(
+        \\fn doNothingWithInteger(a: u32) void { _ = a; }
+        \\const S = struct {
+        \\    alpha: u32,
+        \\    beta: []const u8,
+        \\    fn foo(self: S) void {
+        \\        doNothingWithInteger(self.<cursor>
+        \\    }
+        \\};
+    , &.{
+        .{ .label = "alpha", .kind = .Field, .detail = "alpha: u32" },
+        .{ .label = "beta", .kind = .Field, .detail = "beta: []const u8" },
+        .{ .label = "foo", .kind = .Function, .detail = "fn foo(self: S) void" },
+    });
+
+    try testCompletion(
+        \\const S = struct {
+        \\    const Mode = enum { alpha, beta, };
+        \\    fn foo(mode: <cursor>
+        \\};
+    , &.{
+        .{ .label = "S", .kind = .Constant, .detail = "const S = struct" },
+        .{ .label = "Mode", .kind = .Constant, .detail = "const Mode = enum" },
+    });
 }
 
 test "completion - union" {

--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -261,37 +261,35 @@ test "completion - captures" {
         .{ .label = "alpha", .kind = .Field, .detail = "alpha: u32" },
     });
 
-    // TODO fix error union capture with if-else
-    // try testCompletion(
-    //     \\const E = error{ X, Y };
-    //     \\const S = struct { alpha: u32 };
-    //     \\fn foo() E!S { return undefined; }
-    //     \\fn bar() void {
-    //     \\    if (foo()) |baz| {
-    //     \\        baz.<cursor>
-    //     \\    } else |err| {
-    //     \\        _ = err;
-    //     \\    }
-    //     \\}
-    // , &.{
-    //     .{ .label = "alpha", .kind = .Field, .detail = "alpha: u32" },
-    // });
+    try testCompletion(
+        \\const E = error{ X, Y };
+        \\const S = struct { alpha: u32 };
+        \\fn foo() E!S { return undefined; }
+        \\fn bar() void {
+        \\    if (foo()) |baz| {
+        \\        baz.<cursor>
+        \\    } else |err| {
+        \\        _ = err;
+        \\    }
+        \\}
+    , &.{
+        .{ .label = "alpha", .kind = .Field, .detail = "alpha: u32" },
+    });
 
-    // TODO fix error union capture with while loop
-    // try testCompletion(
-    //     \\const E = error{ X, Y };
-    //     \\const S = struct { alpha: u32 };
-    //     \\fn foo() E!S { return undefined; }
-    //     \\fn bar() void {
-    //     \\    while (foo()) |baz| {
-    //     \\        baz.<cursor>
-    //     \\    } else |err| {
-    //     \\        _ = err;
-    //     \\    }
-    //     \\}
-    // , &.{
-    //     .{ .label = "alpha", .kind = .Field, .detail = "alpha: u32" },
-    // });
+    try testCompletion(
+        \\const E = error{ X, Y };
+        \\const S = struct { alpha: u32 };
+        \\fn foo() E!S { return undefined; }
+        \\fn bar() void {
+        \\    while (foo()) |baz| {
+        \\        baz.<cursor>
+        \\    } else |err| {
+        \\        _ = err;
+        \\    }
+        \\}
+    , &.{
+        .{ .label = "alpha", .kind = .Field, .detail = "alpha: u32" },
+    });
 }
 
 test "completion - struct" {

--- a/tests/lsp_features/folding_range.zig
+++ b/tests/lsp_features/folding_range.zig
@@ -167,8 +167,7 @@ test "foldingRange - container decl" {
         \\  beta: u16,
         \\};
     , &.{
-        // .{ .startLine = 0, .startCharacter = 32, .endLine = 3, .endCharacter = 0 }, // TODO
-        .{ .startLine = 0, .startCharacter = 32, .endLine = 2, .endCharacter = 11 },
+        .{ .startLine = 0, .startCharacter = 32, .endLine = 3, .endCharacter = 0 },
     });
     try testFoldingRange(
         \\const Foo = union {


### PR DESCRIPTION
We were doing a search for the right brace at the source code level in makeScopeAt. This was fallible, since it only searched up to 16 characters from the l_brace. Another problem was that this search was not being done for any parent function scopes. So the parent scope would end up being shorter than its child block, causing any declaration searches within the block to terminate early.

It seems like this was a known issue based on the TODO comment in the handler for block_two nodes in makeScopeAt.

Before this change, this would fail to trigger any completions on the period after self:
```
fn doThing(self: Self) void {
    doSomethingElseHere(self.
}
```
This change fixes that. It also fixes this issue:
```
const pipeline = struct {
    const PolygonMode = enum(c.enum_onyx_polygon_mode) {
        fill = c.ONYX_POLYGON_MODE_FILL,
        line = c.ONYX_POLYGON_MODE_LINE,
        point = c.ONYX_POLYGON_MODE_POINT,
    };

    pub fn basic(polygon_mode: Poly
};

```
Here, I was not getting any completion suggestions after typing the `y` in Poly.

The fix I'm using is to just find the left brace token for the block, and then just search for the corresponding right brace. It's brain dead simple, which leads me to believe there might be a reason it was not already being use. Grammatically, I think it is a reasonable assumption that a scope that opens on an l_brace will end on its corresponding r_brace. But, I'm still learning zig, and there may be some language constructs I'm not familiar with that break this assumption.

I'm still testing this locally. I currently only have this change applied to block_two and container_decl_two, which are so far the two situations I've encountered in my coding where the old behavior was not working and this change has fixed it (the tow examples above). As I code more, I may find other scope types where it will make sense to extend this handling change to them. 

I don't expect this PR to go through as it stands, as I would like to know if it is a sound change from those who know the language better and what other scopes it might apply to.

I'm mainly submitting this PR at the moment for visibility, feedback, and to highlight the issue.
