### PR TITLE
fix single threaded build

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -1549,7 +1549,7 @@ pub fn loop(server: *Server) !void {
         while (server.job_queue.readItem()) |job| {
             if (zig_builtin.single_threaded) {
                 server.processJob(job, null);
-                return;
+                continue;
             }
 
             switch (job.syncMode()) {


### PR DESCRIPTION
How about we continue handling requests after the first one? I know, revolutionary!