### PR TITLE
more fuzzer fixes

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -4329,7 +4329,7 @@ fn addReferencedTypes(
             => {
                 // NOTE: This is a hacky nightmare but it works :P
                 const token = tree.firstToken(p);
-                if (token_tags[token - 2] == .identifier and token_tags[token - 1] == .equal) {
+                if (token >= 2 and token_tags[token - 2] == .identifier and token_tags[token - 1] == .equal) {
                     const str = tree.tokenSlice(token - 2);
                     if (needs_type_reference) {
                         try referenced_types.put(.{
@@ -4340,7 +4340,7 @@ fn addReferencedTypes(
                     }
                     return str;
                 }
-                if (token_tags[token - 1] == .keyword_return) {
+                if (token >= 1 and token_tags[token - 1] == .keyword_return) {
                     const func_node = innermostBlockScopeInternal(handle.*, token_starts[token - 1], true);
                     var buf: [1]Ast.Node.Index = undefined;
                     const func = tree.fullFnProto(&buf, func_node) orelse return null;

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -2446,6 +2446,7 @@ pub fn getPositionContext(
                 else => curr_ctx.ctx = .empty,
             }
 
+            curr_ctx = try peek(allocator, &stack);
             switch (curr_ctx.ctx) {
                 .field_access => |r| curr_ctx.ctx = .{
                     .field_access = tokenLocAppend(r, tok),

--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -1130,7 +1130,7 @@ fn getIdentifierTokenIndexAndFnArgIndex(
                 .l_brace => depth -= 1,
                 .period => if (depth < 0 and token_tags[upper_index + 1] == .l_brace) { // anon struct init `.{.`
                     // if the preceding token is `=`, then this might be a `var foo: Foo = .{.`
-                    if (token_tags[upper_index - 1] == .equal) {
+                    if (upper_index >= 2 and token_tags[upper_index - 1] == .equal) {
                         upper_index -= 2; // eat `= .`
                         break :find_identifier;
                     }

--- a/src/features/goto.zig
+++ b/src/features/goto.zig
@@ -181,8 +181,10 @@ pub fn gotoDefinitionString(
     var import_str_loc = offsets.tokenIndexToLoc(handle.tree.source, loc.start);
     if (import_str_loc.end - import_str_loc.start < 2) return null;
     import_str_loc.start += 1;
-    import_str_loc.end -= 1;
-    var import_str = offsets.locToSlice(handle.tree.source, import_str_loc);
+    if (std.mem.endsWith(u8, offsets.locToSlice(handle.tree.source, import_str_loc), "\"")) {
+        import_str_loc.end -= 1;
+    }
+    const import_str = offsets.locToSlice(handle.tree.source, import_str_loc);
 
     const uri = switch (pos_context) {
         .import_string_literal,

--- a/src/main.zig
+++ b/src/main.zig
@@ -98,6 +98,7 @@ fn updateConfig(
         defer allocator.free(json_message);
 
         const new_config = try std.json.parseFromSlice(Config, allocator, json_message, .{});
+        defer allocator.destroy(new_config.arena);
         config.arena.promote(allocator).deinit();
         config.arena = new_config.arena.state;
         config.config = new_config.value;

--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -663,6 +663,12 @@ test "completion - cyclic struct init field" {
     , &.{});
 }
 
+test "completion - integer overflow in struct init field without lhs" {
+    try testCompletion(
+        \\= .{ .<cursor>foo
+    , &.{});
+}
+
 fn testCompletion(source: []const u8, expected_completions: []const Completion) !void {
     const cursor_idx = std.mem.indexOf(u8, source, "<cursor>").?;
     const text = try std.mem.concat(allocator, u8, &.{ source[0..cursor_idx], source[cursor_idx + "<cursor>".len ..] });

--- a/tests/lsp_features/hover.zig
+++ b/tests/lsp_features/hover.zig
@@ -421,6 +421,19 @@ test "hover - type reference cycle" {
     );
 }
 
+test "hover - integer overflow on top level container" {
+    try testHover(
+        \\enum {  foo.bar: b<cursor>az,}
+    ,
+        \\```zig
+        \\baz
+        \\```
+        \\```zig
+        \\(enum {  foo.bar: baz,})
+        \\```
+    );
+}
+
 fn testHover(source: []const u8, expected: []const u8) !void {
     const cursor_idx = std.mem.indexOf(u8, source, "<cursor>").?;
     const text = try std.mem.concat(allocator, u8, &.{ source[0..cursor_idx], source[cursor_idx + "<cursor>".len ..] });


### PR DESCRIPTION
4c1944a0858b7485eaf46971da8831236549ae26:
```zig
enum {  foo.bar: b<hover here>az,}
```

2144ec85433cffa6edc2823bc5e97e1a6e3483d1:
```zig
_ = @import("beha<goto definition here>vior¶
```

ac5e9b69aa3151c0ecd754020131f8f085fc9512:
```zig
= .{ .<completion here>foo
```

18f55aeed2b601a6f0ad0f030ddc86041d8379d0:
This one can't easily be reproduced but this works sometimes for me.
Place the cursor at the given position, if no crash occurs then place your cursor somewhere else and repeat until you get a crash.
```zig
if ((bits_lost = -@as(i32, @bitCast(@as(Z, @bitCast(@as(u32, @intCast((s >> 8) & 0xff)));
        .llvm<here>_name
```

```
debug: (server): Took 0ms to process request-13-textDocument/hover on Thread 38325
Segmentation fault at address 0x7feee32950f0
/run/media/techatrix/UserFiles/zls/src/analysis.zig:2449:29: 0x525bd2 in getPositionContext (zls)
            switch (curr_ctx.ctx) {
                            ^
/run/media/techatrix/UserFiles/zls/src/Server.zig:1420:56: 0x52b095 in generalReferencesHandler (zls)
    const pos_context = try Analyser.getPositionContext(server.allocator, handle.text, source_index, true);
                                                       ^
/run/media/techatrix/UserFiles/zls/src/Server.zig:1376:50: 0x4d812c in documentHighlightHandler (zls)
    const response = try generalReferencesHandler(server, arena, .{ .highlight = request });
                                                 ^
/run/media/techatrix/UserFiles/zls/src/Server.zig:1926:82: 0x49fff1 in sendRequestSync__anon_26723 (zls)
        .@"textDocument/documentHighlight" => try server.documentHighlightHandler(arena, params),
                                                                                 ^
debug: (server): Took 1ms to process request-15-textDocument/codeAction on Thread 38324
/run/media/techatrix/UserFiles/zls/src/Server.zig:1994:58: 0x4630be in processMessage (zls)
                const result = try server.sendRequestSync(arena_allocator.allocator(), method, params);
                                                         ^
/run/media/techatrix/UserFiles/zls/src/Server.zig:2013:33: 0x40bb05 in processMessageReportError (zls)
    return server.processMessage(message) catch |err| {
                                ^
/run/media/techatrix/UserFiles/zls/src/Server.zig:2051:62: 0x3e5861 in processJob (zls)
            const response = server.processMessageReportError(parsed_message.value) orelse return;
                                                             ^
```