### PR TITLE
Add back AST level r_brace finding with fix for crash.

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -3922,13 +3922,7 @@ fn makeScopeAt(
         => {
             const first_token = tree.firstToken(node_idx);
             const last_token = ast.lastToken(tree, node_idx);
-
-            // the last token may not always be the closing brace because of broken ast
-            // so we look at most 16 characters ahead to find the closing brace
-            // TODO this should automatically be done by `ast.lastToken`
-            var end_index = offsets.tokenToLoc(tree, last_token).start;
-            const lookahead_buffer = tree.source[end_index..@min(tree.source.len, end_index + 16)];
-            end_index += std.mem.indexOfScalar(u8, lookahead_buffer, '}') orelse 0;
+            const end_index = offsets.tokenToLoc(tree, last_token).end;
 
             const scope_index = try context.pushScope(
                 .{

--- a/src/ast.zig
+++ b/src/ast.zig
@@ -55,6 +55,15 @@ fn fullPtrTypeComponents(tree: Ast, info: full.PtrType.Components) full.PtrType 
     return result;
 }
 
+fn findNextLBrace(token_tags: []const TokenTag, start: Ast.TokenIndex) ?Ast.TokenIndex {
+    for (token_tags[start..], 0..) |tag, i| {
+        if (tag == TokenTag.l_brace) {
+            return start + @as(Ast.TokenIndex, @intCast(i));
+        }
+    }
+    return null;
+}
+
 /// Given an l_brace, find the corresponding r_brace.
 /// If no corresponding r_brace is found, return null.
 /// Useful for finding the extent of a block/scope if the syntax is valid.
@@ -684,7 +693,9 @@ pub fn lastToken(tree: Ast, node: Ast.Node.Index) Ast.TokenIndex {
         .container_decl_arg_trailing,
         => {
             // + 4 for the lparen, identifier, rparen, lbrace
-            return findMatchingRBrace(token_tags, main_tokens[n] + 4)
+            const l_brace = findNextLBrace(token_tags, main_tokens[n])
+                orelse return @intCast(tree.tokens.len - 1);
+            return findMatchingRBrace(token_tags, l_brace)
                 orelse @intCast(tree.tokens.len - 1);
         },
         .array_init_dot_two,

--- a/src/ast.zig
+++ b/src/ast.zig
@@ -55,7 +55,10 @@ fn fullPtrTypeComponents(tree: Ast, info: full.PtrType.Components) full.PtrType 
     return result;
 }
 
-fn findMatchingRBrace(token_tags: []const TokenTag, l_brace: Ast.TokenIndex) Ast.TokenIndex {
+/// Given an l_brace, find the corresponding r_brace.
+/// If no corresponding r_brace is found, return null.
+/// Useful for finding the extent of a block/scope if the syntax is valid.
+fn findMatchingRBrace(token_tags: []const TokenTag, l_brace: Ast.TokenIndex) ?Ast.TokenIndex {
     std.debug.assert(token_tags[l_brace] == TokenTag.l_brace);
 
     const start = l_brace + 1;
@@ -75,10 +78,7 @@ fn findMatchingRBrace(token_tags: []const TokenTag, l_brace: Ast.TokenIndex) Ast
         }
     }
 
-    std.debug.assert(depth == 0);
-    std.debug.assert(token_tags[start + offset] == std.zig.Token.Tag.r_brace);
-
-    return start + offset;
+    return if (depth == 0) start + offset else null;
 }
 
 pub fn ptrTypeSimple(tree: Ast, node: Node.Index) full.PtrType {

--- a/src/ast.zig
+++ b/src/ast.zig
@@ -604,15 +604,11 @@ pub fn lastToken(tree: Ast, node: Ast.Node.Index) Ast.TokenIndex {
             }
             n = tree.extra_data[params.end - 1]; // last parameter
         },
+        .switch_comma,
         .@"switch" => {
-            const cases = tree.extraData(datas[n].rhs, Node.SubRange);
-            if (cases.end - cases.start == 0) {
-                end_offset += 3; // rparen, lbrace, rbrace
-                n = datas[n].lhs; // condition expression
-            } else {
-                end_offset += 1; // for the rbrace
-                n = tree.extra_data[cases.end - 1]; // last case
-            }
+            const lhs = datas[n].lhs;
+            const l_brace = tree.lastToken(lhs) + 2; //lparen + rbrace
+            return findMatchingRBrace(token_tags, l_brace);
         },
         .container_decl_arg,
         .container_decl_arg_trailing,
@@ -640,7 +636,6 @@ pub fn lastToken(tree: Ast, node: Ast.Node.Index) Ast.TokenIndex {
         },
         .array_init_comma,
         .struct_init_comma,
-        .switch_comma,
         => {
             if (datas[n].rhs != 0) {
                 const members = tree.extraData(datas[n].rhs, Node.SubRange);

--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -338,6 +338,31 @@ test "completion - struct" {
         .{ .label = "alpha", .kind = .Field, .detail = "alpha: u32" },
         .{ .label = "beta", .kind = .Field, .detail = "beta: []const u8" },
     });
+
+    try testCompletion(
+        \\fn doNothingWithInteger(a: u32) void { _ = a; }
+        \\const S = struct {
+        \\    alpha: u32,
+        \\    beta: []const u8,
+        \\    fn foo(self: S) void {
+        \\        doNothingWithInteger(self.<cursor>
+        \\    }
+        \\};
+    , &.{
+        .{ .label = "alpha", .kind = .Field, .detail = "alpha: u32" },
+        .{ .label = "beta", .kind = .Field, .detail = "beta: []const u8" },
+        .{ .label = "foo", .kind = .Function, .detail = "fn foo(self: S) void" },
+    });
+
+    try testCompletion(
+        \\const S = struct {
+        \\    const Mode = enum { alpha, beta, };
+        \\    fn foo(mode: <cursor>
+        \\};
+    , &.{
+        .{ .label = "S", .kind = .Constant, .detail = "const S = struct" },
+        .{ .label = "Mode", .kind = .Constant, .detail = "const Mode = enum" },
+    });
 }
 
 test "completion - union" {

--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -281,37 +281,35 @@ test "completion - captures" {
         .{ .label = "alpha", .kind = .Field, .detail = "alpha: u32" },
     });
 
-    // TODO fix error union capture with if-else
-    // try testCompletion(
-    //     \\const E = error{ X, Y };
-    //     \\const S = struct { alpha: u32 };
-    //     \\fn foo() E!S { return undefined; }
-    //     \\fn bar() void {
-    //     \\    if (foo()) |baz| {
-    //     \\        baz.<cursor>
-    //     \\    } else |err| {
-    //     \\        _ = err;
-    //     \\    }
-    //     \\}
-    // , &.{
-    //     .{ .label = "alpha", .kind = .Field, .detail = "alpha: u32" },
-    // });
+    try testCompletion(
+        \\const E = error{ X, Y };
+        \\const S = struct { alpha: u32 };
+        \\fn foo() E!S { return undefined; }
+        \\fn bar() void {
+        \\    if (foo()) |baz| {
+        \\        baz.<cursor>
+        \\    } else |err| {
+        \\        _ = err;
+        \\    }
+        \\}
+    , &.{
+        .{ .label = "alpha", .kind = .Field, .detail = "alpha: u32" },
+    });
 
-    // TODO fix error union capture with while loop
-    // try testCompletion(
-    //     \\const E = error{ X, Y };
-    //     \\const S = struct { alpha: u32 };
-    //     \\fn foo() E!S { return undefined; }
-    //     \\fn bar() void {
-    //     \\    while (foo()) |baz| {
-    //     \\        baz.<cursor>
-    //     \\    } else |err| {
-    //     \\        _ = err;
-    //     \\    }
-    //     \\}
-    // , &.{
-    //     .{ .label = "alpha", .kind = .Field, .detail = "alpha: u32" },
-    // });
+    try testCompletion(
+        \\const E = error{ X, Y };
+        \\const S = struct { alpha: u32 };
+        \\fn foo() E!S { return undefined; }
+        \\fn bar() void {
+        \\    while (foo()) |baz| {
+        \\        baz.<cursor>
+        \\    } else |err| {
+        \\        _ = err;
+        \\    }
+        \\}
+    , &.{
+        .{ .label = "alpha", .kind = .Field, .detail = "alpha: u32" },
+    });
 }
 
 test "completion - struct" {

--- a/tests/lsp_features/folding_range.zig
+++ b/tests/lsp_features/folding_range.zig
@@ -167,8 +167,7 @@ test "foldingRange - container decl" {
         \\  beta: u16,
         \\};
     , &.{
-        // .{ .startLine = 0, .startCharacter = 32, .endLine = 3, .endCharacter = 0 }, // TODO
-        .{ .startLine = 0, .startCharacter = 32, .endLine = 2, .endCharacter = 11 },
+        .{ .startLine = 0, .startCharacter = 32, .endLine = 3, .endCharacter = 0 },
     });
     try testFoldingRange(
         \\const Foo = union {


### PR DESCRIPTION
My previous PR was accepted #1331 but then reverted #1360 due to crashes #1362. These crashes seem to have come from the handling for `.container_decl_arg` and `.container_decl_arg_trailing`, where the assumption that the location of the next l_brace would always be at `main_tokens[n] + 4` was incorrect. For these cases, the next l_brace cannot always be assumed to be at a specific place.

The solution here is similar to what I did for finding the r_brace, which is to just do a simple scan until a l_brace is found, and then this is taken to be the start of the block. Now the only assumption taken is that that there will be no l_braces in between the main token and the 'real' start of the scope. I cannot think of a case where this assumption does not hold.

I've only applied this `findNextLBrace` method to the problematic cases mentioned above. If any other cases also have the same problem, it could be applied to those as well.