### PR TITLE
prevent duplicate CI runs

### DIFF
--- a/.github/workflows/build_runner.yml
+++ b/.github/workflows/build_runner.yml
@@ -2,10 +2,14 @@ name: BuildRunner
 
 on:
   push:
+    branches:
+      - master
     paths:
       - ".github/workflows/build_runner.yml"
       - "src/build_runner/**"
   pull_request:
+    branches:
+      - master
     paths:
       - ".github/workflows/build_runner.yml"
       - "src/build_runner/**"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,11 +2,15 @@ name: CI
 
 on:
   push:
+    branches:
+      - master
     paths:
       - ".github/workflows/main.yml"
       - "**.zig"
       - "build.zig.zon"
   pull_request:
+    branches:
+      - master
     paths:
       - ".github/workflows/main.yml"
       - "**.zig"


### PR DESCRIPTION
We are running all CI jobs twice on PRs:
![image](https://github.com/zigtools/zls/assets/2286349/bfc35580-0c63-4893-87ea-b52eab574837)

[This](https://github.com/orgs/community/discussions/26276#discussioncomment-3251140) is the easiest way to stop it.

