### PR TITLE
config related fixes

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -460,7 +460,7 @@ fn initializeHandler(server: *Server, _: std.mem.Allocator, request: types.Initi
     log.info("{}", .{server.client_capabilities});
     log.info("offset encoding: {s}", .{@tagName(server.offset_encoding)});
 
-    server.updateConfiguration(.{}, false) catch |err| {
+    server.updateConfiguration(.{}) catch |err| {
         log.err("failed to load configuration: {}", .{err});
     };
 
@@ -710,7 +710,7 @@ fn handleConfiguration(server: *Server, json: std.json.Value) error{OutOfMemory}
         }
     }
 
-    server.updateConfiguration(new_config, false) catch |err| {
+    server.updateConfiguration(new_config) catch |err| {
         log.err("failed to update configuration: {}", .{err});
     };
 }
@@ -737,20 +737,20 @@ fn didChangeConfigurationHandler(server: *Server, arena: std.mem.Allocator, noti
         return error.ParseError;
     };
 
-    server.updateConfiguration(new_config, false) catch |err| {
+    server.updateConfiguration(new_config) catch |err| {
         log.err("failed to update configuration: {}", .{err});
     };
 }
 
-pub fn updateConfiguration2(server: *Server, new_config: Config, resolve: bool) !void {
+pub fn updateConfiguration2(server: *Server, new_config: Config) !void {
     var cfg: configuration.Configuration = .{};
     inline for (std.meta.fields(Config)) |field| {
         @field(cfg, field.name) = @field(new_config, field.name);
     }
-    try server.updateConfiguration(cfg, resolve);
+    try server.updateConfiguration(cfg);
 }
 
-pub fn updateConfiguration(server: *Server, new_config: configuration.Configuration, resolve: bool) !void {
+pub fn updateConfiguration(server: *Server, new_config: configuration.Configuration) !void {
     // NOTE every changed configuration will increase the amount of memory allocated by the arena
     // This is unlikely to cause any big issues since the user is probably not going set settings
     // often in one session
@@ -761,10 +761,9 @@ pub fn updateConfiguration(server: *Server, new_config: configuration.Configurat
     var new_cfg = new_config;
 
     try server.validateConfiguration(&new_cfg);
-    if (resolve) {
-        try server.resolveConfiguration(config_arena, &new_cfg);
-        try server.validateConfiguration(&new_cfg);
-    }
+    try server.resolveConfiguration(config_arena, &new_cfg);
+    try server.validateConfiguration(&new_cfg);
+
     // <---------------------------------------------------------->
     //                        apply changes
     // <---------------------------------------------------------->

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -758,7 +758,10 @@ pub fn updateConfiguration(server: *Server, new_config: configuration.Configurat
     defer server.config_arena = config_arena_allocator.state;
     const config_arena = config_arena_allocator.allocator();
 
-    var new_cfg = new_config;
+    var new_cfg: configuration.Configuration = .{};
+    inline for (std.meta.fields(Config)) |field| {
+        @field(new_cfg, field.name) = if (@field(new_config, field.name)) |new_value| new_value else @field(server.config, field.name);
+    }
 
     try server.validateConfiguration(&new_cfg);
     try server.resolveConfiguration(config_arena, &new_cfg);

--- a/src/configuration.zig
+++ b/src/configuration.zig
@@ -141,7 +141,7 @@ pub fn getZigEnv(allocator: std.mem.Allocator, zig_exe_path: []const u8) ?std.js
         else => logger.err("zig env invocation failed", .{}),
     }
 
-    var parsed = std.json.parseFromSlice(
+    return std.json.parseFromSlice(
         Env,
         allocator,
         zig_env_result.stdout,
@@ -150,12 +150,6 @@ pub fn getZigEnv(allocator: std.mem.Allocator, zig_exe_path: []const u8) ?std.js
         logger.err("Failed to parse zig env JSON result", .{});
         return null;
     };
-    if (parsed.value.lib_dir) |d| {
-        parsed.value.lib_dir = std.fs.realpathAlloc(parsed.arena.allocator(), d) catch d;
-    }
-    parsed.value.std_dir = std.fs.realpathAlloc(parsed.arena.allocator(), parsed.value.std_dir) catch parsed.value.std_dir;
-
-    return parsed;
 }
 
 /// the same struct as Config but every field is optional

--- a/src/main.zig
+++ b/src/main.zig
@@ -317,7 +317,7 @@ pub fn main() !void {
 
     const server = try Server.create(allocator);
     defer server.destroy();
-    try server.updateConfiguration2(config.config, true);
+    try server.updateConfiguration2(config.config);
     server.recording_enabled = record_file != null;
     server.replay_enabled = replay_file != null;
     server.transport = &transport;

--- a/tests/context.zig
+++ b/tests/context.zig
@@ -34,7 +34,7 @@ pub const Context = struct {
         const server = try Server.create(allocator);
         errdefer server.destroy();
 
-        try server.updateConfiguration2(default_config, true);
+        try server.updateConfiguration2(default_config);
 
         var context: Context = .{
             .server = server,


### PR DESCRIPTION
reverted b47781897acca54b3fffbe052c6daf3ab08fe8b0 because realpath should be avoided.
reverted eb00a8ab15c40ac11b75da3c24886cdcd4680346 because config options still need to happen after startup because as an example you may not have zig set in path