### PR TITLE
Fix snippet being added to parenthesised function completion

### DIFF
--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -1375,6 +1375,11 @@ pub fn completionAtIndex(server: *Server, analyser: *Analyser, arena: std.mem.Al
         const prefix = kindToSortScore(c.kind.?) orelse continue;
 
         c.sortText = try std.fmt.allocPrint(arena, "{s}{s}", .{ prefix, c.label });
+
+        if (source_index < handle.text.len and handle.text[source_index] == '(') {
+            c.insertText = c.label;
+            c.insertTextFormat = .PlainText;
+        }
     }
 
     return .{ .isIncomplete = false, .items = completions };


### PR DESCRIPTION
Hacky but here's the premise
Assume function `fn bruh(a: u8) void`, and `|` is the cursor.

```zig
// old behavior
br| -> bruh(a: u8)
br|( -> bruh(a: u8)(

// new behavior
br| -> bruh(a: u8)
br|( -> bruh(
```