### PR TITLE
Fix Go to Type Definition

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -1828,14 +1828,14 @@ pub const TypeWithHandle = struct {
         };
     }
 
-    pub fn definitionToken(self: TypeWithHandle) ?Ast.TokenIndex {
-        if (self.type.is_type_val) {
-            switch (self.type.data) {
-                .other => |n| return self.handle.tree.firstToken(n),
-                else => {},
-            }
-        }
-        return null;
+    pub fn typeDefinitionToken(self: TypeWithHandle) ?TokenWithHandle {
+        return switch (self.type.data) {
+            .other => |n| .{
+                .token = self.handle.tree.firstToken(n),
+                .handle = self.handle,
+            },
+            else => null,
+        };
     }
 
     pub fn docComments(self: TypeWithHandle, allocator: std.mem.Allocator) !?[]const u8 {
@@ -2555,8 +2555,10 @@ pub const DeclWithHandle = struct {
                 else => {},
             }
             if (try self.resolveType(analyser)) |resolved_type| {
-                if (resolved_type.definitionToken()) |token| {
-                    return .{ .token = token, .handle = resolved_type.handle };
+                if (resolved_type.type.is_type_val) {
+                    if (resolved_type.typeDefinitionToken()) |token| {
+                        return token;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Closes #913

> zls's implementation for `textDocument/typeDefinition` is currently the same as `textDocument/definition`. That's not quite right: instead of finding the definition of whatever is at a given position, zls should either find the definition of that thing's _type_, if that's possible, or fail if it's a type where that doesn't make sense.