### PR TITLE
highlight test decl named after a type

### DIFF
--- a/tests/lsp_features/semantic_tokens.zig
+++ b/tests/lsp_features/semantic_tokens.zig
@@ -1049,6 +1049,17 @@ test "semantic tokens - test decl" {
         .{ "test", .keyword, .{} },
         .{ "foo", .variable, .{} },
     });
+    try testSemanticTokens(
+        \\const Foo = struct {};
+        \\test Foo {}
+    , &.{
+        .{ "const", .keyword, .{} },
+        .{ "Foo", .namespace, .{ .declaration = true } },
+        .{ "=", .operator, .{} },
+        .{ "struct", .keyword, .{} },
+        .{ "test", .keyword, .{} },
+        .{ "Foo", .namespace, .{} },
+    });
 }
 
 test "semantic tokens - assembly" {


### PR DESCRIPTION
```zig
const Foo = struct {};
test Foo {}
//   ^^^ this should be highlighted as a type just like the previous Foo
```