### PR TITLE
Revert "Search for r_brace at the AST level, not the source code level."

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -3894,7 +3894,13 @@ fn makeScopeAt(
         => {
             const first_token = tree.firstToken(node_idx);
             const last_token = ast.lastToken(tree, node_idx);
-            const end_index = offsets.tokenToLoc(tree, last_token).end;
+
+            // the last token may not always be the closing brace because of broken ast
+            // so we look at most 16 characters ahead to find the closing brace
+            // TODO this should automatically be done by `ast.lastToken`
+            var end_index = offsets.tokenToLoc(tree, last_token).start;
+            const lookahead_buffer = tree.source[end_index..@min(tree.source.len, end_index + 16)];
+            end_index += std.mem.indexOfScalar(u8, lookahead_buffer, '}') orelse 0;
 
             const scope_index = try context.pushScope(
                 .{

--- a/src/ast.zig
+++ b/src/ast.zig
@@ -6,7 +6,6 @@ const std = @import("std");
 const offsets = @import("offsets.zig");
 const Ast = std.zig.Ast;
 const Node = Ast.Node;
-const TokenTag = std.zig.Token.Tag;
 const full = Ast.full;
 
 fn fullPtrTypeComponents(tree: Ast, info: full.PtrType.Components) full.PtrType {
@@ -53,32 +52,6 @@ fn fullPtrTypeComponents(tree: Ast, info: full.PtrType.Components) full.PtrType 
         }
     }
     return result;
-}
-
-/// Given an l_brace, find the corresponding r_brace.
-/// If no corresponding r_brace is found, return null.
-/// Useful for finding the extent of a block/scope if the syntax is valid.
-fn findMatchingRBrace(token_tags: []const TokenTag, l_brace: Ast.TokenIndex) ?Ast.TokenIndex {
-    std.debug.assert(token_tags[l_brace] == TokenTag.l_brace);
-
-    const start = l_brace + 1;
-    var depth: i32 = 0;
-    var offset: Ast.TokenIndex = 0;
-
-    for (token_tags[start..], 0..) |tag, i| {
-        if (tag == TokenTag.l_brace) {
-            depth += 1;
-        }
-        if (tag == TokenTag.r_brace) {
-            if (depth == 0) {
-                offset = @intCast(i);
-                break;
-            }
-            depth -= 1;
-        }
-    }
-
-    return if (depth == 0) start + offset else null;
 }
 
 pub fn ptrTypeSimple(tree: Ast, node: Node.Index) full.PtrType {
@@ -604,11 +577,27 @@ pub fn lastToken(tree: Ast, node: Ast.Node.Index) Ast.TokenIndex {
             }
             n = tree.extra_data[params.end - 1]; // last parameter
         },
-        .switch_comma, .@"switch" => {
-            const lhs = datas[n].lhs;
-            const l_brace = tree.lastToken(lhs) + 2; //lparen + rbrace
-            return findMatchingRBrace(token_tags, l_brace)
-                orelse @intCast(tree.tokens.len - 1);
+        .@"switch" => {
+            const cases = tree.extraData(datas[n].rhs, Node.SubRange);
+            if (cases.end - cases.start == 0) {
+                end_offset += 3; // rparen, lbrace, rbrace
+                n = datas[n].lhs; // condition expression
+            } else {
+                end_offset += 1; // for the rbrace
+                n = tree.extra_data[cases.end - 1]; // last case
+            }
+        },
+        .container_decl_arg,
+        .container_decl_arg_trailing,
+        => {
+            const members = tree.extraData(datas[n].rhs, Node.SubRange);
+            if (members.end - members.start == 0) {
+                end_offset += 3; // for the rparen + lbrace + rbrace
+                n = datas[n].lhs;
+            } else {
+                end_offset += 1; // for the rbrace
+                n = tree.extra_data[members.end - 1]; // last parameter
+            }
         },
         .@"asm" => {
             const extra = tree.extraData(datas[n].rhs, Node.Asm);
@@ -624,6 +613,7 @@ pub fn lastToken(tree: Ast, node: Ast.Node.Index) Ast.TokenIndex {
         },
         .array_init_comma,
         .struct_init_comma,
+        .switch_comma,
         => {
             if (datas[n].rhs != 0) {
                 const members = tree.extraData(datas[n].rhs, Node.SubRange);
@@ -637,6 +627,7 @@ pub fn lastToken(tree: Ast, node: Ast.Node.Index) Ast.TokenIndex {
         },
         .array_init_dot,
         .struct_init_dot,
+        .block,
         .container_decl,
         .tagged_union,
         .builtin_call,
@@ -647,6 +638,8 @@ pub fn lastToken(tree: Ast, node: Ast.Node.Index) Ast.TokenIndex {
         },
         .array_init_dot_comma,
         .struct_init_dot_comma,
+        .block_semicolon,
+        .container_decl_trailing,
         .tagged_union_trailing,
         .builtin_call_comma,
         => {
@@ -664,32 +657,11 @@ pub fn lastToken(tree: Ast, node: Ast.Node.Index) Ast.TokenIndex {
             }
             n = datas[n].rhs;
         },
-        .block,
-        .block_semicolon,
-        .block_two_semicolon,
-        .block_two,
-        => {
-            return findMatchingRBrace(token_tags, main_tokens[n])
-                orelse @intCast(tree.tokens.len - 1);
-        },
-        .container_decl_trailing,
-        .container_decl_two_trailing,
-        .container_decl_two,
-        => {
-            // + 1 for the lbrace
-            return findMatchingRBrace(token_tags, main_tokens[n] + 1)
-                orelse @intCast(tree.tokens.len - 1);
-        },
-        .container_decl_arg,
-        .container_decl_arg_trailing,
-        => {
-            // + 4 for the lparen, identifier, rparen, lbrace
-            return findMatchingRBrace(token_tags, main_tokens[n] + 4)
-                orelse @intCast(tree.tokens.len - 1);
-        },
         .array_init_dot_two,
+        .block_two,
         .builtin_call_two,
         .struct_init_dot_two,
+        .container_decl_two,
         .tagged_union_two,
         => {
             if (datas[n].rhs != 0) {
@@ -701,9 +673,15 @@ pub fn lastToken(tree: Ast, node: Ast.Node.Index) Ast.TokenIndex {
             } else {
                 switch (tags[n]) {
                     .array_init_dot_two,
+                    .block_two,
                     .struct_init_dot_two,
                     => end_offset += 1, // rbrace
                     .builtin_call_two => end_offset += 2, // lparen/lbrace + rparen/rbrace
+                    .container_decl_two => {
+                        var i: u32 = 2; // lbrace + rbrace
+                        while (token_tags[main_tokens[n] + i] == .container_doc_comment) i += 1;
+                        end_offset += i;
+                    },
                     .tagged_union_two => {
                         var i: u32 = 5; // (enum) {}
                         while (token_tags[main_tokens[n] + i] == .container_doc_comment) i += 1;
@@ -716,7 +694,9 @@ pub fn lastToken(tree: Ast, node: Ast.Node.Index) Ast.TokenIndex {
         },
         .array_init_dot_two_comma,
         .builtin_call_two_comma,
+        .block_two_semicolon,
         .struct_init_dot_two_comma,
+        .container_decl_two_trailing,
         .tagged_union_two_trailing,
         => {
             end_offset += 2; // for the comma/semicolon + rbrace/rparen

--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -270,35 +270,37 @@ test "completion - captures" {
         .{ .label = "alpha", .kind = .Field, .detail = "alpha: u32" },
     });
 
-    try testCompletion(
-        \\const E = error{ X, Y };
-        \\const S = struct { alpha: u32 };
-        \\fn foo() E!S { return undefined; }
-        \\fn bar() void {
-        \\    if (foo()) |baz| {
-        \\        baz.<cursor>
-        \\    } else |err| {
-        \\        _ = err;
-        \\    }
-        \\}
-    , &.{
-        .{ .label = "alpha", .kind = .Field, .detail = "alpha: u32" },
-    });
+    // TODO fix error union capture with if-else
+    // try testCompletion(
+    //     \\const E = error{ X, Y };
+    //     \\const S = struct { alpha: u32 };
+    //     \\fn foo() E!S { return undefined; }
+    //     \\fn bar() void {
+    //     \\    if (foo()) |baz| {
+    //     \\        baz.<cursor>
+    //     \\    } else |err| {
+    //     \\        _ = err;
+    //     \\    }
+    //     \\}
+    // , &.{
+    //     .{ .label = "alpha", .kind = .Field, .detail = "alpha: u32" },
+    // });
 
-    try testCompletion(
-        \\const E = error{ X, Y };
-        \\const S = struct { alpha: u32 };
-        \\fn foo() E!S { return undefined; }
-        \\fn bar() void {
-        \\    while (foo()) |baz| {
-        \\        baz.<cursor>
-        \\    } else |err| {
-        \\        _ = err;
-        \\    }
-        \\}
-    , &.{
-        .{ .label = "alpha", .kind = .Field, .detail = "alpha: u32" },
-    });
+    // TODO fix error union capture with while loop
+    // try testCompletion(
+    //     \\const E = error{ X, Y };
+    //     \\const S = struct { alpha: u32 };
+    //     \\fn foo() E!S { return undefined; }
+    //     \\fn bar() void {
+    //     \\    while (foo()) |baz| {
+    //     \\        baz.<cursor>
+    //     \\    } else |err| {
+    //     \\        _ = err;
+    //     \\    }
+    //     \\}
+    // , &.{
+    //     .{ .label = "alpha", .kind = .Field, .detail = "alpha: u32" },
+    // });
 }
 
 test "completion - struct" {
@@ -324,31 +326,6 @@ test "completion - struct" {
     , &.{
         .{ .label = "alpha", .kind = .Field, .detail = "alpha: u32" },
         .{ .label = "beta", .kind = .Field, .detail = "beta: []const u8" },
-    });
-
-    try testCompletion(
-        \\fn doNothingWithInteger(a: u32) void { _ = a; }
-        \\const S = struct {
-        \\    alpha: u32,
-        \\    beta: []const u8,
-        \\    fn foo(self: S) void {
-        \\        doNothingWithInteger(self.<cursor>
-        \\    }
-        \\};
-    , &.{
-        .{ .label = "alpha", .kind = .Field, .detail = "alpha: u32" },
-        .{ .label = "beta", .kind = .Field, .detail = "beta: []const u8" },
-        .{ .label = "foo", .kind = .Function, .detail = "fn foo(self: S) void" },
-    });
-
-    try testCompletion(
-        \\const S = struct {
-        \\    const Mode = enum { alpha, beta, };
-        \\    fn foo(mode: <cursor>
-        \\};
-    , &.{
-        .{ .label = "S", .kind = .Constant, .detail = "const S = struct" },
-        .{ .label = "Mode", .kind = .Constant, .detail = "const Mode = enum" },
     });
 }
 

--- a/tests/lsp_features/folding_range.zig
+++ b/tests/lsp_features/folding_range.zig
@@ -167,7 +167,8 @@ test "foldingRange - container decl" {
         \\  beta: u16,
         \\};
     , &.{
-        .{ .startLine = 0, .startCharacter = 32, .endLine = 3, .endCharacter = 0 },
+        // .{ .startLine = 0, .startCharacter = 32, .endLine = 3, .endCharacter = 0 }, // TODO
+        .{ .startLine = 0, .startCharacter = 32, .endLine = 2, .endCharacter = 11 },
     });
     try testFoldingRange(
         \\const Foo = union {


### PR DESCRIPTION
fixes #1362
Here are two examples that would crash ZLS after this change:
```zig
enum {try foo(}, bar  }
```

```zig
const std = @import("std");
fn func() void {
    const foo = std.ChildProcess.init();
    const bar = foo.stderr.?.reader();
    _ = bar catch {};
}
```