### PR TITLE
CI: trigger CI when build.zig.zon changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,10 +5,12 @@ on:
     paths:
       - ".github/workflows/main.yml"
       - "**.zig"
+      - "build.zig.zon"
   pull_request:
     paths:
       - ".github/workflows/main.yml"
       - "**.zig"
+      - "build.zig.zon"
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:


### PR DESCRIPTION
Just noticed in https://github.com/zigtools/zls/pull/1333 that the CI doesn't run when the only change is build.zig.zon.