### PR TITLE
explore duplicate packages in build runner

### DIFF
--- a/src/special/build_runner.zig
+++ b/src/special/build_runner.zig
@@ -245,7 +245,7 @@ fn processModules(
 
         const already_added = try packages.addPackage(name, path);
         // if the package has already been added short circuit here or recursive modules will ruin us
-        if (already_added) return;
+        if (already_added) continue;
 
         try processModules(builder, packages, mod.dependencies);
     }


### PR DESCRIPTION
This will make it easier to get stuck in cycles in the build runner. But in my defense, I think before It was still easily doable to create a build.zig that will loop.
fixes #1388