### PR TITLE
Simplify resolved types of primitive values

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -1117,9 +1117,7 @@ pub fn generalReferencesHandler(server: *Server, arena: std.mem.Allocator, reque
         .field_access => |loc| z: {
             const held_loc = offsets.locMerge(loc, name_loc);
             const a = try analyser.getSymbolFieldAccesses(arena, handle, source_index, held_loc, name);
-            if (a) |b| {
-                if (b.len != 0) break :z b[0];
-            }
+            if (a.declarations.len != 0) break :z a.declarations[0];
 
             break :z null;
         },

--- a/src/analyser/primitive.zig
+++ b/src/analyser/primitive.zig
@@ -1,0 +1,193 @@
+const std = @import("std");
+
+pub const PrimitiveType = union(enum) {
+    uint: u16,
+    int: u16,
+    null,
+    undefined,
+    isize,
+    usize,
+    c_short,
+    c_ushort,
+    c_int,
+    c_uint,
+    c_long,
+    c_ulong,
+    c_longlong,
+    c_ulonglong,
+    c_longdouble,
+    anyopaque,
+    f16,
+    f32,
+    f64,
+    f80,
+    f128,
+    bool,
+    void,
+    noreturn,
+    type,
+    anyerror,
+    comptime_int,
+    comptime_float,
+    @"anyframe",
+    @"anytype",
+    c_char,
+
+    pub fn fromValueIdent(text: []const u8) ?PrimitiveType {
+        const map = std.ComptimeStringMap(PrimitiveType, .{
+            .{ "true", .bool },
+            .{ "false", .bool },
+            .{ "null", .null },
+            .{ "undefined", .undefined },
+        });
+
+        return map.get(text);
+    }
+
+    pub fn fromTypeIdent(text: []const u8) ?PrimitiveType {
+        const map = std.ComptimeStringMap(PrimitiveType, .{
+            .{ "isize", .isize },               .{ "usize", .usize },
+            .{ "c_short", .c_short },           .{ "c_ushort", .c_ushort },
+            .{ "c_int", .c_int },               .{ "c_uint", .c_uint },
+            .{ "c_long", .c_long },             .{ "c_ulong", .c_ulong },
+            .{ "c_longlong", .c_longlong },     .{ "c_ulonglong", .c_ulonglong },
+            .{ "c_longdouble", .c_longdouble }, .{ "anyopaque", .anyopaque },
+            .{ "f16", .f16 },                   .{ "f32", .f32 },
+            .{ "f64", .f64 },                   .{ "f80", .f80 },
+            .{ "f128", .f128 },                 .{ "bool", .bool },
+            .{ "void", .void },                 .{ "noreturn", .noreturn },
+            .{ "type", .type },                 .{ "anyerror", .anyerror },
+            .{ "comptime_int", .comptime_int }, .{ "comptime_float", .comptime_float },
+            .{ "anyframe", .@"anyframe" },      .{ "anytype", .@"anytype" },
+            .{ "c_char", .c_char },
+        });
+
+        if (map.get(text)) |t| return t;
+        if (text.len == 1) return null;
+        for (text[1..]) |c|
+            if (!std.ascii.isDigit(c)) return null;
+        const size = std.fmt.parseUnsigned(u16, text[1..], 10) catch return null;
+        return switch (text[0]) {
+            'u' => .{ .uint = size },
+            'i' => .{ .int = size },
+            else => null,
+        };
+    }
+
+    pub fn toString(self: PrimitiveType, allocator: std.mem.Allocator) ![]const u8 {
+        return switch (self) {
+            .uint => |size| try std.fmt.allocPrint(allocator, "u{d}", .{size}),
+            .int => |size| try std.fmt.allocPrint(allocator, "i{d}", .{size}),
+            .null => "@TypeOf(null)",
+            .undefined => "@TypeOf(undefined)",
+            .isize,
+            .usize,
+            .c_short,
+            .c_ushort,
+            .c_int,
+            .c_uint,
+            .c_long,
+            .c_ulong,
+            .c_longlong,
+            .c_ulonglong,
+            .c_longdouble,
+            .anyopaque,
+            .f16,
+            .f32,
+            .f64,
+            .f80,
+            .f128,
+            .bool,
+            .void,
+            .noreturn,
+            .type,
+            .anyerror,
+            .comptime_int,
+            .comptime_float,
+            .@"anyframe",
+            .@"anytype",
+            .c_char,
+            => @tagName(self),
+        };
+    }
+
+    pub fn hash(self: PrimitiveType, hasher: *std.hash.Wyhash) void {
+        hasher.update(&.{@intFromEnum(self)});
+
+        switch (self) {
+            .uint, .int => |size| hasher.update(&std.mem.toBytes(size)),
+            .null,
+            .undefined,
+            .isize,
+            .usize,
+            .c_short,
+            .c_ushort,
+            .c_int,
+            .c_uint,
+            .c_long,
+            .c_ulong,
+            .c_longlong,
+            .c_ulonglong,
+            .c_longdouble,
+            .anyopaque,
+            .f16,
+            .f32,
+            .f64,
+            .f80,
+            .f128,
+            .bool,
+            .void,
+            .noreturn,
+            .type,
+            .anyerror,
+            .comptime_int,
+            .comptime_float,
+            .@"anyframe",
+            .@"anytype",
+            .c_char,
+            => {},
+        }
+    }
+
+    pub fn eql(a: PrimitiveType, b: PrimitiveType) bool {
+        if (@intFromEnum(a) != @intFromEnum(b)) return false;
+
+        switch (a) {
+            inline .uint, .int => |size, tag| {
+                if (size != @field(b, @tagName(tag))) return false;
+            },
+            .null,
+            .undefined,
+            .isize,
+            .usize,
+            .c_short,
+            .c_ushort,
+            .c_int,
+            .c_uint,
+            .c_long,
+            .c_ulong,
+            .c_longlong,
+            .c_ulonglong,
+            .c_longdouble,
+            .anyopaque,
+            .f16,
+            .f32,
+            .f64,
+            .f80,
+            .f128,
+            .bool,
+            .void,
+            .noreturn,
+            .type,
+            .anyerror,
+            .comptime_int,
+            .comptime_float,
+            .@"anyframe",
+            .@"anytype",
+            .c_char,
+            => {},
+        }
+
+        return true;
+    }
+};

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -2643,13 +2643,20 @@ pub const DeclWithHandle = struct {
                 })) orelse return null,
                 pay.side,
             ),
-            .array_payload => |pay| try analyser.resolveBracketAccessType(
-                (try analyser.resolveTypeOfNodeInternal(.{
-                    .node = pay.array_expr,
-                    .handle = self.handle,
-                })) orelse return null,
-                .Single,
-            ),
+            .array_payload => |pay| {
+                if (node_tags[pay.array_expr] == .for_range) {
+                    return TypeWithHandle{
+                        .type = .{ .data = .{ .primitive = .usize }, .is_type_val = false },
+                    };
+                }
+                return try analyser.resolveBracketAccessType(
+                    (try analyser.resolveTypeOfNodeInternal(.{
+                        .node = pay.array_expr,
+                        .handle = self.handle,
+                    })) orelse return null,
+                    .Single,
+                );
+            },
             .label_decl => |decl| try analyser.resolveTypeOfNodeInternal(.{
                 .node = decl.block,
                 .handle = self.handle,

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -2654,6 +2654,8 @@ pub const DeclWithHandle = struct {
                     .node = pay.switch_expr,
                     .handle = self.handle,
                 })) orelse return null;
+                if (switch_expr_type.isEnumType())
+                    return switch_expr_type;
                 if (!switch_expr_type.isUnionType())
                     return null;
 

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -1535,9 +1535,9 @@ pub const Type = struct {
         /// - Container type: `struct {}`, `enum {}`, `union {}`, `opaque {}`, `error {}`
         /// - Pointer type: `*Foo`, `[]Foo`, `?Foo`
         /// - Error type: `Foo || Bar`, `Foo!Bar`
-        /// - Function: `fn () Foo`, `fn foo() Foo`
-        /// - Literal: `"foo"`, `'x'`, `42`, `.foo`, `error.Foo`
-        /// - Primitive value: `true`, `false`, `null`, `undefined`
+        /// - Function type: `fn () Foo`
+        /// - Function: `fn foo() Foo`
+        /// - Literal: `"foo"`, `.foo`, `error.Foo`
         other: NodeWithHandle,
 
         /// Primitive type: `u8`, `bool`, `type`, etc.

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -989,6 +989,13 @@ fn resolveTypeOfNodeUncached(analyser: *Analyser, node_handle: NodeWithHandle) e
             const value = .{ .node = var_decl.ast.init_node, .handle = handle };
             return try analyser.resolveTypeOfNodeInternal(value);
         },
+        .@"continue",
+        .@"break",
+        .@"return",
+        .unreachable_literal,
+        => return TypeWithHandle{
+            .type = .{ .data = .{ .primitive = .noreturn }, .is_type_val = false },
+        },
         .identifier => {
             const name = offsets.nodeToSlice(tree, node);
 

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -1573,7 +1573,10 @@ pub const TypeWithHandle = struct {
                 .error_union,
                 .union_tag,
                 => |t| hashTypeWithHandle(hasher, t.*),
-                .other => |idx| hasher.update(&std.mem.toBytes(idx)),
+                .other => |n| {
+                    hasher.update(n.handle.uri);
+                    hasher.update(&std.mem.toBytes(n.node));
+                },
                 .primitive => |p| p.hash(hasher),
                 .either => |entries| {
                     for (entries) |e| {

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -1575,9 +1575,6 @@ pub const Type = struct {
         /// Branching types
         either: []const EitherEntry,
 
-        // TODO: Unused?
-        array_index,
-
         @"comptime": struct {
             interpreter: *ComptimeInterpreter,
             value: ComptimeInterpreter.Value,
@@ -1613,7 +1610,6 @@ pub const TypeWithHandle = struct {
                         hashTypeWithHandle(hasher, e.type_with_handle);
                     }
                 },
-                .array_index => {},
                 .@"comptime" => {
                     // TODO
                 },
@@ -1664,7 +1660,6 @@ pub const TypeWithHandle = struct {
                         if (!self.eql(ae.type_with_handle, be.type_with_handle)) return false;
                     }
                 },
-                .array_index => {},
                 .@"comptime" => {
                     // TODO
                 },
@@ -1711,7 +1706,7 @@ pub const TypeWithHandle = struct {
         };
     }
 
-    /// Resolves possible types of a type (single for all except array_index and either)
+    /// Resolves possible types of a type (single for all except either)
     /// Drops duplicates
     pub fn getAllTypesWithHandles(ty: TypeWithHandle, arena: std.mem.Allocator) ![]const TypeWithHandle {
         var all_types = std.ArrayListUnmanaged(TypeWithHandle){};
@@ -2478,7 +2473,6 @@ pub const Declaration = union(enum) {
         identifier: Ast.TokenIndex,
         array_expr: Ast.Node.Index,
     },
-    array_index: Ast.TokenIndex,
     switch_payload: struct {
         node: Ast.TokenIndex,
         switch_expr: Ast.Node.Index,
@@ -2537,7 +2531,6 @@ pub const DeclWithHandle = struct {
             .pointer_payload => |pp| pp.name,
             .error_union_payload => |ep| ep.name,
             .array_payload => |ap| ap.identifier,
-            .array_index => |ai| ai,
             .switch_payload => |sp| sp.node,
             .label_decl => |ld| ld.label,
             .error_token => |et| et,
@@ -2692,10 +2685,6 @@ pub const DeclWithHandle = struct {
                 })) orelse return null,
                 .Single,
             ),
-            .array_index => TypeWithHandle{
-                .type = .{ .data = .array_index, .is_type_val = false },
-                .handle = self.handle,
-            },
             .label_decl => |decl| try analyser.resolveTypeOfNodeInternal(.{
                 .node = decl.block,
                 .handle = self.handle,

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -1040,9 +1040,9 @@ fn resolveTypeOfNodeUncached(analyser: *Analyser, node_handle: NodeWithHandle) e
                 };
             }
 
-            if (isValueIdent(name)) {
+            if (primitive_types.get(name)) |type_name| {
                 return TypeWithHandle{
-                    .type = .{ .data = .{ .other = node_handle }, .is_type_val = false },
+                    .type = .{ .data = .{ .primitive = type_name }, .is_type_val = false },
                 };
             }
 
@@ -4420,11 +4420,6 @@ fn addReferencedTypes(
                 .error_value => {
                     const identifier = tree.tokenSlice(datas[node].rhs);
                     return try std.fmt.allocPrint(allocator, "error{{{s}}}", .{identifier});
-                },
-
-                .identifier => {
-                    const name = offsets.nodeToSlice(tree, node);
-                    return primitive_types.get(name);
                 },
 
                 else => {}, // TODO: Implement more "other" type expressions; better safe than sorry

--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -974,8 +974,8 @@ fn resolveContainer(
             const name_loc = Analyser.identifierLocFromPosition(loc.end, handle) orelse break :fa;
             const name = offsets.locToSlice(handle.text, name_loc);
             const held_loc = offsets.locMerge(loc, name_loc);
-            const decls = try analyser.getSymbolFieldAccesses(arena, handle, loc.end, held_loc, name) orelse break :fa;
-            for (decls) |decl| {
+            const accesses = try analyser.getSymbolFieldAccesses(arena, handle, loc.end, held_loc, name);
+            for (accesses.declarations) |decl| {
                 const decl_node = switch (decl.decl.*) {
                     .ast_node => |ast_node| ast_node,
                     else => continue,

--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -443,7 +443,6 @@ fn declToCompletion(context: DeclToCompletionContext, decl_handle: Analyser.Decl
         .pointer_payload,
         .error_union_payload,
         .array_payload,
-        .array_index,
         .switch_payload,
         .label_decl,
         => {

--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -444,6 +444,7 @@ fn declToCompletion(context: DeclToCompletionContext, decl_handle: Analyser.Decl
         .error_union_payload,
         .array_payload,
         .switch_payload,
+        .switch_tag_payload,
         .label_decl,
         => {
             const name = tree.tokenSlice(decl_handle.nameToken());

--- a/src/features/goto.zig
+++ b/src/features/goto.zig
@@ -135,10 +135,10 @@ pub fn gotoDefinitionFieldAccess(
     const name_loc = Analyser.identifierLocFromPosition(source_index, handle) orelse return null;
     const name = offsets.locToSlice(handle.text, name_loc);
     const held_loc = offsets.locMerge(loc, name_loc);
-    const accesses = (try analyser.getSymbolFieldAccesses(arena, handle, source_index, held_loc, name)) orelse return null;
+    const accesses = (try analyser.getSymbolFieldAccesses(arena, handle, source_index, held_loc, name));
     var locs = std.ArrayListUnmanaged(types.DefinitionLink){};
 
-    for (accesses) |access| {
+    for (accesses.declarations) |access| {
         if (try gotoDefinitionSymbol(analyser, offsets.locToRange(handle.text, name_loc, offset_encoding), access, resolve_alias, offset_encoding)) |l|
             try locs.append(arena, l);
     }

--- a/src/features/hover.zig
+++ b/src/features/hover.zig
@@ -106,6 +106,7 @@ pub fn hoverSymbol(
         .error_union_payload,
         .array_payload,
         .switch_payload,
+        .switch_tag_payload,
         .label_decl,
         .error_token,
         => tree.tokenSlice(decl_handle.nameToken()),

--- a/src/features/hover.zig
+++ b/src/features/hover.zig
@@ -86,7 +86,6 @@ pub fn hoverSymbol(
         .pointer_payload,
         .error_union_payload,
         .array_payload,
-        .array_index,
         .switch_payload,
         .label_decl,
         .error_token,

--- a/src/features/references.zig
+++ b/src/features/references.zig
@@ -215,7 +215,6 @@ pub fn symbolReferences(
         .error_union_payload,
         .switch_payload,
         .array_payload,
-        .array_index,
         => {
             try builder.collectReferences(curr_handle, 0);
 

--- a/src/features/references.zig
+++ b/src/features/references.zig
@@ -214,6 +214,7 @@ pub fn symbolReferences(
         .pointer_payload,
         .error_union_payload,
         .switch_payload,
+        .switch_tag_payload,
         .array_payload,
         => {
             try builder.collectReferences(curr_handle, 0);

--- a/src/features/semantic_tokens.zig
+++ b/src/features/semantic_tokens.zig
@@ -599,7 +599,7 @@ fn writeNodeTokens(builder: *Builder, node: Ast.Node.Index) error{OutOfMemory}!v
                 field_token_type = if (try builder.analyser.resolveTypeOfNode(
                     .{ .node = struct_init.ast.type_expr, .handle = handle },
                 )) |struct_type| switch (struct_type.type.data) {
-                    .other => |n| fieldTokenType(n, struct_type.handle, false),
+                    .other => |n| fieldTokenType(n.node, n.handle, false),
                     else => null,
                 } else null;
             }
@@ -846,7 +846,7 @@ fn writeNodeTokens(builder: *Builder, node: Ast.Node.Index) error{OutOfMemory}!v
                     .ast_node => |decl_node| {
                         if (decl_type.handle.tree.nodes.items(.tag)[decl_node].isContainerField()) {
                             const tok_type = switch (lhs_type.type.data) {
-                                .other => |n| fieldTokenType(n, lhs_type.handle, lhs_type.type.is_type_val),
+                                .other => |n| fieldTokenType(n.node, n.handle, lhs_type.type.is_type_val),
                                 else => null,
                             };
 

--- a/src/features/semantic_tokens.zig
+++ b/src/features/semantic_tokens.zig
@@ -7,6 +7,7 @@ const DocumentStore = @import("../DocumentStore.zig");
 const Analyser = @import("../analysis.zig");
 const ast = @import("../ast.zig");
 const types = @import("../lsp.zig");
+const PrimitiveType = @import("../analyser/primitive.zig").PrimitiveType;
 
 pub const TokenType = enum(u32) {
     type,
@@ -389,9 +390,9 @@ fn writeNodeTokens(builder: *Builder, node: Ast.Node.Index) error{OutOfMemory}!v
 
             if (std.mem.eql(u8, name, "_")) {
                 return;
-            } else if (Analyser.isValueIdent(name)) {
+            } else if (PrimitiveType.fromValueIdent(name) != null) {
                 return try writeToken(builder, main_token, .keywordLiteral);
-            } else if (Analyser.isTypeIdent(name)) {
+            } else if (PrimitiveType.fromTypeIdent(name) != null) {
                 return try writeToken(builder, main_token, .type);
             }
 

--- a/src/features/signature_help.zig
+++ b/src/features/signature_help.zig
@@ -248,14 +248,14 @@ pub fn getSignatureInfo(analyser: *Analyser, arena: std.mem.Allocator, handle: *
                     };
 
                     var buf: [1]Ast.Node.Index = undefined;
-                    if (type_handle.handle.tree.fullFnProto(&buf, node)) |proto| {
+                    if (node.handle.tree.fullFnProto(&buf, node.node)) |proto| {
                         return try fnProtoToSignatureInfo(
                             analyser,
                             arena,
                             paren_commas,
                             false,
-                            type_handle.handle,
-                            node,
+                            node.handle,
+                            node.node,
                             proto,
                         );
                     }
@@ -271,35 +271,31 @@ pub fn getSignatureInfo(analyser: *Analyser, arena: std.mem.Allocator, handle: *
                         try symbol_stack.append(arena, .l_paren);
                         continue;
                     };
-                    var res_handle = decl_handle.handle;
                     node = switch (decl_handle.decl.*) {
-                        .ast_node => |n| n,
+                        .ast_node => |n| .{ .node = n, .handle = decl_handle.handle },
                         else => {
                             try symbol_stack.append(arena, .l_paren);
                             continue;
                         },
                     };
 
-                    if (try analyser.resolveVarDeclAlias(
-                        .{ .node = node, .handle = decl_handle.handle },
-                    )) |resolved| {
+                    if (try analyser.resolveVarDeclAlias(node)) |resolved| {
                         switch (resolved.decl.*) {
                             .ast_node => |n| {
-                                res_handle = resolved.handle;
-                                node = n;
+                                node = .{ .node = n, .handle = resolved.handle };
                             },
                             else => {},
                         }
                     }
 
-                    if (res_handle.tree.fullFnProto(&buf, node)) |proto| {
+                    if (node.handle.tree.fullFnProto(&buf, node.node)) |proto| {
                         return try fnProtoToSignatureInfo(
                             analyser,
                             arena,
                             paren_commas,
                             skip_self_param,
-                            res_handle,
-                            node,
+                            node.handle,
+                            node.node,
                             proto,
                         );
                     }

--- a/src/lsp.zig
+++ b/src/lsp.zig
@@ -90,9 +90,9 @@ pub fn UnionParser(comptime T: type) type {
             return error.UnexpectedToken;
         }
 
-        pub fn jsonStringify(self: T, options: std.json.StringifyOptions, out_stream: anytype) @TypeOf(out_stream).Error!void {
+        pub fn jsonStringify(self: T, stream: anytype) @TypeOf(stream.*).Error!void {
             switch (self) {
-                inline else => |value| try std.json.stringify(value, options, out_stream),
+                inline else => |value| try stream.write(value),
             }
         }
     };
@@ -122,16 +122,16 @@ pub fn EnumWithEmptyParser(comptime T: type) type {
             return std.meta.stringToEnum(T, source.string) orelse return error.InvalidEnumTag;
         }
 
-        pub fn jsonStringify(self: T, options: std.json.StringifyOptions, out_stream: anytype) @TypeOf(out_stream).Error!void {
-            try std.json.encodeJsonString(if (self == .empty) "" else @tagName(self), options, out_stream);
+        pub fn jsonStringify(self: T, stream: anytype) @TypeOf(stream.*).Error!void {
+            try stream.write(if (self == .empty) "" else @tagName(self));
         }
     };
 }
 
 pub fn EnumStringifyAsInt(comptime T: type) type {
     return struct {
-        pub fn jsonStringify(self: T, options: std.json.StringifyOptions, out_stream: anytype) @TypeOf(out_stream).Error!void {
-            try std.json.stringify(@intFromEnum(self), options, out_stream);
+        pub fn jsonStringify(self: T, stream: anytype) @TypeOf(stream.*).Error!void {
+            try stream.write(@intFromEnum(self));
         }
     };
 }


### PR DESCRIPTION
## Simplify resolved types of primitive values

Instead of storing a primitive value as `Type.data.other`, we can just directly map it to `Type.data.primitive`. This allows `true` and `false` to coerce into `bool`.

Partially addresses #1341

```zig
const a: u32 = 5;
const b: u32 = a + 5;
const c = if (b > 5) true else false; // bool
```

## Fix resolved types of number literals

```zig
const a = true;
const b = if (a) 1 else 2; // comptime_int
const c = if (a) 'a' else 'b'; // comptime_int
const d = if (a) 1.2 else 3.4; // comptime_float
```

Technically, these should be resolved by the comptime interpreter, but this works for now.

## Resolve type of enum in switch capture

```zig
const E = enum { a, b, c };
const e: E = .a;
const f = switch (e) {
    .a, .b => |foo| foo, // E
    .c => |bar| bar, // E
};
```

## Resolve type of continue/break/return/unreachable (noreturn)

```zig
const std = @import("std");
pub fn main() void {
    std.log.info("{}", .{@TypeOf(if (true) return else unreachable)});
    const x = if (true) return else unreachable; // noreturn
    _ = x;
}
```

## Add hover for `slice.len` and `slice.ptr`

<img width="279" alt="Screenshot 2023-07-23 at 5 55 21 AM" src="https://github.com/zigtools/zls/assets/70830482/fc02bfaa-7985-474f-95c7-b8066d6affca">

<img width="277" alt="Screenshot 2023-07-23 at 5 55 32 AM" src="https://github.com/zigtools/zls/assets/70830482/4bcf73a1-3141-4f1c-a8b3-ff0ad8a9c13b">

## Resolve type of index capture in `for` loop

<img width="589" alt="Screenshot 2023-07-23 at 6 12 33 AM" src="https://github.com/zigtools/zls/assets/70830482/08942e75-7642-4348-be65-98ce15008cd6">

## Resolve type of tag capture on `inline` prong of `switch`

```zig
const U = union(enum) { a: i32, b: i32, c: i32 };
const u: U = .{ .a = 42 };
const g = switch (u) {
    inline .a, .b => |_, foo| foo, // @typeInfo(U).Union.tag_type.?
    inline .c => |_, bar| bar, // @typeInfo(U).Union.tag_type.?
};
```