### PR TITLE
simplify type resolution on switch payload

### DIFF
--- a/tests/lsp_features/hover.zig
+++ b/tests/lsp_features/hover.zig
@@ -271,6 +271,23 @@ test "hover - switch capture" {
         \\(i32)
         \\```
     );
+    try testHover(
+        \\const E = enum { foo };
+        \\fn func(e: E) void {
+        \\    switch (e) {
+        \\        .foo => |b<cursor>ar| {},
+        \\    }
+        \\}
+    ,
+        \\```zig
+        \\bar
+        \\```
+        \\```zig
+        \\(E)
+        \\```
+        \\
+        \\Go to [E](file:///test.zig#L1)
+    );
 }
 
 test "hover - errdefer capture" {


### PR DESCRIPTION
This also allows hovering over a switch case capture on an enum.
```zig
const E = enum { foo };
fn func(e: E) void {
    switch (e) {
        .foo => |b<hover here>ar| {},
    }
}
```