### PR TITLE
remove unnecessary comptime specifier from functions

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -1269,7 +1269,7 @@ fn gotoDefinitionHandler(
 fn gotoHandler(
     server: *Server,
     arena: std.mem.Allocator,
-    comptime kind: goto.GotoKind,
+    kind: goto.GotoKind,
     request: types.DefinitionParams,
 ) Error!ResultType("textDocument/definition") {
     if (request.position.character == 0) return null;

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -3004,7 +3004,7 @@ pub fn innermostBlockScope(handle: DocumentStore.Handle, source_index: usize) As
     return innermostBlockScopeInternal(handle, source_index, false);
 }
 
-fn innermostBlockScopeInternal(handle: DocumentStore.Handle, source_index: usize, comptime skip_block: bool) Ast.Node.Index {
+fn innermostBlockScopeInternal(handle: DocumentStore.Handle, source_index: usize, skip_block: bool) Ast.Node.Index {
     const scope_datas = handle.document_scope.scopes.items(.data);
     const scope_parents = handle.document_scope.scopes.items(.parent);
 


### PR DESCRIPTION
there is no need to force separate function instantiations.