### PR TITLE
`ast.lastToken`: Handle `switch` nodes containing an invalid condition

### DIFF
--- a/src/ast.zig
+++ b/src/ast.zig
@@ -616,7 +616,10 @@ pub fn lastToken(tree: Ast, node: Ast.Node.Index) Ast.TokenIndex {
         },
         .switch_comma, .@"switch" => {
             const lhs = datas[n].lhs;
-            const l_brace = tree.lastToken(lhs) + 2; //lparen + rbrace
+            var l_brace = tree.lastToken(lhs) + 2; // + 2 => (last) token of the condition + the .r_paren
+            // If the condition within the switch is invalid, eg `switch (a.) {}`,
+            // l_brace would be the index of the .r_paren of the switch ----^
+            if (token_tags[l_brace] != .l_brace) l_brace += 1;
             return findMatchingRBrace(token_tags, l_brace) orelse @intCast(tree.tokens.len - 1);
         },
         .@"asm" => {

--- a/tests/lsp_features/folding_range.zig
+++ b/tests/lsp_features/folding_range.zig
@@ -210,6 +210,15 @@ test "foldingRange - multi-line string literal" {
     });
 }
 
+test "foldingRange - invalid condition within a `switch`" {
+    try testFoldingRange(
+        \\switch (a.) {
+        \\}
+    , &.{
+        .{ .startLine = 0, .startCharacter = 11, .endLine = 1, .endCharacter = 0 },
+    });
+}
+
 fn testFoldingRange(source: []const u8, expect: []const types.FoldingRange) !void {
     var ctx = try Context.init();
     defer ctx.deinit();


### PR DESCRIPTION
Eg `switch (a.) {}`

```
thread 26165 panic: reached unreachable code
/home/rad/lab/zig/lib/std/debug.zig:342:14: 0x3d42f2 in assert (zls)
    if (!ok) unreachable; // assertion failure
             ^
/home/rad/lab/zls/npdm/src/ast.zig:71:21: 0x53f2f6 in findMatchingRBrace (zls)
    std.debug.assert(token_tags[l_brace] == TokenTag.l_brace);
                    ^
/home/rad/lab/zls/npdm/src/ast.zig:621:38: 0x4f1006 in lastToken (zls)
            return findMatchingRBrace(token_tags, l_brace) orelse @intCast(tree.tokens.len - 1);
                                     ^
/home/rad/lab/zls/npdm/src/features/folding_range.zig:204:46: 0x52fb61 in generateFoldingRanges (zls)
                const end_tok = ast.lastToken(tree, node);

...
```