### PR TITLE
unset max_value_len when parsing LSP messages

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -1899,7 +1899,7 @@ pub fn sendJsonMessage(server: *Server, json_message: []const u8) Error!void {
         Message,
         server.allocator,
         json_message,
-        .{ .ignore_unknown_fields = true },
+        .{ .ignore_unknown_fields = true, .max_value_len = null },
     ) catch return error.ParseError;
     server.job_queue.writeItemAssumeCapacity(.{ .incoming_message = parsed_message });
 }
@@ -1909,7 +1909,7 @@ pub fn sendJsonMessageSync(server: *Server, json_message: []const u8) Error!?[]u
         Message,
         server.allocator,
         json_message,
-        .{ .ignore_unknown_fields = true },
+        .{ .ignore_unknown_fields = true, .max_value_len = null },
     ) catch return error.ParseError;
     defer parsed_message.deinit();
     return try server.processMessage(parsed_message.value);


### PR DESCRIPTION
turns out, ZLS can't open a file over 4Mb.
Yes, I am looking at you `zig/lib/compiler_rt/udivmodti4_test.zig`

~~depends on https://github.com/ziglang/zig/pull/17107~~
~~TODO: update nix flake~~
