### PR TITLE
make variable declaration and parameter name hints separately configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ The following options are currently available.
 | `enable_import_embedfile_argument_completions` | `bool` | `true` | Whether to enable import/embedFile argument completions |
 | `semantic_tokens` | `enum` | `.full` | Set level of semantic tokens. Partial only includes information that requires semantic analysis. |
 | `enable_inlay_hints` | `bool` | `true` | Enables inlay hint support when the client also supports it |
+| `inlay_hints_show_variable_declaration` | `bool` | `true` | Enable inlay hints for variable declarations |
+| `inlay_hints_show_parameter_name` | `bool` | `true` | Enable inlay hints for parameter names |
 | `inlay_hints_show_builtin` | `bool` | `true` | Enable inlay hints for builtin functions |
 | `inlay_hints_exclude_single_argument` | `bool` | `true` | Don't show inlay hints for single argument calls |
 | `inlay_hints_hide_redundant_param_names` | `bool` | `false` | Hides inlay hints when parameter name matches the identifier (e.g. foo: foo) |

--- a/schema.json
+++ b/schema.json
@@ -49,6 +49,16 @@
             "type": "boolean",
             "default": "true"
         },
+        "inlay_hints_show_variable_declaration": {
+            "description": "Enable inlay hints for variable declarations",
+            "type": "boolean",
+            "default": "true"
+        },
+        "inlay_hints_show_parameter_name": {
+            "description": "Enable inlay hints for parameter names",
+            "type": "boolean",
+            "default": "true"
+        },
         "inlay_hints_show_builtin": {
             "description": "Enable inlay hints for builtin functions",
             "type": "boolean",

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -32,6 +32,12 @@ semantic_tokens: enum {
 /// Enables inlay hint support when the client also supports it
 enable_inlay_hints: bool = true,
 
+/// Enable inlay hints for variable declarations
+inlay_hints_show_variable_declaration: bool = true,
+
+/// Enable inlay hints for parameter names
+inlay_hints_show_parameter_name: bool = true,
+
 /// Enable inlay hints for builtin functions
 inlay_hints_show_builtin: bool = true,
 

--- a/src/config_gen/config.json
+++ b/src/config_gen/config.json
@@ -54,6 +54,18 @@
             "default": "true"
         },
         {
+            "name": "inlay_hints_show_variable_declaration",
+            "description": "Enable inlay hints for variable declarations",
+            "type": "bool",
+            "default": "true"
+        },
+        {
+            "name": "inlay_hints_show_parameter_name",
+            "description": "Enable inlay hints for parameter names",
+            "type": "bool",
+            "default": "true"
+        },
+        {
             "name": "inlay_hints_show_builtin",
             "description": "Enable inlay hints for builtin functions",
             "type": "bool",

--- a/src/features/inlay_hints.zig
+++ b/src/features/inlay_hints.zig
@@ -319,6 +319,8 @@ fn writeNodeInlayHint(
         .async_call,
         .async_call_comma,
         => {
+            if (!builder.config.inlay_hints_show_parameter_name) return;
+
             var params: [1]Ast.Node.Index = undefined;
             const call = tree.fullCall(&params, node).?;
             try writeCallNodeHint(builder, call);
@@ -328,17 +330,20 @@ fn writeNodeInlayHint(
         .global_var_decl,
         .aligned_var_decl,
         => {
+            if (!builder.config.inlay_hints_show_variable_declaration) return;
             try writeVariableDeclHint(builder, node);
         },
         .builtin_call_two,
         .builtin_call_two_comma,
         .builtin_call,
         .builtin_call_comma,
-        => blk: {
+        => {
+            if (!builder.config.inlay_hints_show_parameter_name or !builder.config.inlay_hints_show_builtin) return;
+
             var buffer: [2]Ast.Node.Index = undefined;
             const params = ast.builtinCallParams(tree, node, &buffer).?;
 
-            if (!builder.config.inlay_hints_show_builtin or params.len == 0) break :blk;
+            if (params.len == 0) return;
 
             const name = tree.tokenSlice(main_tokens[node]);
 


### PR DESCRIPTION
Adds "inlay_hints_show_variable_declaration" and "inlay_hints_show_parameter_name" to allow control of what hints are displayed.