### PR TITLE
fix use of uninitialised value

### DIFF
--- a/src/configuration.zig
+++ b/src/configuration.zig
@@ -29,7 +29,7 @@ pub fn loadFromFile(allocator: std.mem.Allocator, file_path: []const u8) ?Config
     @setEvalBranchQuota(10000);
 
     const parse_options = std.json.ParseOptions{ .ignore_unknown_fields = true };
-    var parse_diagnostics: std.json.Diagnostics = undefined;
+    var parse_diagnostics: std.json.Diagnostics = .{};
 
     var scanner = std.json.Scanner.initCompleteInput(allocator, file_buf);
     defer scanner.deinit();


### PR DESCRIPTION
valgrind was not happy about this:
```
==104380== Conditional jump or move depends on uninitialised value(s)
==104380==    at 0x4D394D: json.scanner.Scanner.skipWhitespace (scanner.zig:1632)
==104380==    by 0x4D39F8: json.scanner.Scanner.skipWhitespaceCheckEnd (scanner.zig:1650)
==104380==    by 0x51C2CB: json.scanner.Scanner.peekNextTokenType (scanner.zig:1455)
==104380==    by 0x4D21D6: json.scanner.Scanner.nextAllocMax (scanner.zig:493)
==104380==    by 0x4809C9: json.static.innerParse__anon_23441 (static.zig:331)
==104380==    by 0x4549FB: json.static.parseFromTokenSourceLeaky__anon_21058 (static.zig:140)
==104380==    by 0x422482: json.static.parseFromTokenSource__anon_19238 (static.zig:107)
==104380==    by 0x3DE1D9: legacy_json.parseFromTokenSource__anon_13837 (legacy_json.zig:26)
==104380==    by 0x3C701B: configuration.loadFromFile (configuration.zig:39)
==104380==    by 0x3C677E: main.getConfig (main.zig:132)
==104380==    by 0x3D8E3E: main.main (main.zig:349)
==104380==    by 0x3C4CEE: callMain (start.zig:615)
==104380==    by 0x3C4CEE: initEventLoopAndCallMain (start.zig:549)
==104380==    by 0x3C4CEE: callMainWithArgs (start.zig:499)
==104380==    by 0x3C4CEE: start.posixCallMainAndExit (start.zig:455)
```