### PR TITLE
Fix panic when parsing `array_hash_map.zig`

### DIFF
--- a/src/build_runner/master.zig
+++ b/src/build_runner/master.zig
@@ -336,6 +336,10 @@ const copied_from_zig = struct {
             .path => |p| return builder.pathFromRoot(p),
             .cwd_relative => |p| return pathFromCwd(builder, p),
             .generated => |gen| return builder.pathFromRoot(gen.path orelse return null),
+            .dependency => |dep| return dep.dependency.builder.pathJoin(&[_][]const u8{
+                dep.dependency.builder.build_root.path.?,
+                dep.sub_path,
+            }),
         }
     }
 

--- a/src/features/inlay_hints.zig
+++ b/src/features/inlay_hints.zig
@@ -128,7 +128,7 @@ fn writeCallHint(builder: *Builder, call: Ast.full.Call, decl_handle: Analyser.D
     }
 
     const has_self_param = call.ast.params.len + 1 == params.items.len and
-        try builder.analyser.isInstanceCall(handle, call, decl_handle.handle, fn_proto);
+        try builder.analyser.isInstanceCall(handle, call, resolved_decl_handle.handle, fn_proto);
 
     const parameters = params.items[@intFromBool(has_self_param)..];
     const arguments = call.ast.params;


### PR DESCRIPTION
Fixes: https://github.com/zigtools/zls/issues/1465

Changes:
inlay_hints: fix incorrect handle being passed to isInstanceCall when resolved_decl != decl_handle
build_runner: fixup for latest changes in master