### PR TITLE
nix: add missing dependency on zig language reference file

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -105,13 +105,25 @@
         "url": "https://github.com/ziglibs/known-folders/archive/fa75e1bc672952efa0cf06160bbd942b47f6d59b.tar.gz"
       }
     },
+    "langref": {
+      "flake": false,
+      "locked": {
+        "narHash": "sha256-UDwr6vJynfpD5SEoZzhXouoKu+Okdtpv20Vx2E5Ltcc=",
+        "type": "file",
+        "url": "https://raw.githubusercontent.com/ziglang/zig/f1992a39a59b941f397b8501a525b38e5863a527/doc/langref.html.in"
+      },
+      "original": {
+        "type": "file",
+        "url": "https://raw.githubusercontent.com/ziglang/zig/f1992a39a59b941f397b8501a525b38e5863a527/doc/langref.html.in"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1691155369,
-        "narHash": "sha256-CIuJO5pgwCMsZM8flIU2OiZ79QfDCesXPsAiokCzlNM=",
+        "lastModified": 1692221125,
+        "narHash": "sha256-nKUDlbLL8/WW3Fpx9Y0sY+LliTqU3/GexvHU9BdA8Qk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7d050b98e51cdbdd88ad960152d398d41c7ff5b4",
+        "rev": "214c9de8159b25f3cdc8374a80794d4d5787b4cf",
         "type": "github"
       },
       "original": {
@@ -128,6 +140,7 @@
         "flake-utils": "flake-utils",
         "gitignore": "gitignore",
         "known_folders": "known_folders",
+        "langref": "langref",
         "nixpkgs": "nixpkgs",
         "zig-overlay": "zig-overlay"
       }
@@ -156,11 +169,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1691195023,
-        "narHash": "sha256-Ud0wU0LospRfKgpfggFSmKVH0Vywww1WozsvQNEUhjo=",
+        "lastModified": 1692231604,
+        "narHash": "sha256-J7fxnC6FbGCthYRH7Ec8LbuUt8meWURelw1Rx0sqdOI=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "5b4dec84f870c21f8110f18640f8d4da87e99210",
+        "rev": "5b15c13b046a9c2f5dae58f9051ba17b513c49fb",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,9 @@
 
       flake-utils.url = "github:numtide/flake-utils";
 
+      langref.url = "https://raw.githubusercontent.com/ziglang/zig/f1992a39a59b941f397b8501a525b38e5863a527/doc/langref.html.in";
+      langref.flake = false;
+
       binned_allocator.url = "https://gist.github.com/antlilja/8372900fcc09e38d7b0b6bbaddad3904/archive/6c3321e0969ff2463f8335da5601986cf2108690.tar.gz";
       binned_allocator.flake = false;
 
@@ -57,11 +60,12 @@
           nativeBuildInputs = [ zig ];
           dontConfigure = true;
           dontInstall = true;
+          langref = inputs.langref;
           buildPhase = ''
             mkdir -p $out
             mkdir -p .cache/{p,z,tmp}
             ${cp-phase}
-            zig build install --cache-dir $(pwd)/zig-cache --global-cache-dir $(pwd)/.cache -Dcpu=baseline -Doptimize=ReleaseSafe -Ddata_version=master --prefix $out
+            zig build install --cache-dir $(pwd)/zig-cache --global-cache-dir $(pwd)/.cache -Dversion_data_path=$langref -Dcpu=baseline -Doptimize=ReleaseSafe --prefix $out
           '';
         };
       }


### PR DESCRIPTION
I broke nix build in #1409 because you can't just download a file without declaring it as a dependency.

@acristoffers I hope you don't mind the ping. Did I do this correctly?
The `langref.html.in` file dependency would need to be manually updated whenever it changes. Don't know if there is a better way to make it easier to update. I thought about just depending on the `zig-lang/zig` repo which contains `langref.html.in` but that seems to be a bit wasteful just to get a single file.