### PR TITLE
fix integer overflow on dot completion at beginning of file

### DIFF
--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -1240,8 +1240,8 @@ fn completeDot(document_store: *DocumentStore, analyser: *Analyser, arena: std.m
 
     // as invoked source_index points to the char/token after the `.`, do `- 1`
     var dot_token_index = offsets.sourceIndexToTokenIndex(tree, source_index - 1);
+    if (dot_token_index < 2) return &.{};
 
-    // if (dot_token_index < 2) exit;
     var completions = std.ArrayListUnmanaged(types.CompletionItem){};
 
     // This prevents completions popping up for floating point numbers

--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -1051,6 +1051,12 @@ test "completion - integer overflow in struct init field without lhs" {
     , &.{});
 }
 
+test "completion - integer overflow in dot completions at beginning of file" {
+    try testCompletion(
+        \\.<cursor>
+    , &.{});
+}
+
 fn testCompletion(source: []const u8, expected_completions: []const Completion) !void {
     const cursor_idx = std.mem.indexOf(u8, source, "<cursor>").?;
     const text = try std.mem.concat(allocator, u8, &.{ source[0..cursor_idx], source[cursor_idx + "<cursor>".len ..] });


### PR DESCRIPTION
```zig
.<completions here>
```

```
thread 2199 panic: integer overflow
/run/media/techatrix/UserFiles/zls/src/features/completions.zig:1250:54: 0x574a2c in completeDot (zls)
    var token_index = if (token_tags[dot_token_index - 1] == .number_literal) (dot_token_index - 2) else (dot_token_index - 1);
                                                     ^
/run/media/techatrix/UserFiles/zls/src/features/completions.zig:1440:41: 0x51217f in completionAtIndex (zls)
        .enum_literal => try completeDot(&server.document_store, analyser, arena, handle, source_index),
                                        ^
/run/media/techatrix/UserFiles/zls/src/Server.zig:1230:60: 0x4d778f in completionHandler (zls)
        .CompletionList = try completions.completionAtIndex(server, &analyser, arena, handle, source_index) orelse return null,
                                                           ^
/run/media/techatrix/UserFiles/zls/src/Server.zig:1933:68: 0x4a88a6 in sendRequestSync__anon_26295 (zls)
        .@"textDocument/completion" => try server.completionHandler(arena, params),
                                                                   ^
/run/media/techatrix/UserFiles/zls/src/Server.zig:2009:58: 0x46a31e in processMessage (zls)
                const result = try server.sendRequestSync(arena_allocator.allocator(), @tagName(method), params);
                                                         ^
/run/media/techatrix/UserFiles/zls/src/Server.zig:2026:33: 0x4131b5 in processMessageReportError (zls)
    return server.processMessage(message) catch |err| {
                                ^
/run/media/techatrix/UserFiles/zls/src/Server.zig:2064:62: 0x3ed831 in processJob (zls)
            const response = server.processMessageReportError(parsed_message.value) orelse return;
                                                             ^
/nix/store/a636h639y0vcjhx9jd1vc3p0hqfb3fxp-zig-0.12.0-dev.415+5af5d87ad/lib/std/Thread/Pool.zig:94:39: 0x3eca1e in runFn (zls)
            @call(.auto, func, closure.arguments);
                                      ^
/nix/store/a636h639y0vcjhx9jd1vc3p0hqfb3fxp-zig-0.12.0-dev.415+5af5d87ad/lib/std/Thread/Pool.zig:133:18: 0x496e84 in worker (zls)
            runFn(&run_node.data);
                 ^
/nix/store/a636h639y0vcjhx9jd1vc3p0hqfb3fxp-zig-0.12.0-dev.415+5af5d87ad/lib/std/Thread.zig:412:13: 0x45492d in callFn__anon_22729 (zls)
            @call(.auto, f, args);
            ^
/nix/store/a636h639y0vcjhx9jd1vc3p0hqfb3fxp-zig-0.12.0-dev.415+5af5d87ad/lib/std/Thread.zig:1210:30: 0x3fc1b3 in entryFn (zls)
                return callFn(f, self.fn_args);
                             ^
/nix/store/a636h639y0vcjhx9jd1vc3p0hqfb3fxp-zig-0.12.0-dev.415+5af5d87ad/lib/c.zig:239:13: 0x94f570 in clone (c)
            asm volatile (
            ^
???:?:?: 0x0 in ??? (???)
```