### PR TITLE
Fuzzer fixes

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -1475,13 +1475,13 @@ fn resolveTypeOfNodeUncached(analyser: *Analyser, node_handle: NodeWithHandle) e
                 label_token: ?Ast.TokenIndex,
                 then_expr: Ast.Node.Index,
                 else_expr: Ast.Node.Index,
-            } = if (tree.fullWhile(node)) |while_node|
+            } = if (ast.fullWhile(tree, node)) |while_node|
                 .{
                     .label_token = while_node.label_token,
                     .then_expr = while_node.ast.then_expr,
                     .else_expr = while_node.ast.else_expr,
                 }
-            else if (tree.fullFor(node)) |for_node|
+            else if (ast.fullFor(tree, node)) |for_node|
                 .{
                     .label_token = for_node.label_token,
                     .then_expr = for_node.ast.then_expr,
@@ -3212,7 +3212,7 @@ pub fn resolveExpressionTypeFromAncestors(
                 .handle = handle,
             });
         }
-    } else if (tree.fullIf(ancestors[0])) |if_node| {
+    } else if (ast.fullIf(tree, ancestors[0])) |if_node| {
         if (node == if_node.ast.then_expr or node == if_node.ast.else_expr) {
             return try analyser.resolveExpressionType(
                 handle,
@@ -3220,7 +3220,7 @@ pub fn resolveExpressionTypeFromAncestors(
                 ancestors[1..],
             );
         }
-    } else if (tree.fullFor(ancestors[0])) |for_node| {
+    } else if (ast.fullFor(tree, ancestors[0])) |for_node| {
         if (node == for_node.ast.else_expr) {
             return try analyser.resolveExpressionType(
                 handle,
@@ -3228,7 +3228,7 @@ pub fn resolveExpressionTypeFromAncestors(
                 ancestors[1..],
             );
         }
-    } else if (tree.fullWhile(ancestors[0])) |while_node| {
+    } else if (ast.fullWhile(tree, ancestors[0])) |while_node| {
         if (node == while_node.ast.else_expr) {
             return try analyser.resolveExpressionType(
                 handle,
@@ -3336,11 +3336,11 @@ pub fn resolveExpressionTypeFromAncestors(
                 null;
 
             const index = blk: for (1..ancestors.len) |index| {
-                if (tree.fullFor(ancestors[index])) |for_node| {
+                if (ast.fullFor(tree, ancestors[index])) |for_node| {
                     const break_label = break_label_maybe orelse break :blk index;
                     const for_label = tree.tokenSlice(for_node.label_token orelse continue);
                     if (std.mem.eql(u8, break_label, for_label)) break :blk index;
-                } else if (tree.fullWhile(ancestors[index])) |while_node| {
+                } else if (ast.fullWhile(tree, ancestors[index])) |while_node| {
                     const break_label = break_label_maybe orelse break :blk index;
                     const while_label = tree.tokenSlice(while_node.label_token orelse continue);
                     if (std.mem.eql(u8, break_label, while_label)) break :blk index;
@@ -4374,7 +4374,7 @@ fn addReferencedTypes(
             .ptr_type_bit_range,
             .ptr_type_sentinel,
             => {
-                const ptr_type = tree.fullPtrType(p).?;
+                const ptr_type = ast.fullPtrType(tree, p).?;
 
                 const child_type_str = try analyser.addReferencedTypesFromNode(
                     .{ .node = ptr_type.ast.child_type, .handle = handle },

--- a/src/ast.zig
+++ b/src/ast.zig
@@ -993,7 +993,7 @@ pub fn paramFirstToken(tree: Ast, param: Ast.full.FnProto.Param) Ast.TokenIndex 
 }
 
 pub fn paramLastToken(tree: Ast, param: Ast.full.FnProto.Param) Ast.TokenIndex {
-    return param.anytype_ellipsis3 orelse tree.lastToken(param.type_expr);
+    return param.anytype_ellipsis3 orelse lastToken(tree, param.type_expr);
 }
 
 pub fn paramSlice(tree: Ast, param: Ast.full.FnProto.Param) []const u8 {
@@ -1106,6 +1106,7 @@ pub fn nextFnParam(it: *Ast.full.FnProto.Iterator) ?Ast.full.FnProto.Param {
                 return null;
             }
             const param_type = it.fn_proto.ast.params[it.param_i];
+            const last_param_type_token = lastToken(it.tree.*, param_type);
             var tok_i = it.tree.firstToken(param_type) - 1;
             while (true) : (tok_i -= 1) switch (token_tags[tok_i]) {
                 .colon => continue,
@@ -1115,11 +1116,11 @@ pub fn nextFnParam(it: *Ast.full.FnProto.Iterator) ?Ast.full.FnProto.Param {
                 else => break,
             };
             it.param_i += 1;
-            it.tok_i = it.tree.lastToken(param_type) + 1;
+            it.tok_i = last_param_type_token + 1;
 
             // #boundsCheck
             // https://github.com/zigtools/zls/issues/567
-            if (it.tree.lastToken(param_type) >= it.tree.tokens.len - 1)
+            if (last_param_type_token >= it.tree.tokens.len - 1)
                 return Ast.full.FnProto.Param{
                     .first_doc_comment = first_doc_comment,
                     .comptime_noalias = comptime_noalias,

--- a/src/ast.zig
+++ b/src/ast.zig
@@ -982,6 +982,7 @@ pub fn lastToken(tree: Ast, node: Ast.Node.Index) Ast.TokenIndex {
 
 pub fn hasInferredError(tree: Ast, fn_proto: Ast.full.FnProto) bool {
     const token_tags = tree.tokens.items(.tag);
+    if (fn_proto.ast.return_type == 0) return false;
     return token_tags[tree.firstToken(fn_proto.ast.return_type) - 1] == .bang;
 }
 

--- a/src/features/inlay_hints.zig
+++ b/src/features/inlay_hints.zig
@@ -139,7 +139,7 @@ fn writeCallHint(builder: *Builder, call: Ast.full.Call, decl_handle: Analyser.D
         const name = decl_tree.tokenSlice(name_token);
 
         if (builder.config.inlay_hints_hide_redundant_param_names or builder.config.inlay_hints_hide_redundant_param_names_last_token) {
-            const last_arg_token = tree.lastToken(arg);
+            const last_arg_token = ast.lastToken(tree, arg);
             const arg_name = tree.tokenSlice(last_arg_token);
 
             if (std.mem.eql(u8, arg_name, name)) {

--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -44,6 +44,15 @@ test "completion - root scope" {
     });
 }
 
+test "completion - root scope with self referential decl" {
+    try testCompletion(
+        \\const foo = foo;
+        \\const bar = <cursor>
+    , &.{
+        .{ .label = "foo", .kind = .Constant },
+    });
+}
+
 test "completion - local scope" {
     if (true) return error.SkipZigTest;
     try testCompletion(


### PR DESCRIPTION
Case 1:
will fixed by https://github.com/ziglang/zig/pull/16584
```zig
for (foo) |_| foo
```
Case 2:
fixed by bc92b46036730c2a7bb8ee6262b9527b0f01c996
@FnControlOption [ast.zig](https://github.com/zigtools/zls/blob/master/src/ast.zig) has custom versions of some functions you would find for `std.zig.Ast` like `ast.fullPtrType()`, `ast.fullIf()`, `ast.lastToken()`. You should (almost) always use them instead of the standard ones because they don't crash on invalid ast.
```zig
for (regs_lock) |reg| a. .lhs = d), }
```
Case 3:
fixed by bf8df351d407dc6dccc05263bf03dddf04789bd5
crash when hovering over `baz`
```zig
.{ extern fn baz(); }
```
Case 4:
fixed by d140da01512d6b02f7594975e73b6d8f423ddf90
```zig
const foo = foo;
const bar = <ask for completions here>
```