### PR TITLE
workflow: specify `-Dcpu=baseline` when building artifacts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Build with Tracy
         if: ${{ matrix.os != 'macos-latest' && github.event.inputs.bypass_tracy_and_artifacts != 'true' }}
-        run: zig build -Denable_tracy -Denable_tracy_allocation
+        run: zig build -Denable_tracy
 
       - name: Run Tests
         run: zig build test
@@ -59,10 +59,10 @@ jobs:
             echo "Building target ${target}..."
             if [ "${GITHUB_REF##*/}" == "master" ]; then
               echo "Building safe"
-              zig build -Dtarget=${target} -Doptimize=ReleaseSafe --prefix artifacts/${target}/
+              zig build -Dtarget=${target} -Dcpu=baseline -Doptimize=ReleaseSafe --prefix artifacts/${target}/
             else
               echo "Building debug as action is not running on master"
-              zig build -Dtarget=${target} --prefix artifacts/${target}/
+              zig build -Dtarget=${target} -Dcpu=baseline --prefix artifacts/${target}/
             fi
             sed -e '1,5d' < README.md > artifacts/${target}/README.md
             cp LICENSE artifacts/${target}/


### PR DESCRIPTION
just in case someone is running on very old hardware.
I've also removed `-Denable_tracy_allocation` because `-Denable_tracy` already enables that