### PR TITLE
Fix use of wrong handle for struct init completions

### DIFF
--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -958,11 +958,11 @@ fn resolveContainer(
                                 .other => |n| n,
                                 else => continue,
                             };
-                            if (ast.isContainer(symbol_decl.handle.tree, node))
+                            if (ast.isContainer(either.handle.tree, node))
                                 try types_with_handles.append(
                                     arena,
                                     Analyser.TypeWithHandle{
-                                        .handle = symbol_decl.handle,
+                                        .handle = either.handle,
                                         .type = .{
                                             .data = .{ .other = node },
                                             .is_type_val = true,


### PR DESCRIPTION
Ran into an index out of bounds

```log
completions.zig:961:48: 0x100414f97 in resolveContainer (zls)
                            if (ast.isContainer(symbol_decl.handle.tree, node))
```

This PR fixes it :)