### PR TITLE
build_runner: handle more types of include dirs

### DIFF
--- a/src/special/build_runner.zig
+++ b/src/special/build_runner.zig
@@ -2,6 +2,7 @@ const root = @import("@build");
 const std = @import("std");
 const log = std.log;
 const process = std.process;
+const builtin = @import("builtin");
 
 pub const dependencies = @import("@dependencies");
 
@@ -72,6 +73,7 @@ pub fn main() !void {
     cache.addPrefix(build_root_directory);
     cache.addPrefix(local_cache_directory);
     cache.addPrefix(global_cache_directory);
+    cache.hash.addBytes(builtin.zig_version_string);
 
     const host = try std.zig.system.NativeTargetInfo.detect(.{});
 


### PR DESCRIPTION
Linked libraries can provide headers to the exe, so to acquire include paths for these headers we have to handle the `other_step` variant of `IncludeDir`.

The handling of `other_step` and `config_header_step` is copied from [here](https://github.com/ziglang/zig/blob/a190582b26a82f96da7488eff37e9676cdb937bc/lib/std/Build/Step/Compile.zig#L1797-L1813), however I have been unable to get the same paths as zig's build runner.

As shown in the below the path we get is "zig-cache/i/a15f9b5ad97b67eb661607f3b4ddfb6a/include" but zig outputs the headers to  "zig-cache/i/811dc2cb6c69e7e1fc596f13575652d5/include".

```
$ git clone --recurse-submodules https://github.com/ethernetsellout/hex.git
$ cd hex
$ zig build
$ zig build --build-runner ~/src/zls/src/special/build_runner.zig
{
 "packages": [
  {
   "name": "root",
   "path": "/home/lee/src/hex/src/main.zig"
  },
  {
   "name": "options",
   "path": "/home/lee/src/hex/zig-cache/c/c347fd218672a329f4a91f9818d34266/options.zig"
  }
 ],
 "include_dirs": [
  "/home/lee/.cache/zig/p/1220b465cb4815363ae29c36e55800240b9a02850574c1df6709fc0f1c97945a3947/src/external/glfw/include",
  "/usr/include",
  "/home/lee/src/hex/zig-cache/i/a15f9b5ad97b67eb661607f3b4ddfb6a/include"
 ]
}%
$ ls zig-cache/i/a15f9b5ad97b67eb661607f3b4ddfb6a/include
ls: cannot access 'zig-cache/i/a15f9b5ad97b67eb661607f3b4ddfb6a/include': No such file or directory
$ ls zig-cache/i/811dc2cb6c69e7e1fc596f13575652d5/include
raylib.h  raymath.h  rlgl.h
```

I suspect the cause is the `other.step.owner` that provides the `install_prefix` is a sub-`std.Build` and not the main one when zig executes this logic unlike when we do it.