### PR TITLE
update semantic tokens in response to #1454

### DIFF
--- a/src/features/semantic_tokens.zig
+++ b/src/features/semantic_tokens.zig
@@ -382,7 +382,7 @@ fn writeNodeTokens(builder: *Builder, node: Ast.Node.Index) error{OutOfMemory}!v
             while (tok_i < node_data[node].rhs) : (tok_i += 1) {
                 switch (token_tags[tok_i]) {
                     .doc_comment, .comma => {},
-                    .identifier => try writeToken(builder, tok_i, .errorTag),
+                    .identifier => try writeTokenMod(builder, tok_i, .errorTag, .{ .declaration = true }),
                     else => {},
                 }
             }
@@ -964,7 +964,7 @@ fn writeContainerField(builder: *Builder, node: Ast.Node.Index, container_decl: 
 
     try writeToken(builder, container_field.comptime_token, .keyword);
     if (!container_field.ast.tuple_like) {
-        try writeToken(builder, container_field.ast.main_token, field_token_type);
+        try writeTokenMod(builder, container_field.ast.main_token, field_token_type, .{ .declaration = true });
     }
 
     if (container_field.ast.type_expr != 0) {

--- a/tests/lsp_features/semantic_tokens.zig
+++ b/tests/lsp_features/semantic_tokens.zig
@@ -554,9 +554,9 @@ test "semantic tokens - struct" {
         .{ "Foo", .@"struct", .{ .declaration = true } },
         .{ "=", .operator, .{} },
         .{ "struct", .keyword, .{} },
-        .{ "alpha", .property, .{} },
+        .{ "alpha", .property, .{ .declaration = true } },
         .{ "u32", .type, .{} },
-        .{ "beta", .property, .{} },
+        .{ "beta", .property, .{ .declaration = true } },
         .{ "void", .type, .{} },
     });
     try testSemanticTokens(
@@ -569,12 +569,12 @@ test "semantic tokens - struct" {
         .{ "Foo", .@"struct", .{ .declaration = true } },
         .{ "=", .operator, .{} },
         .{ "struct", .keyword, .{} },
-        .{ "alpha", .property, .{} },
+        .{ "alpha", .property, .{ .declaration = true } },
         .{ "u32", .type, .{} },
         .{ "=", .operator, .{} },
         .{ "3", .number, .{} },
         .{ "comptime", .keyword, .{} },
-        .{ "beta", .property, .{} },
+        .{ "beta", .property, .{ .declaration = true } },
         .{ "void", .type, .{} },
         .{ "=", .operator, .{} },
     });
@@ -629,7 +629,7 @@ test "semantic tokens - union" {
         .{ "=", .operator, .{} },
         .{ "union", .keyword, .{} },
         .{ "E", .variable, .{} },
-        .{ "alpha", .property, .{} },
+        .{ "alpha", .property, .{ .declaration = true } },
     });
     try testSemanticTokens(
         \\const Foo = union(E) {
@@ -642,8 +642,8 @@ test "semantic tokens - union" {
         .{ "=", .operator, .{} },
         .{ "union", .keyword, .{} },
         .{ "E", .variable, .{} },
-        .{ "alpha", .property, .{} },
-        .{ "beta", .property, .{} },
+        .{ "alpha", .property, .{ .declaration = true } },
+        .{ "beta", .property, .{ .declaration = true } },
         .{ "void", .type, .{} },
     });
     try testSemanticTokens(
@@ -656,7 +656,7 @@ test "semantic tokens - union" {
         .{ "=", .operator, .{} },
         .{ "union", .keyword, .{} },
         .{ "E", .variable, .{} },
-        .{ "alpha", .property, .{} },
+        .{ "alpha", .property, .{ .declaration = true } },
         .{ "void", .type, .{} },
         .{ "align", .keyword, .{} },
         .{ "2", .number, .{} },
@@ -682,10 +682,10 @@ test "semantic tokens - enum" {
         .{ "Foo", .@"enum", .{ .declaration = true } },
         .{ "=", .operator, .{} },
         .{ "enum", .keyword, .{} },
-        .{ "alpha", .enumMember, .{} },
+        .{ "alpha", .enumMember, .{ .declaration = true } },
         .{ "=", .operator, .{} },
         .{ "3", .number, .{} },
-        .{ "beta", .enumMember, .{} },
+        .{ "beta", .enumMember, .{ .declaration = true } },
     });
     try testSemanticTokens(
         \\const Foo = enum(u4) {};
@@ -708,8 +708,8 @@ test "semantic tokens - enum member" {
         .{ "Foo", .@"enum", .{ .declaration = true } },
         .{ "=", .operator, .{} },
         .{ "enum", .keyword, .{} },
-        .{ "bar", .enumMember, .{} },
-        .{ "baz", .enumMember, .{} },
+        .{ "bar", .enumMember, .{ .declaration = true } },
+        .{ "baz", .enumMember, .{ .declaration = true } },
 
         .{ "const", .keyword, .{} },
         .{ "alpha", .variable, .{ .declaration = true } },
@@ -742,7 +742,7 @@ test "semantic tokens - error set" {
         .{ "Foo", .type, .{ .declaration = true } },
         .{ "=", .operator, .{} },
         .{ "error", .keyword, .{} },
-        .{ "OutOfMemory", .errorTag, .{} },
+        .{ "OutOfMemory", .errorTag, .{ .declaration = true } },
     });
 }
 
@@ -757,7 +757,7 @@ test "semantic tokens - error set member" {
         .{ "Foo", .type, .{ .declaration = true } },
         .{ "=", .operator, .{} },
         .{ "error", .keyword, .{} },
-        .{ "OutOfMemory", .errorTag, .{} },
+        .{ "OutOfMemory", .errorTag, .{ .declaration = true } },
 
         .{ "const", .keyword, .{} },
         .{ "bar", .variable, .{ .declaration = true } },

--- a/tests/lsp_features/semantic_tokens.zig
+++ b/tests/lsp_features/semantic_tokens.zig
@@ -824,6 +824,30 @@ test "semantic tokens - function" {
     });
 }
 
+test "semantic tokens - method" {
+    try testSemanticTokens(
+        \\const S = struct {
+        \\    fn create() S {}
+        \\    fn doTheThing(self: S) void {}
+        \\};
+    , &.{
+        .{ "const", .keyword, .{} },
+        .{ "S", .namespace, .{ .declaration = true } },
+        .{ "=", .operator, .{} },
+        .{ "struct", .keyword, .{} },
+
+        .{ "fn", .keyword, .{} },
+        .{ "create", .function, .{ .declaration = true } },
+        .{ "S", .namespace, .{} },
+
+        .{ "fn", .keyword, .{} },
+        .{ "doTheThing", .method, .{ .declaration = true } },
+        .{ "self", .parameter, .{ .declaration = true } },
+        .{ "S", .namespace, .{} },
+        .{ "void", .type, .{} },
+    });
+}
+
 test "semantic tokens - builtin fuctions" {
     try testSemanticTokens(
         \\const foo = @as(type, u32);


### PR DESCRIPTION
see #1454
- container field declaration were missing `TokenModifiers.declaration`.
- function that can participate in the "dot syntax" now use `TokenType.method`