### PR TITLE
More enum completions

### DIFF
--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -840,7 +840,7 @@ fn resolveContainer(
     arena: std.mem.Allocator,
     handle: *const DocumentStore.Handle,
     text_index: usize,
-    fn_arg_index: usize,
+    dot_context: *DotContext,
 ) error{OutOfMemory}![]Analyser.TypeWithHandle {
     const tracy_zone = tracy.trace(@src());
     defer tracy_zone.end();
@@ -857,18 +857,42 @@ fn resolveContainer(
             if (nodes_tags[symbol_decl.decl.ast_node] == .fn_decl) {
                 var buf: [1]Ast.Node.Index = undefined;
                 const full_fn_proto = symbol_decl.handle.tree.fullFnProto(&buf, symbol_decl.decl.ast_node) orelse break :va;
+                if (dot_context.likely == .enum_op) {
+                    // TODO if (enum_op == `=`) break :va; // can't assing to a fn result
+                    if (full_fn_proto.ast.return_type == 0) break :va;
+                    const node_type = try analyser.resolveTypeOfNode(.{ .node = full_fn_proto.ast.return_type, .handle = symbol_decl.handle }) orelse break :va;
+                    for (try node_type.getAllTypesWithHandles(arena)) |either| {
+                        const node = switch (either.type.data) {
+                            .other => |n| n,
+                            else => continue,
+                        };
+                        if (ast.isContainer(either.handle.tree, node))
+                            try types_with_handles.append(
+                                arena,
+                                Analyser.TypeWithHandle{
+                                    .handle = either.handle,
+                                    .type = .{
+                                        .data = .{ .other = node },
+                                        .is_type_val = true,
+                                    },
+                                },
+                            );
+                    }
+                    break :va;
+                }
                 var maybe_fn_param: ?Ast.full.FnProto.Param = undefined;
                 var fn_param_iter = full_fn_proto.iterate(&symbol_decl.handle.tree);
-                for (fn_arg_index + 1) |_| maybe_fn_param = ast.nextFnParam(&fn_param_iter);
+                for (dot_context.fn_arg_index + 1) |_| maybe_fn_param = ast.nextFnParam(&fn_param_iter);
                 const param = maybe_fn_param orelse break :va;
                 if (param.type_expr == 0) break :va;
+
                 const param_rcts = try resolveContainer(
                     document_store,
                     analyser,
                     arena,
                     symbol_decl.handle,
                     offsets.nodeToLoc(symbol_decl.handle.tree, param.type_expr).end,
-                    fn_arg_index,
+                    dot_context,
                 );
                 for (param_rcts) |prct| try types_with_handles.append(arena, prct);
                 break :va;
@@ -922,7 +946,7 @@ fn resolveContainer(
                         arena,
                         handle,
                         node_loc.end,
-                        fn_arg_index,
+                        dot_context,
                     );
                     for (rcts) |rct| try types_with_handles.append(arena, rct);
                 },
@@ -935,7 +959,7 @@ fn resolveContainer(
                         arena,
                         handle,
                         node_loc.end,
-                        fn_arg_index,
+                        dot_context,
                     );
                     for (rcts) |rct| try types_with_handles.append(arena, rct);
                 },
@@ -972,7 +996,6 @@ fn resolveContainer(
                                 );
                         }
                     }
-                    //Analyser.DeclWithHandle{ .handle = symbol_decl.handle, .decl = .{.array_payload = .{}} };
                 },
             }
         },
@@ -1006,7 +1029,7 @@ fn resolveContainer(
                         }
                         break :blk 1; // is `T`, no SelfParam
                     };
-                    for (fn_arg_index + additional_index) |_| maybe_fn_param = ast.nextFnParam(&fn_param_iter);
+                    for (dot_context.fn_arg_index + additional_index) |_| maybe_fn_param = ast.nextFnParam(&fn_param_iter);
                     const param = maybe_fn_param orelse continue;
                     if (param.type_expr == 0) continue;
                     const param_rcts = try resolveContainer(
@@ -1015,7 +1038,7 @@ fn resolveContainer(
                         arena,
                         node_type.handle,
                         offsets.nodeToLoc(node_type.handle.tree, param.type_expr).end,
-                        fn_arg_index,
+                        dot_context,
                     );
                     for (param_rcts) |prct| try types_with_handles.append(arena, prct);
                     continue;
@@ -1032,11 +1055,11 @@ fn resolveContainer(
                         .other => |n| n,
                         else => continue,
                     };
-                    if (ast.isContainer(node_type.handle.tree, enode))
+                    if (ast.isContainer(either.handle.tree, enode))
                         try types_with_handles.append(
                             arena,
                             Analyser.TypeWithHandle{
-                                .handle = node_type.handle,
+                                .handle = either.handle,
                                 .type = .{
                                     .data = .{ .other = enode },
                                     .is_type_val = true,
@@ -1049,15 +1072,14 @@ fn resolveContainer(
         .enum_literal => |loc| el: {
             const alleged_field_name = handle.text[loc.start + 1 .. loc.end];
             const dot_index = offsets.sourceIndexToTokenIndex(handle.tree, loc.start);
-            var field_fn_arg_index: usize = 0;
-            const id_token_index = getIdentifierTokenIndexAndFnArgIndex(handle.tree, dot_index, &field_fn_arg_index) orelse break :el;
+            var el_dot_context = identifyDotContext(handle.tree, dot_index) orelse break :el;
             const containers = try resolveContainer(
                 document_store,
                 analyser,
                 arena,
                 handle,
-                handle.tree.tokens.items(.start)[id_token_index],
-                field_fn_arg_index,
+                handle.tree.tokens.items(.start)[el_dot_context.identifier_token_index],
+                &el_dot_context,
             );
             for (containers) |container| {
                 const node = switch (container.type.data) {
@@ -1089,7 +1111,7 @@ fn resolveContainer(
                             arena,
                             container.handle,
                             end,
-                            fn_arg_index,
+                            &el_dot_context,
                         );
                         for (param_rcts) |prct| try types_with_handles.append(arena, prct);
                     }
@@ -1101,14 +1123,24 @@ fn resolveContainer(
     return types_with_handles.toOwnedSlice(arena);
 }
 
+const DotContext = struct {
+    const Likely = enum { // TODO: better name, tagged union?
+        enum_op, // `=`, `==`, `!=`
+        enum_arg, // the enum is a fn arg
+        struct_init,
+    };
+    likely: Likely,
+    identifier_token_index: Ast.TokenIndex = 9001,
+    fn_arg_index: usize = 0,
+};
+
 /// Looks for an identifier that can be passed to `resolveContainer()`
 /// Returns the token index of the identifer
 /// If the identifier is a `fn_name`, `fn_arg_index` is the index of the fn's param
-fn getIdentifierTokenIndexAndFnArgIndex(
+fn identifyDotContext(
     tree: Ast,
     dot_index: Ast.TokenIndex,
-    fn_arg_index_out: *usize,
-) ?Ast.TokenIndex {
+) ?DotContext {
     // at least 3 tokens should be present, `x{.`
     if (dot_index < 2) return null;
     const token_tags = tree.tokens.items(.tag);
@@ -1121,54 +1153,82 @@ fn getIdentifierTokenIndexAndFnArgIndex(
     // in this case `fn completeDot` would still provide enum completions
     if (token_tags[upper_index] == .equal) return null;
 
+    var likely: DotContext.Likely = .struct_init;
+
     var fn_arg_index: usize = 0;
 
-    // look for .identifier followed by .l_brace, skipping matches at depth 0+
-    var depth: i32 = 0; // Should end up being negative, ie even the first/single .l_brace would put it at -1; 0+ => nested
-    find_identifier: while (upper_index > 0) {
-        if (token_tags[upper_index] != .identifier) {
-            switch (token_tags[upper_index]) {
-                .r_brace => depth += 1,
-                .l_brace => depth -= 1,
-                .period => if (depth < 0 and token_tags[upper_index + 1] == .l_brace) { // anon struct init `.{.`
-                    // if the preceding token is `=`, then this might be a `var foo: Foo = .{.`
-                    if (upper_index >= 2 and token_tags[upper_index - 1] == .equal) {
-                        upper_index -= 2; // eat `= .`
-                        break :find_identifier;
+    // The following logic is weird because we assume at least one .l_brace and/or .l_paren
+    // => a couple of helpful constants:
+    const even = 1; // we haven't found an opening brace or paren so the count is even
+    const one_opening = 0; // an unmatched opening brace or paren makes the depth 0
+
+    // look for .identifier followed by .l_brace, skipping matches at braces_depth 'even'+
+    var braces_depth: i32 = even;
+    var parens_depth: i32 = even;
+    find_identifier: while (upper_index > 0) : (upper_index -= 1) {
+        switch (token_tags[upper_index]) {
+            .r_brace => braces_depth += 1,
+            .l_brace => braces_depth -= 1,
+            .period => if (braces_depth == one_opening and token_tags[upper_index + 1] == .l_brace) { // anon struct init `.{.`
+                // if the preceding token is `=`, then this might be a `var foo: Foo = .{.`
+                if (upper_index > 1 and token_tags[upper_index - 1] == .equal) {
+                    upper_index -= 2; // eat `= .`
+                    break :find_identifier;
+                }
+                // We never return from this branch/condition to the `find_identifier: while ..` loop, so reset and reuse these
+                fn_arg_index = 0;
+                braces_depth = even; // not actually looking for/expecting an uneven number of braces, just making use of the helpful const
+                parens_depth = even;
+                while (upper_index > 0) : (upper_index -= 1) {
+                    switch (token_tags[upper_index]) {
+                        .r_brace => braces_depth += 1,
+                        .l_brace => braces_depth -= 1,
+                        .r_paren => parens_depth += 1,
+                        .l_paren => {
+                            parens_depth -= 1;
+                            if (parens_depth == one_opening and token_tags[upper_index - 1] == .identifier) {
+                                upper_index -= 1;
+                                break :find_identifier;
+                            }
+                        },
+                        .comma => if (braces_depth == even and parens_depth == even) { // those only matter when outside of braces and before final '('
+                            fn_arg_index += 1;
+                        },
+                        .semicolon => return null, // generic exit; maybe also .keyword_(var/const)
+                        else => {},
                     }
-                    var num_braces: i32 = 0;
-                    var num_parens: i32 = 0;
-                    while (upper_index > 0) : (upper_index -= 1) {
-                        switch (token_tags[upper_index]) {
-                            .r_brace => num_braces += 1,
-                            .l_brace => num_braces -= 1,
-                            .r_paren => num_parens += 1,
-                            .l_paren => {
-                                num_parens -= 1;
-                                if (num_parens < 0) {
-                                    upper_index -= 1;
-                                    break :find_identifier;
-                                }
-                            },
-                            .semicolon => return null, // generic exit; maybe also .keyword_(var/const)
-                            .comma => if (num_braces == 0 and num_parens == 0) { // those only matter when outside of braces or parens
-                                fn_arg_index += 1;
-                            },
-                            else => {},
-                        }
-                    }
+                }
+                break :find_identifier;
+            },
+            // We're fishing for a `f(some, other{}, .<cursor>enum)`
+            .r_paren => parens_depth += 1,
+            .l_paren => parens_depth -= 1,
+            .comma => if (braces_depth == even and parens_depth == even) { // those only matter when outside of braces and before final '('
+                fn_arg_index += 1;
+            },
+            // Have we arrived at an .identifier matching the criteria?
+            .identifier => switch (token_tags[upper_index + 1]) {
+                .l_brace => if (braces_depth == one_opening) break :find_identifier, // `S{.`
+                .l_paren => if (braces_depth == even and parens_depth == one_opening) { // `f(.`
+                    likely = .enum_arg;
                     break :find_identifier;
                 },
-                .semicolon => return null, // generic exit; maybe also .keyword_(var/const)
                 else => {},
-            }
-        } else if (token_tags[upper_index + 1] == .l_brace and depth < 0) break :find_identifier;
-        upper_index -= 1;
+            },
+            // Exit conditions
+            .semicolon => return null, // generic exit; maybe also .keyword_(var/const)
+            else => {},
+        }
     }
-    if (depth > -1) return null;
+    // Maybe we simply ran out of tokens?
+    // FIXME: This creates a 'blind spot' if the first node in a file is a .container_field_init
+    if (upper_index == 0) return null;
 
-    fn_arg_index_out.* = fn_arg_index;
-    return upper_index;
+    return DotContext{
+        .likely = likely,
+        .identifier_token_index = upper_index,
+        .fn_arg_index = fn_arg_index,
+    };
 }
 
 fn completeDot(document_store: *DocumentStore, analyser: *Analyser, arena: std.mem.Allocator, handle: *const DocumentStore.Handle, source_index: usize) error{OutOfMemory}![]types.CompletionItem {
@@ -1179,33 +1239,94 @@ fn completeDot(document_store: *DocumentStore, analyser: *Analyser, arena: std.m
     const token_tags = tree.tokens.items(.tag);
 
     // as invoked source_index points to the char/token after the `.`, do `- 1`
-    var token_index = offsets.sourceIndexToTokenIndex(tree, source_index - 1);
+    var dot_token_index = offsets.sourceIndexToTokenIndex(tree, source_index - 1);
 
+    // if (dot_token_index < 2) exit;
     var completions = std.ArrayListUnmanaged(types.CompletionItem){};
 
-    struct_init: {
-        // This prevents completions popping up for floating point numbers
-        // but I discovered it is a very helpful parser workaround to enable providing completions
-        // for struct that are declared after the current block !
-        // The fact that the logic outside this block (struct_init) already pops up completions for
-        // floating point numbers, ie `var a = `1.m` will pop up completions for `m*`, makes me think
-        // this hasn't been an issue for many ..
-        // if (token_tags[token_index - 1] == .number_literal) break :struct_init; // `var s = MyStruct{.float_field = 1.`
+    // This prevents completions popping up for floating point numbers
+    // but I discovered it is a very helpful parser workaround to enable providing completions
+    // for structs declared after the current block or when completing within same struct (Self)
+    var token_index = if (token_tags[dot_token_index - 1] == .number_literal) (dot_token_index - 2) else (dot_token_index - 1);
 
-        var fn_arg_index: usize = 0;
-        token_index = getIdentifierTokenIndexAndFnArgIndex(tree, token_index, &fn_arg_index) orelse break :struct_init;
-        if (token_index == 0) break :struct_init;
+    var dot_context = DotContext{ .likely = .enum_op };
+
+    switch (token_tags[token_index]) {
+        .equal, .equal_equal, .bang_equal => {
+            token_index -= 1;
+            const token_end = offsets.tokenToLoc(tree, token_index).end;
+            const pos_ctx = try Analyser.getPositionContext(arena, tree.source, token_end, false);
+            switch (pos_ctx) {
+                .var_access, // fn or var_decl, ie `var mye: MyEnum = .`
+                .enum_literal,
+                => { // assume it's a struct field, ie `x{.field = .`
+                    const containers = try resolveContainer(
+                        document_store,
+                        analyser,
+                        arena,
+                        handle,
+                        token_end,
+                        &dot_context, // resolveContainer does it's own lookup for .enum_literal
+                    );
+                    for (containers) |container| {
+                        if (!container.isEnumType()) continue;
+                        try collectContainerFields(arena, container, &completions);
+                    }
+                },
+                // TODO Audit this logic/incorporate it into resolveContainer
+                // TODO None of these work for ?Enum
+                .field_access => |loc| fa: {
+                    const held_range = try arena.dupeZ(u8, offsets.locToSlice(handle.text, loc));
+                    var tokenizer = std.zig.Tokenizer.init(held_range);
+
+                    if (try analyser.getFieldAccessType(handle, token_end, &tokenizer)) |result| {
+                        const container_handle = result.unwrapped orelse result.original;
+                        if (container_handle.isEnumType()) try collectContainerFields(arena, container_handle, &completions);
+                        // getFieldAccessType works for `name.f()`, but not for `name.field`
+                        if (completions.items.len == 0) {
+                            const containers = try resolveContainer(
+                                document_store,
+                                analyser,
+                                arena,
+                                handle,
+                                token_end,
+                                &dot_context, // hope it's not a fn
+                            );
+
+                            for (containers) |container| {
+                                if (!container.isEnumType()) continue;
+                                try collectContainerFields(arena, container, &completions);
+                            }
+                        }
+                        if (completions.items.len == 0 and container_handle.type.data == .other) {
+                            const node_type = try analyser.resolveTypeOfNode(.{ .node = container_handle.type.data.other, .handle = container_handle.handle }) orelse break :fa;
+                            if (node_type.isEnumType()) try collectContainerFields(arena, node_type, &completions);
+                        }
+                    }
+                },
+                else => {},
+            }
+            if (completions.items.len != 0) return completions.toOwnedSlice(arena);
+        },
+        else => {},
+    }
+
+    struct_init_or_enum_arg: {
+        dot_context = identifyDotContext(tree, dot_token_index) orelse break :struct_init_or_enum_arg;
 
         const containers = try resolveContainer(
             document_store,
             analyser,
             arena,
             handle,
-            tree.tokens.items(.start)[token_index],
-            fn_arg_index,
+            tree.tokens.items(.start)[dot_context.identifier_token_index],
+            &dot_context,
         );
 
-        for (containers) |container| try collectContainerFields(arena, container, &completions);
+        for (containers) |container| {
+            if (dot_context.likely == .enum_arg and !container.isEnumType()) continue;
+            try collectContainerFields(arena, container, &completions);
+        }
 
         if (completions.items.len != 0) return completions.toOwnedSlice(arena);
     }

--- a/src/offsets.zig
+++ b/src/offsets.zig
@@ -115,11 +115,10 @@ pub fn sourceIndexToTokenIndex(tree: Ast, source_index: usize) Ast.TokenIndex {
     while (upper_index > 0) : (upper_index -= 1) {
         var token_start = tokens_start[upper_index];
         if (token_start > source_index) continue; // checking for equality here is suboptimal
-        // check if source_index is within current token
-        //  `token_start - 1` to include it's loc.start source_index and avoid the equality part of the check
-        //  because the above `if` doesn't check for equality upper_index ends up always `< last/max index`,
-        //  and the check below doesn't overflow => ie if upper_index is the last index and even if
-        //  token_start == source_index => another iteration, `(upper_index -= 1)`
+        // Handle source_index being > than the last possible token_start (max_token_start < source_index < tree.source.len)
+        if (upper_index == tokens_start.len - 1) break;
+        // Check if source_index is within current token
+        // (`token_start - 1` to include it's loc.start source_index and avoid the equality part of the check)
         const is_within_current_token = (source_index > (token_start - 1)) and (source_index < tokens_start[upper_index + 1]);
         if (!is_within_current_token) upper_index += 1; // gone 1 past
         break;

--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -432,6 +432,161 @@ test "completion - enum" {
     , &.{
         .{ .label = "inner", .kind = .Function, .detail = "fn inner(_: E) void" },
     });
+    // Because current logic is to list all enums if all else fails,
+    // the following tests include an extra enum to ensure that we're not just 'getting lucky'
+    try testCompletion(
+        \\const Birdie = enum {
+        \\    canary,
+        \\};
+        \\const SomeEnum = enum {
+        \\    sef1,
+        \\    sef2,
+        \\};
+        \\fn retEnum() SomeEnum {}
+        \\test {
+        \\    retEnum() == .<cursor>
+        \\}
+    , &.{
+        .{ .label = "sef1", .kind = .EnumMember },
+        .{ .label = "sef2", .kind = .EnumMember },
+    });
+    try testCompletion(
+        \\const Birdie = enum {
+        \\    canary,
+        \\};
+        \\const SomeEnum = enum {
+        \\    sef1,
+        \\    sef2,
+        \\};
+        \\const S = struct {
+        \\    pub fn retEnum() SomeEnum {}
+        \\};
+        \\test {
+        \\    S.retEnum() == .<cursor>
+        \\}
+    , &.{
+        .{ .label = "sef1", .kind = .EnumMember },
+        .{ .label = "sef2", .kind = .EnumMember },
+    });
+    try testCompletion(
+        \\const Birdie = enum {
+        \\    canary,
+        \\};
+        \\const SomeEnum = enum {
+        \\    sef1,
+        \\    sef2,
+        \\};
+        \\const S = struct {
+        \\    pub fn retEnum() SomeEnum {}
+        \\};
+        \\test {
+        \\    const s = S{};
+        \\    s.retEnum() == .<cursor>
+        \\}
+    , &.{
+        .{ .label = "sef1", .kind = .EnumMember },
+        .{ .label = "sef2", .kind = .EnumMember },
+    });
+    try testCompletion(
+        \\const Birdie = enum {
+        \\    canary,
+        \\};
+        \\const SomeEnum = enum {
+        \\    sef1,
+        \\    sef2,
+        \\};
+        \\const S = struct {
+        \\    se: SomeEnum = .sef1,
+        \\};
+        \\test {
+        \\    const s = S{};
+        \\    s.se == .<cursor>
+        \\}
+    , &.{
+        .{ .label = "sef1", .kind = .EnumMember },
+        .{ .label = "sef2", .kind = .EnumMember },
+    });
+    try testCompletion(
+        \\const Birdie = enum {
+        \\    canary,
+        \\};
+        \\const S = struct {
+        \\    mye: enum {
+        \\        myef1,
+        \\        myef2,
+        \\    };
+        \\};
+        \\test {
+        \\    const s = S{};
+        \\    s.mye == .<cursor>
+        \\}
+    , &.{
+        .{ .label = "myef1", .kind = .EnumMember },
+        .{ .label = "myef2", .kind = .EnumMember },
+    });
+    try testCompletion(
+        \\const Birdie = enum {
+        \\    canary,
+        \\};
+        \\const SomeEnum = enum {
+        \\    sef1,
+        \\    sef2,
+        \\};
+        \\const S = struct {
+        \\    const Self = @This();
+        \\    pub fn f(_: *Self, _: SomeEnum) void {}
+        \\};
+        \\test {
+        \\    S.f(null, .<cursor>
+        \\}
+    , &.{
+        .{ .label = "sef1", .kind = .EnumMember },
+        .{ .label = "sef2", .kind = .EnumMember },
+    });
+    try testCompletion(
+        \\const Birdie = enum {
+        \\    canary,
+        \\};
+        \\const SomeEnum = enum {
+        \\    sef1,
+        \\    sef2,
+        \\};
+        \\const S = struct {
+        \\    const Self = @This();
+        \\    pub fn f(_: *Self, _: SomeEnum) void {}
+        \\};
+        \\test {
+        \\    const s = S{};
+        \\    s.f(.<cursor>
+        \\}
+    , &.{
+        .{ .label = "sef1", .kind = .EnumMember },
+        .{ .label = "sef2", .kind = .EnumMember },
+    });
+    try testCompletion(
+        \\const Birdie = enum {
+        \\    canary,
+        \\};
+        \\const SomeEnum = enum {
+        \\    sef1,
+        \\    sef2,
+        \\};
+        \\const SCE = struct{
+        \\    se: SomeEnum,
+        \\};
+        \\const S = struct {
+        \\    const Self = @This();
+        \\    pub fn f(_: *Self, _: SCE) void {}
+        \\};
+        \\test {
+        \\    const s = S{};
+        // XXX This doesn't work without the closing brace at the end
+        \\    s.f(.{.se = .<cursor>}
+        \\}
+    , &.{
+        .{ .label = "sef1", .kind = .EnumMember },
+        .{ .label = "sef2", .kind = .EnumMember },
+    });
 }
 
 test "completion - error set" {


### PR DESCRIPTION
![enumc2](https://github.com/zigtools/zls/assets/16590917/dabd6edb-ec81-4fbd-80f5-5c620337857d)
![enumc1](https://github.com/zigtools/zls/assets/16590917/f77004a3-1801-412e-bfea-f0f2dec993e5)
![enumc4](https://github.com/zigtools/zls/assets/16590917/54369f0d-66ed-4fee-af05-4f7b67a83932)
![enumc3](https://github.com/zigtools/zls/assets/16590917/bca96189-40f3-4bc9-823d-c954dae2f7f0)

Limitations:
Doesn't work for container fields that have an optional enum type (?Enum).
Can be "peeked/previewed" => `exe.wasi_exec_model.? = .`

Known side effects:
Currently `=` and `==`/`!=` are treated the same, ie completions are provided for `f() = .`.
