### PR TITLE
Inlay Type Hints in Variable Declarations

### DIFF
--- a/src/features/inlay_hints.zig
+++ b/src/features/inlay_hints.zig
@@ -237,18 +237,8 @@ fn writeVariableDeclHint(builder: *Builder, decl_node: Ast.Node.Index) !void {
     );
     if (type_str.len == 0) return;
 
-    const assign_token = tree.firstToken(hint.ast.init_node) - 1;
-
-    const decl_str = offsets.tokensToSlice(tree, tree.firstToken(hint.ast.init_node) - 2, assign_token);
-    var decl_spaces: usize = 0;
-    for (decl_str) |char| {
-        if (char == ' ') {
-            decl_spaces += 1;
-        }
-    }
-
     try builder.hints.append(builder.arena, .{
-        .index = offsets.tokenToIndex(tree, assign_token) - decl_spaces,
+        .index = offsets.tokenToLoc(tree, hint.ast.mut_token + 1).end,
         .label = try std.fmt.allocPrint(builder.arena, ": {s}", .{
             type_str,
         }),

--- a/src/features/inlay_hints.zig
+++ b/src/features/inlay_hints.zig
@@ -82,7 +82,7 @@ const Builder = struct {
                 .position = position,
                 .label = .{ .string = hint.label },
                 .kind = hint.kind,
-                .tooltip = if (hint.tooltip != null) .{ .MarkupContent = hint.tooltip.? } else null,
+                .tooltip = if (hint.tooltip) |tooltip| .{ .MarkupContent = tooltip } else null,
                 .paddingLeft = false,
                 .paddingRight = hint.kind == .Parameter,
             };

--- a/src/features/inlay_hints.zig
+++ b/src/features/inlay_hints.zig
@@ -22,7 +22,7 @@ pub const InlayHint = struct {
     token_index: Ast.TokenIndex,
     label: []const u8,
     kind: types.InlayHintKind,
-    tooltip: types.MarkupContent,
+    tooltip: ?types.MarkupContent,
     after_token: bool = false,
 
     fn lessThan(_: void, lhs: InlayHint, rhs: InlayHint) bool {
@@ -84,7 +84,7 @@ const Builder = struct {
                 .position = position,
                 .label = .{ .string = hint.label },
                 .kind = hint.kind,
-                .tooltip = .{ .MarkupContent = hint.tooltip },
+                .tooltip = if (hint.tooltip != null) .{ .MarkupContent = hint.tooltip.? } else null,
                 .paddingLeft = false,
                 .paddingRight = !hint.after_token,
             };
@@ -245,10 +245,7 @@ fn writeVariableDeclHint(builder: *Builder, decl_node: Ast.Node.Index) !void {
             type_str,
         }),
         // TODO: Implement on-hover stuff.
-        .tooltip = .{
-            .kind = builder.hover_kind,
-            .value = "",
-        },
+        .tooltip = null,
         .kind = .Parameter,
         .after_token = true,
     });

--- a/src/features/inlay_hints.zig
+++ b/src/features/inlay_hints.zig
@@ -237,9 +237,18 @@ fn writeVariableDeclHint(builder: *Builder, decl_node: Ast.Node.Index) !void {
     );
     if (type_str.len == 0) return;
 
+    const assign_token = tree.firstToken(hint.ast.init_node) - 1;
+
+    const decl_str = offsets.tokensToSlice(tree, tree.firstToken(hint.ast.init_node) - 2, assign_token);
+    var decl_spaces: usize = 0;
+    for (decl_str) |char| {
+        if (char == ' ') {
+            decl_spaces += 1;
+        }
+    }
+
     try builder.hints.append(builder.arena, .{
-        // TODO: Add logic to detect when there is no space between assignment operator and variable name.
-        .index = offsets.tokenToIndex(tree, tree.firstToken(hint.ast.init_node) - 1) - 1,
+        .index = offsets.tokenToIndex(tree, assign_token) - decl_spaces,
         .label = try std.fmt.allocPrint(builder.arena, ": {s}", .{
             type_str,
         }),

--- a/tests/lsp_features/inlay_hints.zig
+++ b/tests/lsp_features/inlay_hints.zig
@@ -12,29 +12,30 @@ const offsets = zls.offsets;
 const allocator: std.mem.Allocator = std.testing.allocator;
 
 test "inlayhints - empty" {
-    try testInlayHints("");
+    try testInlayHints("", .Parameter);
+    try testInlayHints("", .Type);
 }
 
 test "inlayhints - function call" {
     try testInlayHints(
         \\fn foo(alpha: u32) void {}
         \\const _ = foo(<alpha>5);
-    );
+    , .Parameter);
     try testInlayHints(
         \\fn foo(alpha: u32, beta: u64) void {}
         \\const _ = foo(<alpha>5,<beta>4);
-    );
+    , .Parameter);
     try testInlayHints(
         \\fn foo(alpha: u32, beta: u64) void {}
         \\const _ = foo(  <alpha>3 + 2 ,  <beta>(3 - 2));
-    );
+    , .Parameter);
     try testInlayHints(
         \\fn foo(alpha: u32, beta: u64) void {}
         \\const _ = foo(
         \\    <alpha>3 + 2,
         \\    <beta>(3 - 2),
         \\);
-    );
+    , .Parameter);
 }
 
 test "inlayhints - function self parameter" {
@@ -42,21 +43,21 @@ test "inlayhints - function self parameter" {
         \\const Foo = struct { pub fn bar(self: *Foo, alpha: u32) void {} };
         \\const foo: Foo = .{};
         \\const _ = foo.bar(<alpha>5);
-    );
+    , .Parameter);
     try testInlayHints(
         \\const Foo = struct { pub fn bar(_: Foo, alpha: u32, beta: []const u8) void {} };
         \\const foo: Foo = .{};
         \\const _ = foo.bar(<alpha>5,<beta>"");
-    );
+    , .Parameter);
     try testInlayHints(
         \\const Foo = struct { pub fn bar(self: Foo, alpha: u32, beta: anytype) void {} };
         \\const foo: Foo = .{};
         \\const _ = foo.bar(<alpha>5,<beta>4);
-    );
+    , .Parameter);
     try testInlayHints(
         \\const Foo = struct { pub fn bar(self: Foo, alpha: u32, beta: []const u8) void {} };
         \\const _ = Foo.bar(<self>undefined,<alpha>5,<beta>"");
-    );
+    , .Parameter);
     try testInlayHints(
         \\const Foo = struct {
         \\  pub fn bar(self: Foo, alpha: u32, beta: []const u8) void {}
@@ -64,7 +65,7 @@ test "inlayhints - function self parameter" {
         \\      bar(<self>undefined,<alpha>5,<beta>"");
         \\  }
         \\};
-    );
+    , .Parameter);
 }
 
 test "inlayhints - resolve alias" {
@@ -72,23 +73,28 @@ test "inlayhints - resolve alias" {
         \\fn foo(alpha: u32) void {}
         \\const bar = foo;
         \\const _ = bar(<alpha>5);
-    );
+    , .Parameter);
 }
 
 test "inlayhints - builtin call" {
     try testInlayHints(
         \\const _ = @memcpy(<dest>"",<source>"");
-    );
-
+    , .Parameter);
     try testInlayHints(
         \\const _ = @sizeOf(<T>u32);
-    );
+    , .Parameter);
     try testInlayHints(
         \\const _ = @TypeOf(5);
-    );
+    , .Parameter);
 }
 
-fn testInlayHints(source: []const u8) !void {
+test "inlayhints - var decl" {
+    try testInlayHints(
+        \\const foo<comptime_int> = 5;
+    , .Type);
+}
+
+fn testInlayHints(source: []const u8, kind: types.InlayHintKind) !void {
     var phr = try helper.collectClearPlaceholders(allocator, source);
     defer phr.deinit(allocator);
 
@@ -130,6 +136,7 @@ fn testInlayHints(source: []const u8) !void {
 
         for (hints, 0..) |hint, i| {
             if (position.line != hint.position.line or position.character != hint.position.character) continue;
+            if (hint.kind.? != kind) continue;
 
             if (visited.isSet(i)) {
                 try error_builder.msgAtIndex("duplicate inlay hint here!", test_uri, new_loc.start, .err, .{});
@@ -138,16 +145,25 @@ fn testInlayHints(source: []const u8) !void {
                 visited.set(i);
             }
 
-            if (!std.mem.endsWith(u8, hint.label.string, ":")) {
-                try error_builder.msgAtLoc("label `{s}` must end with a colon!", test_uri, new_loc, .err, .{hint.label.string});
-            }
-            const actual_label = hint.label.string[0 .. hint.label.string.len - 1];
+            const actual_label = switch (kind) {
+                .Parameter => blk: {
+                    if (!std.mem.endsWith(u8, hint.label.string, ":")) {
+                        try error_builder.msgAtLoc("label `{s}` must end with a colon!", test_uri, new_loc, .err, .{hint.label.string});
+                        continue :outer;
+                    }
+                    break :blk hint.label.string[0 .. hint.label.string.len - 1];
+                },
+                .Type => blk: {
+                    if (!std.mem.startsWith(u8, hint.label.string, ": ")) {
+                        try error_builder.msgAtLoc("label `{s}` must start with \": \"!", test_uri, new_loc, .err, .{hint.label.string});
+                        continue :outer;
+                    }
+                    break :blk hint.label.string[2..hint.label.string.len];
+                },
+            };
 
             if (!std.mem.eql(u8, expected_label, actual_label)) {
                 try error_builder.msgAtLoc("expected label `{s}` here but got `{s}`!", test_uri, new_loc, .err, .{ expected_label, actual_label });
-            }
-            if (hint.kind.? != types.InlayHintKind.Parameter) {
-                try error_builder.msgAtLoc("hint kind should be `{s}` but got `{s}`!", test_uri, new_loc, .err, .{ @tagName(types.InlayHintKind.Parameter), @tagName(hint.kind.?) });
             }
 
             continue :outer;
@@ -158,6 +174,7 @@ fn testInlayHints(source: []const u8) !void {
     var it = visited.iterator(.{ .kind = .unset });
     while (it.next()) |index| {
         const hint = hints[index];
+        if (hint.kind.? != kind) continue;
         const source_index = offsets.positionToIndex(phr.new_source, hint.position, ctx.server.offset_encoding);
         try error_builder.msgAtIndex("unexpected inlay hint `{s}` here!", test_uri, source_index, .err, .{hint.label.string});
     }

--- a/tests/lsp_features/inlay_hints.zig
+++ b/tests/lsp_features/inlay_hints.zig
@@ -92,6 +92,26 @@ test "inlayhints - var decl" {
     try testInlayHints(
         \\const foo<comptime_int> = 5;
     , .Type);
+    try testInlayHints(
+        \\const foo<**const [3:0]u8> = &"Bar";
+    , .Type);
+    try testInlayHints(
+        \\const foo: *[]const u8 = &"Bar";
+        \\const baz<**[]const u8> = &foo;
+    , .Type);
+    try testInlayHints(
+        \\const Foo<type> = struct { bar: u32 };
+        \\const Error<type> = error{e};
+        \\fn test_context() !void {
+        \\    const baz: ?Foo = Foo{ .bar = 42 };
+        \\    if (baz) |b| {
+        \\        const d: Error!?Foo = b;
+        \\        const e<*Error!?Foo> = &d;
+        \\        const f<Foo> = (try e.*).?;
+        \\        _ = f;
+        \\    }
+        \\}
+    , .Type);
 }
 
 fn testInlayHints(source: []const u8, kind: types.InlayHintKind) !void {


### PR DESCRIPTION
![Screenshot from 2023-09-17 19-03-00](https://github.com/zigtools/zls/assets/101683475/ec87f70f-28e0-4ca4-a240-bd9bf6c82fd2)

Adds inlay hints to variable declarations - useful for making sure a type is what _you_ think _zls_ thinks it is without having to hover over a variable name.
fixes #318