### PR TITLE
emit variable semantic token even when semantic_tokens is set to partial

### DIFF
--- a/src/features/semantic_tokens.zig
+++ b/src/features/semantic_tokens.zig
@@ -137,6 +137,7 @@ const Builder = struct {
             .interface,
             .@"struct",
             .typeParameter,
+            .variable,
             .property,
             .enumMember,
             .event,
@@ -154,7 +155,6 @@ const Builder = struct {
             => token_type = .type,
 
             .parameter,
-            .variable,
             .keyword,
             .comment,
             .string,

--- a/tests/lsp_features/semantic_tokens.zig
+++ b/tests/lsp_features/semantic_tokens.zig
@@ -216,7 +216,7 @@ test "semantic tokens - operators" {
     });
 }
 
-test "semantic tokens - field access" {
+test "semantic tokens - field access with @import" {
     if (!std.process.can_spawn) return error.SkipZigTest;
     // this will make sure that the std module can be resolved
     try testSemanticTokens(
@@ -244,6 +244,30 @@ test "semantic tokens - field access" {
         .{ "std", .namespace, .{} },
         .{ "zig", .namespace, .{} },
         .{ "Ast", .@"struct", .{} },
+    });
+}
+
+test "semantic tokens - field access" {
+    try testSemanticTokens(
+        \\const S = struct {
+        \\    const @"u32" = 5;
+        \\};
+        \\const alpha = S.u32;
+    , &.{
+        .{ "const", .keyword, .{} },
+        .{ "S", .namespace, .{ .declaration = true } },
+        .{ "=", .operator, .{} },
+        .{ "struct", .keyword, .{} },
+        .{ "const", .keyword, .{} },
+        .{ "@\"u32\"", .variable, .{ .declaration = true } },
+        .{ "=", .operator, .{} },
+        .{ "5", .number, .{} },
+
+        .{ "const", .keyword, .{} },
+        .{ "alpha", .variable, .{ .declaration = true } },
+        .{ "=", .operator, .{} },
+        .{ "S", .namespace, .{} },
+        .{ "u32", .variable, .{} },
     });
 }
 


### PR DESCRIPTION
In the following code snippet, the `u32` in `S.u32` is a variable even though tokenization considers it a keyword.
```zig
const S = struct {
    const @"u32" = 5;
};
const alpha = S.u32;
```