### PR TITLE
resolve primitive types and values using InternPool

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -1597,9 +1597,6 @@ pub const Type = struct {
         /// Branching types
         either: []const EitherEntry,
 
-        // TODO: Unused?
-        array_index,
-
         ip_index: struct {
             node: ?Ast.Node.Index = null,
             /// this stores both the type and the value
@@ -1636,7 +1633,6 @@ pub const TypeWithHandle = struct {
                         hashTypeWithHandle(hasher, e.type_with_handle);
                     }
                 },
-                .array_index => {},
                 .ip_index => |payload| {
                     std.hash.autoHash(hasher, payload.node);
                     std.hash.autoHash(hasher, payload.index);
@@ -1688,7 +1684,6 @@ pub const TypeWithHandle = struct {
                         if (!self.eql(ae.type_with_handle, be.type_with_handle)) return false;
                     }
                 },
-                .array_index => {},
                 .ip_index => |a_payload| {
                     const b_payload = b.type.data.ip_index;
 
@@ -1744,7 +1739,7 @@ pub const TypeWithHandle = struct {
         };
     }
 
-    /// Resolves possible types of a type (single for all except array_index and either)
+    /// Resolves possible types of a type (single for all except either)
     /// Drops duplicates
     pub fn getAllTypesWithHandles(ty: TypeWithHandle, arena: std.mem.Allocator) ![]const TypeWithHandle {
         var all_types = std.ArrayListUnmanaged(TypeWithHandle){};
@@ -2545,7 +2540,6 @@ pub const Declaration = union(enum) {
         node: Ast.Node.Index,
         index: u32,
     },
-    array_index: Ast.TokenIndex,
     switch_payload: Switch,
     label_decl: struct {
         label: Ast.TokenIndex,
@@ -2631,7 +2625,6 @@ pub const DeclWithHandle = struct {
             .error_union_payload => |ep| ep.name,
             .error_union_error => |ep| ep.name,
             .array_payload => |ap| ap.identifier,
-            .array_index => |ai| ai,
             .label_decl => |ld| ld.label,
             .error_token => |et| et,
             .assign_destructure => |payload| {
@@ -2813,10 +2806,6 @@ pub const DeclWithHandle = struct {
                 .Single,
             ),
             .assign_destructure => null, // TODO
-            .array_index => TypeWithHandle{
-                .type = .{ .data = .array_index, .is_type_val = false },
-                .handle = self.handle,
-            },
             .label_decl => |decl| try analyser.resolveTypeOfNodeInternal(.{
                 .node = decl.block,
                 .handle = self.handle,

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -737,38 +737,48 @@ fn resolveBracketAccessType(analyser: *Analyser, lhs: TypeWithHandle, rhs: enum 
 
     const tree = lhs.handle.tree;
     const tags = tree.nodes.items(.tag);
-    const tag = tags[lhs_node];
-    const data = tree.nodes.items(.data)[lhs_node];
 
-    if (tag == .array_type or tag == .array_type_sentinel) {
-        const child_type = (try analyser.resolveTypeOfNodeInternal(.{
-            .node = data.rhs,
+    switch (tags[lhs_node]) {
+        .array_type, .array_type_sentinel => {
+            const child_type = (try analyser.resolveTypeOfNodeInternal(.{
+                .node = tree.nodes.items(.data)[lhs_node].rhs,
+                .handle = lhs.handle,
+            })) orelse return null;
+            if (rhs == .Single)
+                return child_type.instanceTypeVal();
+            const child_type_ptr = try analyser.arena.allocator().create(TypeWithHandle);
+            child_type_ptr.* = child_type.instanceTypeVal() orelse return null;
+            return TypeWithHandle{
+                .type = .{ .data = .{ .slice = child_type_ptr }, .is_type_val = false },
+                .handle = lhs.handle,
+            };
+        },
+        .ptr_type_aligned,
+        .ptr_type_sentinel,
+        .ptr_type,
+        .ptr_type_bit_range,
+        => {
+            const ptr_type = ast.fullPtrType(tree, lhs_node).?;
+            switch (ptr_type.size) {
+                .Slice, .C, .Many => {
+                    if (rhs == .Single) {
+                        return ((try analyser.resolveTypeOfNodeInternal(.{
+                            .node = ptr_type.ast.child_type,
+                            .handle = lhs.handle,
+                        })) orelse return null).instanceTypeVal();
+                    }
+                    return lhs;
+                },
+                .One => {},
+            }
+            return null;
+        },
+        .for_range => return TypeWithHandle{
+            .type = .{ .data = .{ .ip_index = .{ .index = .usize_type } }, .is_type_val = false },
             .handle = lhs.handle,
-        })) orelse return null;
-        if (rhs == .Single)
-            return child_type.instanceTypeVal();
-        const child_type_ptr = try analyser.arena.allocator().create(TypeWithHandle);
-        child_type_ptr.* = child_type.instanceTypeVal() orelse return null;
-        return TypeWithHandle{
-            .type = .{ .data = .{ .slice = child_type_ptr }, .is_type_val = false },
-            .handle = lhs.handle,
-        };
-    } else if (ast.fullPtrType(tree, lhs_node)) |ptr_type| {
-        switch (ptr_type.size) {
-            .Slice, .C, .Many => {
-                if (rhs == .Single) {
-                    return ((try analyser.resolveTypeOfNodeInternal(.{
-                        .node = ptr_type.ast.child_type,
-                        .handle = lhs.handle,
-                    })) orelse return null).instanceTypeVal();
-                }
-                return lhs;
-            },
-            .One => {},
-        }
+        },
+        else => return null,
     }
-
-    return null;
 }
 
 /// Called to remove one level of pointerness before a field access
@@ -1561,6 +1571,11 @@ fn resolveTypeOfNodeUncached(analyser: *Analyser, node_handle: NodeWithHandle) e
             }
         },
 
+        .for_range => return TypeWithHandle{
+            .type = .{ .data = .{ .other = node }, .is_type_val = false },
+            .handle = handle,
+        },
+
         .equal_equal,
         .bang_equal,
         .less_than,
@@ -1685,7 +1700,6 @@ fn resolveTypeOfNodeUncached(analyser: *Analyser, node_handle: NodeWithHandle) e
         .switch_case,
         .switch_case_inline,
         .switch_range,
-        .for_range,
         .@"continue",
         .@"break",
         .@"return",

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -821,7 +821,7 @@ fn resolvePropertyType(analyser: *Analyser, type_handle: TypeWithHandle, name: [
         .slice => |t| {
             if (std.mem.eql(u8, "len", name)) {
                 return TypeWithHandle{
-                    .type = .{ .data = .{ .primitive = "usize" }, .is_type_val = false },
+                    .type = .{ .data = .{ .ip_index = .{ .index = .usize_type } }, .is_type_val = false },
                     .handle = handle,
                 };
             }
@@ -841,7 +841,7 @@ fn resolvePropertyType(analyser: *Analyser, type_handle: TypeWithHandle, name: [
             .string_literal,
             => if (std.mem.eql(u8, "len", name)) {
                 return TypeWithHandle{
-                    .type = .{ .data = .{ .primitive = "usize" }, .is_type_val = false },
+                    .type = .{ .data = .{ .ip_index = .{ .index = .usize_type } }, .is_type_val = false },
                     .handle = handle,
                 };
             },
@@ -856,7 +856,7 @@ fn resolvePropertyType(analyser: *Analyser, type_handle: TypeWithHandle, name: [
                 if (ptr_type.size == .Slice) {
                     if (std.mem.eql(u8, "len", name)) {
                         return TypeWithHandle{
-                            .type = .{ .data = .{ .primitive = "usize" }, .is_type_val = false },
+                            .type = .{ .data = .{ .ip_index = .{ .index = .usize_type } }, .is_type_val = false },
                             .handle = handle,
                         };
                     }
@@ -910,41 +910,64 @@ fn allDigits(str: []const u8) bool {
     return true;
 }
 
-const primitive_types = std.ComptimeStringMap([]const u8, .{
-    .{ "true", "bool" },
-    .{ "false", "bool" },
-    .{ "null", "@TypeOf(null)" },
-    .{ "undefined", "@TypeOf(undefined)" },
+const primitives = std.ComptimeStringMap(InternPool.Index, .{
+    .{ "anyerror", .anyerror_type },
+    .{ "anyframe", .anyframe_type },
+    .{ "anyopaque", .anyopaque_type },
+    .{ "bool", .bool_type },
+    .{ "c_int", .c_int_type },
+    .{ "c_long", .c_long_type },
+    .{ "c_longdouble", .c_longdouble_type },
+    .{ "c_longlong", .c_longlong_type },
+    .{ "c_char", .c_char_type },
+    .{ "c_short", .c_short_type },
+    .{ "c_uint", .c_uint_type },
+    .{ "c_ulong", .c_ulong_type },
+    .{ "c_ulonglong", .c_ulonglong_type },
+    .{ "c_ushort", .c_ushort_type },
+    .{ "comptime_float", .comptime_float_type },
+    .{ "comptime_int", .comptime_int_type },
+    .{ "f128", .f128_type },
+    .{ "f16", .f16_type },
+    .{ "f32", .f32_type },
+    .{ "f64", .f64_type },
+    .{ "f80", .f80_type },
+    .{ "false", .bool_false },
+    .{ "i16", .i16_type },
+    .{ "i32", .i32_type },
+    .{ "i64", .i64_type },
+    .{ "i128", .i128_type },
+    .{ "i8", .i8_type },
+    .{ "isize", .isize_type },
+    .{ "noreturn", .noreturn_type },
+    .{ "null", .null_value },
+    .{ "true", .bool_true },
+    .{ "type", .type_type },
+    .{ "u16", .u16_type },
+    .{ "u29", .u29_type },
+    .{ "u32", .u32_type },
+    .{ "u64", .u64_type },
+    .{ "u128", .u128_type },
+    .{ "u1", .u1_type },
+    .{ "u8", .u8_type },
+    .{ "undefined", .undefined_type },
+    .{ "usize", .usize_type },
+    .{ "void", .void_type },
 });
 
-pub fn isValueIdent(text: []const u8) bool {
-    return primitive_types.has(text);
-}
+pub fn resolvePrimitiveType(identifier_name: []const u8) ?InternPool.Index {
+    if (primitives.get(identifier_name)) |primitive| return primitive;
 
-pub fn isTypeIdent(text: []const u8) bool {
-    const PrimitiveTypes = std.ComptimeStringMap(void, .{
-        .{"isize"},        .{"usize"},
-        .{"c_short"},      .{"c_ushort"},
-        .{"c_int"},        .{"c_uint"},
-        .{"c_long"},       .{"c_ulong"},
-        .{"c_longlong"},   .{"c_ulonglong"},
-        .{"c_longdouble"}, .{"anyopaque"},
-        .{"f16"},          .{"f32"},
-        .{"f64"},          .{"f80"},
-        .{"f128"},         .{"bool"},
-        .{"void"},         .{"noreturn"},
-        .{"type"},         .{"anyerror"},
-        .{"comptime_int"}, .{"comptime_float"},
-        .{"anyframe"},     .{"anytype"},
-        .{"c_char"},
-    });
-
-    if (PrimitiveTypes.has(text)) return true;
-    if (text.len == 1) return false;
-    if (!(text[0] == 'u' or text[0] == 'i')) return false;
-    if (!allDigits(text[1..])) return false;
-    _ = std.fmt.parseUnsigned(u16, text[1..], 10) catch return false;
-    return true;
+    if (identifier_name.len < 2) return null;
+    const first_c = identifier_name[0];
+    if (first_c != 'i' and first_c != 'u') return null;
+    for (identifier_name[1..]) |c| {
+        switch (c) {
+            '0'...'9' => {},
+            else => return null,
+        }
+    }
+    return .unknown_type; // TODO
 }
 
 const FindBreaks = struct {
@@ -1049,16 +1072,10 @@ fn resolveTypeOfNodeUncached(analyser: *Analyser, node_handle: NodeWithHandle) e
         .identifier => {
             const name = offsets.nodeToSlice(tree, node);
 
-            if (isTypeIdent(name)) {
+            if (resolvePrimitiveType(name)) |primitive| {
+                const is_type = analyser.ip.?.indexToKey(primitive).typeOf() == .type_type;
                 return TypeWithHandle{
-                    .type = .{ .data = .{ .primitive = name }, .is_type_val = true },
-                    .handle = handle,
-                };
-            }
-
-            if (isValueIdent(name)) {
-                return TypeWithHandle{
-                    .type = .{ .data = .{ .other = node }, .is_type_val = false },
+                    .type = .{ .data = .{ .ip_index = .{ .index = primitive } }, .is_type_val = is_type },
                     .handle = handle,
                 };
             }
@@ -1227,7 +1244,7 @@ fn resolveTypeOfNodeUncached(analyser: *Analyser, node_handle: NodeWithHandle) e
                     field.convertToNonTupleLike(tree.nodes);
                     if (field.ast.type_expr == 0)
                         return TypeWithHandle{
-                            .type = .{ .data = .{ .primitive = "void" }, .is_type_val = false },
+                            .type = .{ .data = .{ .ip_index = .{ .index = .void_type } }, .is_type_val = false },
                             .handle = handle,
                         };
                 }
@@ -1296,7 +1313,6 @@ fn resolveTypeOfNodeUncached(analyser: *Analyser, node_handle: NodeWithHandle) e
                 return try child.resolveType(analyser);
             } else return null;
         },
-        .anyframe_literal,
         .anyframe_type,
         .array_type,
         .array_type_sentinel,
@@ -1430,16 +1446,6 @@ fn resolveTypeOfNodeUncached(analyser: *Analyser, node_handle: NodeWithHandle) e
                 .handle = handle,
             };
         },
-        .multiline_string_literal,
-        .string_literal,
-        .char_literal,
-        .number_literal,
-        .enum_literal,
-        .error_value,
-        => return TypeWithHandle{
-            .type = .{ .data = .{ .other = node }, .is_type_val = false },
-            .handle = handle,
-        },
         .@"if", .if_simple => {
             const if_node = ast.fullIf(tree, node).?;
 
@@ -1554,7 +1560,147 @@ fn resolveTypeOfNodeUncached(analyser: *Analyser, node_handle: NodeWithHandle) e
                     return operand_type;
             }
         },
-        else => {},
+
+        .equal_equal,
+        .bang_equal,
+        .less_than,
+        .greater_than,
+        .less_or_equal,
+        .greater_or_equal,
+        .bool_and,
+        .bool_or,
+        .bool_not,
+        .negation,
+        => return TypeWithHandle{
+            .type = .{ .data = .{ .ip_index = .{ .index = .bool_type } }, .is_type_val = false },
+            .handle = handle,
+        },
+
+        .multiline_string_literal,
+        .string_literal,
+        .error_value, // TODO
+        => return TypeWithHandle{
+            .type = .{ .data = .{ .other = node }, .is_type_val = false },
+            .handle = handle,
+        },
+
+        .char_literal => return TypeWithHandle{
+            .type = .{ .data = .{ .ip_index = .{ .index = .comptime_int_type } }, .is_type_val = false },
+            .handle = handle,
+        },
+
+        .number_literal => {
+            const bytes = offsets.tokenToSlice(tree, main_tokens[node]);
+            const result = std.zig.parseNumberLiteral(bytes);
+            const index: InternPool.Index = switch (result) {
+                .int,
+                .big_int,
+                => .comptime_int_type,
+                .float => .comptime_float_type,
+                .failure => return null,
+            };
+            return TypeWithHandle{
+                .type = .{ .data = .{ .ip_index = .{ .index = index } }, .is_type_val = false },
+                .handle = handle,
+            };
+        },
+
+        .enum_literal => return TypeWithHandle{
+            .type = .{ .data = .{ .ip_index = .{ .index = .enum_literal_type } }, .is_type_val = false },
+            .handle = handle,
+        },
+        .unreachable_literal => return TypeWithHandle{
+            .type = .{ .data = .{ .ip_index = .{ .index = .noreturn_type } }, .is_type_val = false },
+            .handle = handle,
+        },
+
+        .anyframe_literal => return TypeWithHandle{
+            .type = .{ .data = .{ .ip_index = .{ .index = .anyframe_type } }, .is_type_val = false },
+            .handle = handle,
+        },
+
+        .mul,
+        .div,
+        .mod,
+        .mul_wrap,
+        .mul_sat,
+        .add,
+        .sub,
+        .add_wrap,
+        .sub_wrap,
+        .add_sat,
+        .sub_sat,
+        .shl,
+        .shl_sat,
+        .shr,
+        .bit_and,
+        .bit_xor,
+        .bit_or,
+        .bit_not,
+        .negation_wrap,
+        => {},
+
+        .array_mult,
+        .array_cat,
+        => {},
+
+        .assign_mul,
+        .assign_div,
+        .assign_mod,
+        .assign_add,
+        .assign_sub,
+        .assign_shl,
+        .assign_shl_sat,
+        .assign_shr,
+        .assign_bit_and,
+        .assign_bit_xor,
+        .assign_bit_or,
+        .assign_mul_wrap,
+        .assign_add_wrap,
+        .assign_sub_wrap,
+        .assign_mul_sat,
+        .assign_add_sat,
+        .assign_sub_sat,
+        .assign,
+        .assign_destructure,
+        => {},
+
+        .array_init_dot_two,
+        .array_init_dot_two_comma,
+        .array_init_dot,
+        .array_init_dot_comma,
+        .struct_init_dot_two,
+        .struct_init_dot_two_comma,
+        .struct_init_dot,
+        .struct_init_dot_comma,
+        => {},
+
+        .root,
+        .@"usingnamespace",
+        .test_decl,
+        .@"errdefer",
+        .@"defer",
+        .switch_case_one,
+        .switch_case_inline_one,
+        .switch_case,
+        .switch_case_inline,
+        .switch_range,
+        .for_range,
+        .@"continue",
+        .@"break",
+        .@"return",
+        => {},
+
+        .@"await",
+        .@"suspend",
+        .@"resume",
+        => {},
+
+        .asm_simple,
+        .@"asm",
+        .asm_output,
+        .asm_input,
+        => {},
     }
     return null;
 }
@@ -1588,15 +1734,13 @@ pub const Type = struct {
         /// - Error type: `Foo || Bar`, `Foo!Bar`
         /// - Function: `fn () Foo`, `fn foo() Foo`
         /// - Literal: `"foo"`, `'x'`, `42`, `.foo`, `error.Foo`
-        /// - Primitive value: `true`, `false`, `null`, `undefined`
         other: Ast.Node.Index,
-
-        /// Primitive type: `u8`, `bool`, `type`, etc.
-        primitive: []const u8,
 
         /// Branching types
         either: []const EitherEntry,
 
+        /// Primitive type: `u8`, `bool`, `type`, etc.
+        /// Primitive value: `true`, `false`, `null`, `undefined`
         ip_index: struct {
             node: ?Ast.Node.Index = null,
             /// this stores both the type and the value
@@ -1604,6 +1748,10 @@ pub const Type = struct {
         },
     },
     /// If true, the type `type`, the attached data is the value of the type value.
+    /// ```zig
+    /// const foo = u32; // is_type_val == true
+    /// const bar = @as(u32, ...); // is_type_val == false
+    /// ```
     is_type_val: bool,
 };
 
@@ -1626,7 +1774,6 @@ pub const TypeWithHandle = struct {
                 .union_tag,
                 => |t| hashTypeWithHandle(hasher, t.*),
                 .other => |idx| std.hash.autoHash(hasher, idx),
-                .primitive => |name| hasher.update(name),
                 .either => |entries| {
                     for (entries) |e| {
                         hasher.update(e.descriptor);
@@ -1670,10 +1817,6 @@ pub const TypeWithHandle = struct {
                 .other => |a_idx| {
                     const b_idx = b.type.data.other;
                     if (a_idx != b_idx) return false;
-                },
-                .primitive => |a_name| {
-                    const b_name = b.type.data.primitive;
-                    if (!std.mem.eql(u8, a_name, b_name)) return false;
                 },
                 .either => |a_entries| {
                     const b_entries = b.type.data.either;
@@ -4370,17 +4513,23 @@ pub fn referencedTypes(
     collector: *ReferencedType.Collector,
 ) error{OutOfMemory}!void {
     analyser.resolved_nodes.clearRetainingCapacity();
-    const allocator = collector.referenced_types.allocator;
     if (resolved_type.type.is_type_val) {
         collector.needs_type_reference = false;
         _ = try analyser.addReferencedTypes(resolved_type, collector.*);
-        resolved_type_str.* = switch (resolved_type.type.data) {
-            .ip_index => |payload| try std.fmt.allocPrint(allocator, "{}", .{payload.index.fmt(analyser.ip.?.*)}),
-            else => "type",
-        };
+        resolved_type_str.* = "type";
     } else {
         if (try analyser.addReferencedTypes(resolved_type, collector.*)) |str|
             resolved_type_str.* = str;
+    }
+
+    switch (resolved_type.type.data) {
+        .ip_index => |payload| {
+            const allocator = collector.referenced_types.allocator;
+            const ip = analyser.ip.?;
+            const index = if (resolved_type.type.is_type_val) ip.indexToKey(payload.index).typeOf() else payload.index;
+            resolved_type_str.* = try std.fmt.allocPrint(allocator, "{}", .{index.fmt(ip.*)});
+        },
+        else => {},
     }
 }
 
@@ -4417,8 +4566,6 @@ fn addReferencedTypes(
     const token_starts = tree.tokens.items(.start);
 
     switch (type_handle.type.data) {
-        .primitive => |name| return name,
-
         .pointer => |t| {
             const child_type_str = try analyser.addReferencedTypes(t.*, ReferencedType.Collector.init(referenced_types));
             return try std.fmt.allocPrint(allocator, "*{s}", .{child_type_str orelse return null});
@@ -4644,13 +4791,18 @@ fn addReferencedTypes(
 
             .identifier => {
                 const name = offsets.nodeToSlice(tree, p);
-                return primitive_types.get(name);
+                const primitive = Analyser.resolvePrimitiveType(name) orelse return null;
+                return try std.fmt.allocPrint(allocator, "{}", .{primitive.fmt(analyser.ip.?.*)});
             },
 
             else => {}, // TODO: Implement more "other" type expressions; better safe than sorry
         },
 
-        else => {},
+        .ip_index => |payload| {
+            return try std.fmt.allocPrint(allocator, "{}", .{payload.index.fmt(analyser.ip.?.*)});
+        },
+
+        .either => {}, // TODO
     }
 
     return null;

--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -70,13 +70,13 @@ fn typeToCompletion(
             null,
             either_descriptor,
         ),
-        .@"comptime" => |co| try analyser_completions.dotCompletions(
+        .ip_index => |payload| try analyser_completions.dotCompletions(
             arena,
             list,
-            co.interpreter.ip,
-            co.value.index,
+            analyser.ip.?,
+            payload.index,
             type_handle.type.is_type_val,
-            co.value.node_idx,
+            payload.node,
         ),
         .either => |bruh| {
             for (bruh) |a|

--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -440,7 +440,6 @@ fn declToCompletion(context: DeclToCompletionContext, decl_handle: Analyser.Decl
         .error_union_error,
         .array_payload,
         .assign_destructure,
-        .array_index,
         .switch_payload,
         .label_decl,
         => {

--- a/src/features/hover.zig
+++ b/src/features/hover.zig
@@ -91,7 +91,6 @@ pub fn hoverSymbol(
         .error_union_error,
         .array_payload,
         .assign_destructure,
-        .array_index,
         .switch_payload,
         .label_decl,
         .error_token,

--- a/src/features/references.zig
+++ b/src/features/references.zig
@@ -227,7 +227,7 @@ pub fn symbolReferences(
         },
         .param_payload => |payload| try builder.collectReferences(curr_handle, payload.func),
         .label_decl => unreachable, // handled separately by labelReferences
-        .array_index, .error_token => {},
+        .error_token => {},
     }
 
     return builder.locations;

--- a/src/features/semantic_tokens.zig
+++ b/src/features/semantic_tokens.zig
@@ -1005,12 +1005,11 @@ fn writeIdentifier(builder: *Builder, name_token: Ast.Node.Index) error{OutOfMem
     std.debug.assert(tree.tokens.items(.tag)[name_token] == .identifier);
     const name = offsets.tokenToSlice(tree, name_token);
 
-    if (std.mem.eql(u8, name, "_")) {
-        return;
-    } else if (Analyser.isValueIdent(name)) {
-        return try writeToken(builder, name_token, .keywordLiteral);
-    } else if (Analyser.isTypeIdent(name)) {
-        return try writeToken(builder, name_token, .type);
+    if (std.mem.eql(u8, name, "_")) return;
+
+    if (Analyser.resolvePrimitiveType(name)) |primitive| {
+        const is_type = builder.analyser.ip.?.indexToKey(primitive).typeOf() == .type_type;
+        return try writeToken(builder, name_token, if (is_type) .type else .keywordLiteral);
     }
 
     if (try builder.analyser.lookupSymbolGlobal(

--- a/tests/lsp_features/hover.zig
+++ b/tests/lsp_features/hover.zig
@@ -252,6 +252,19 @@ test "hover - for capture" {
         \\(i32)
         \\```
     );
+    try testHover(
+        \\fn func() void {
+        \\    const foo: []i32 = undefined;
+        \\    for (foo, 0..) |bar, in<cursor>dex| {}
+        \\}
+    ,
+        \\```zig
+        \\index
+        \\```
+        \\```zig
+        \\(usize)
+        \\```
+    );
 }
 
 test "hover - switch capture" {


### PR DESCRIPTION
this PR will utilize the InternPool to represent primitives which is the first time that the InternPool is used outside of the comptime interpreter.