### PR TITLE
remove unnecessary config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ The following options are currently available.
 | `enable_ast_check_diagnostics` | `bool` | `true` | Whether to enable ast-check diagnostics |
 | `enable_build_on_save` | `bool` | `false` | Whether to enable build-on-save diagnostics |
 | `enable_autofix` | `bool` | `true` | Whether to automatically fix errors on save. Currently supports adding and removing discards. |
-| `enable_import_embedfile_argument_completions` | `bool` | `true` | Whether to enable import/embedFile argument completions |
 | `semantic_tokens` | `enum` | `.full` | Set level of semantic tokens. Partial only includes information that requires semantic analysis. |
 | `enable_inlay_hints` | `bool` | `true` | Enables inlay hint support when the client also supports it |
 | `inlay_hints_show_variable_declaration` | `bool` | `true` | Enable inlay hints for variable declarations |
@@ -70,13 +69,10 @@ The following options are currently available.
 | `inlay_hints_exclude_single_argument` | `bool` | `true` | Don't show inlay hints for single argument calls |
 | `inlay_hints_hide_redundant_param_names` | `bool` | `false` | Hides inlay hints when parameter name matches the identifier (e.g. foo: foo) |
 | `inlay_hints_hide_redundant_param_names_last_token` | `bool` | `false` | Hides inlay hints when parameter name matches the last token of a parameter node (e.g. foo: bar.foo, foo: &foo) |
-| `operator_completions` | `bool` | `true` | Enables `*` and `?` operators in completion lists |
 | `warn_style` | `bool` | `false` | Enables warnings for style guideline mismatches |
 | `highlight_global_var_declarations` | `bool` | `false` | Whether to highlight global var declarations |
 | `dangerous_comptime_experiments_do_not_enable` | `bool` | `false` | Whether to use the comptime interpreter |
-| `include_at_in_builtins` | `bool` | `false` | Whether the @ sign should be part of the completion of builtins |
 | `skip_std_references` | `bool` | `false` | When true, skips searching for references in std. Improves lookup speed for functions in user's code. Renaming and go-to-definition will continue to work as is |
-| `max_detail_length` | `usize` | `1048576` | The detail field of completions is truncated to be no longer than this (in bytes) |
 | `prefer_ast_check_as_child_process` | `bool` | `true` | Can be used in conjuction with `enable_ast_check_diagnostics` to favor using `zig ast-check` instead of ZLS's fork |
 | `record_session` | `bool` | `false` | When true, zls will record all request is receives and write in into `record_session_path`, so that they can replayed with `zls replay` |
 | `record_session_path` | `?[]const u8` | `null` | Output file path when `record_session` is set. The recommended file extension *.zlsreplay |

--- a/schema.json
+++ b/schema.json
@@ -29,11 +29,6 @@
             "type": "boolean",
             "default": "true"
         },
-        "enable_import_embedfile_argument_completions": {
-            "description": "Whether to enable import/embedFile argument completions",
-            "type": "boolean",
-            "default": "true"
-        },
         "semantic_tokens": {
             "description": "Set level of semantic tokens. Partial only includes information that requires semantic analysis.",
             "type": "string",
@@ -79,11 +74,6 @@
             "type": "boolean",
             "default": "false"
         },
-        "operator_completions": {
-            "description": "Enables `*` and `?` operators in completion lists",
-            "type": "boolean",
-            "default": "true"
-        },
         "warn_style": {
             "description": "Enables warnings for style guideline mismatches",
             "type": "boolean",
@@ -99,20 +89,10 @@
             "type": "boolean",
             "default": "false"
         },
-        "include_at_in_builtins": {
-            "description": "Whether the @ sign should be part of the completion of builtins",
-            "type": "boolean",
-            "default": "false"
-        },
         "skip_std_references": {
             "description": "When true, skips searching for references in std. Improves lookup speed for functions in user's code. Renaming and go-to-definition will continue to work as is",
             "type": "boolean",
             "default": "false"
-        },
-        "max_detail_length": {
-            "description": "The detail field of completions is truncated to be no longer than this (in bytes)",
-            "type": "integer",
-            "default": "1048576"
         },
         "prefer_ast_check_as_child_process": {
             "description": "Can be used in conjuction with `enable_ast_check_diagnostics` to favor using `zig ast-check` instead of ZLS's fork",

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -19,9 +19,6 @@ enable_build_on_save: bool = false,
 /// Whether to automatically fix errors on save. Currently supports adding and removing discards.
 enable_autofix: bool = true,
 
-/// Whether to enable import/embedFile argument completions
-enable_import_embedfile_argument_completions: bool = true,
-
 /// Set level of semantic tokens. Partial only includes information that requires semantic analysis.
 semantic_tokens: enum {
     none,
@@ -50,9 +47,6 @@ inlay_hints_hide_redundant_param_names: bool = false,
 /// Hides inlay hints when parameter name matches the last token of a parameter node (e.g. foo: bar.foo, foo: &foo)
 inlay_hints_hide_redundant_param_names_last_token: bool = false,
 
-/// Enables `*` and `?` operators in completion lists
-operator_completions: bool = true,
-
 /// Enables warnings for style guideline mismatches
 warn_style: bool = false,
 
@@ -62,14 +56,8 @@ highlight_global_var_declarations: bool = false,
 /// Whether to use the comptime interpreter
 dangerous_comptime_experiments_do_not_enable: bool = false,
 
-/// Whether the @ sign should be part of the completion of builtins
-include_at_in_builtins: bool = false,
-
 /// When true, skips searching for references in std. Improves lookup speed for functions in user's code. Renaming and go-to-definition will continue to work as is
 skip_std_references: bool = false,
-
-/// The detail field of completions is truncated to be no longer than this (in bytes)
-max_detail_length: usize = 1048576,
 
 /// Can be used in conjuction with `enable_ast_check_diagnostics` to favor using `zig ast-check` instead of ZLS's fork
 prefer_ast_check_as_child_process: bool = true,

--- a/src/config_gen/config.json
+++ b/src/config_gen/config.json
@@ -31,12 +31,6 @@
             "default": "true"
         },
         {
-            "name": "enable_import_embedfile_argument_completions",
-            "description": "Whether to enable import/embedFile argument completions",
-            "type": "bool",
-            "default": "true"
-        },
-        {
             "name": "semantic_tokens",
             "description": "Set level of semantic tokens. Partial only includes information that requires semantic analysis.",
             "type": "enum",
@@ -90,12 +84,6 @@
             "default": "false"
         },
         {
-            "name": "operator_completions",
-            "description": "Enables `*` and `?` operators in completion lists",
-            "type": "bool",
-            "default": "true"
-        },
-        {
             "name": "warn_style",
             "description": "Enables warnings for style guideline mismatches",
             "type": "bool",
@@ -114,22 +102,10 @@
             "default": "false"
         },
         {
-            "name": "include_at_in_builtins",
-            "description": "Whether the @ sign should be part of the completion of builtins",
-            "type": "bool",
-            "default": "false"
-        },
-        {
             "name": "skip_std_references",
             "description": "When true, skips searching for references in std. Improves lookup speed for functions in user's code. Renaming and go-to-definition will continue to work as is",
             "type": "bool",
             "default": "false"
-        },
-        {
-            "name": "max_detail_length",
-            "description": "The detail field of completions is truncated to be no longer than this (in bytes)",
-            "type": "usize",
-            "default": "1048576"
         },
         {
             "name": "prefer_ast_check_as_child_process",

--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -48,14 +48,12 @@ fn typeToCompletion(
             }
         },
         .pointer => |t| {
-            if (server.config.operator_completions) {
-                try list.append(arena, .{
-                    .label = "*",
-                    .kind = .Operator,
-                    .insertText = "*",
-                    .insertTextFormat = .PlainText,
-                });
-            }
+            try list.append(arena, .{
+                .label = "*",
+                .kind = .Operator,
+                .insertText = "*",
+                .insertTextFormat = .PlainText,
+            });
             try typeToCompletion(server, analyser, arena, list, .{ .original = t.* }, orig_handle, null);
         },
         .other => |n| try nodeToCompletion(
@@ -305,7 +303,7 @@ fn nodeToCompletion(
             const ptr_type = ast.fullPtrType(tree, node).?;
 
             switch (ptr_type.size) {
-                .One, .C, .Many => if (server.config.operator_completions) {
+                .One, .C, .Many => {
                     try list.append(arena, .{
                         .label = "*",
                         .kind = .Operator,
@@ -337,15 +335,12 @@ fn nodeToCompletion(
             return;
         },
         .optional_type => {
-            if (server.config.operator_completions) {
-                try list.append(arena, .{
-                    .label = "?",
-                    .kind = .Operator,
-                    .insertText = "?",
-                    .insertTextFormat = .PlainText,
-                });
-            }
-            return;
+            try list.append(arena, .{
+                .label = "?",
+                .kind = .Operator,
+                .insertText = "?",
+                .insertTextFormat = .PlainText,
+            });
         },
         .multiline_string_literal,
         .string_literal,
@@ -537,7 +532,7 @@ fn completeBuiltin(server: *Server, arena: std.mem.Allocator) error{OutOfMemory}
             .kind = .Function,
             .filterText = builtin.name[1..],
             .detail = builtin.signature,
-            .insertText = if (server.config.include_at_in_builtins) insert_text else insert_text[1..],
+            .insertText = if (server.client_capabilities.include_at_in_builtins) insert_text else insert_text[1..],
             .insertTextFormat = if (use_snippets) .Snippet else .PlainText,
             .documentation = .{
                 .MarkupContent = .{
@@ -1442,13 +1437,9 @@ pub fn completionAtIndex(server: *Server, analyser: *Analyser, arena: std.mem.Al
         .import_string_literal,
         .cinclude_string_literal,
         .embedfile_string_literal,
-        => blk: {
-            if (!server.config.enable_import_embedfile_argument_completions) break :blk null;
-
-            break :blk completeFileSystemStringLiteral(arena, server.document_store, handle.*, pos_context) catch |err| {
-                log.err("failed to get file system completions: {}", .{err});
-                return null;
-            };
+        => completeFileSystemStringLiteral(arena, server.document_store, handle.*, pos_context) catch |err| {
+            log.err("failed to get file system completions: {}", .{err});
+            return null;
         },
         else => null,
     };
@@ -1488,8 +1479,8 @@ pub fn completionAtIndex(server: *Server, analyser: *Analyser, arena: std.mem.Al
     // truncate completions
     for (completions) |*item| {
         if (item.detail) |det| {
-            if (det.len > server.config.max_detail_length) {
-                item.detail = det[0..server.config.max_detail_length];
+            if (det.len > server.client_capabilities.max_detail_length) {
+                item.detail = det[0..server.client_capabilities.max_detail_length];
             }
         }
     }


### PR DESCRIPTION
`enable_import_embedfile_argument_completions` existed because this option has been buggy in the past but not anymore.

`include_at_in_builtins` is a workaround for builtin completions in sublime text 3 which can instead be detected by
inspecting the `clientInfo` field in initialize request.

`max_detail_length` is a workaround for long completion detail entries bricking the preview window in Sublime Text #261 which can also be detected through the `clientInfo` field.

`operator_completions` this option has been added when this feature was implemented but is there anyone who needs it?