### PR TITLE
Restrict Maximum Whitespace in Inlay Hints

### DIFF
--- a/src/features/inlay_hints.zig
+++ b/src/features/inlay_hints.zig
@@ -257,7 +257,7 @@ fn writeVariableDeclHint(builder: *Builder, decl_node: Ast.Node.Index) !void {
     if (type_str.len == 0) return;
 
     // TODO: Remove once long type hints can be reduced, i.e. `struct { .. }`
-    type_str = reduce_string_whitespace(type_str, builder.arena);
+    type_str = try reduce_string_whitespace(type_str, builder.arena);
 
     try builder.hints.append(builder.arena, .{
         .index = offsets.tokenToLoc(tree, hint.ast.mut_token + 1).end,

--- a/src/features/inlay_hints.zig
+++ b/src/features/inlay_hints.zig
@@ -216,7 +216,7 @@ fn writeBuiltinHint(builder: *Builder, parameters: []const Ast.Node.Index, argum
 // Restrict whitespace to only one space at a time.
 fn reduce_string_whitespace(str: []const u8, arena: std.mem.Allocator) ![]const u8 {
     // Overallocates by a small amount if whitespace is reduced, but it should be fine.
-    var reduced_type_str = try std.ArrayList(u8).initCapacity(arena, str.len);
+    var reduced_type_str = try std.ArrayListUnmanaged(u8).initCapacity(arena, str.len);
     var skip = false;
     for (str) |char| {
         if (char == '\n' or char == ' ') {

--- a/tests/lsp_features/inlay_hints.zig
+++ b/tests/lsp_features/inlay_hints.zig
@@ -112,6 +112,28 @@ test "inlayhints - var decl" {
         \\    }
         \\}
     , .Type);
+    try testInlayHints(
+        \\ fn thing(a: u32, b: i32) struct {
+        \\     a: u32,
+        \\     b: i32,
+        \\     c: struct {
+        \\         d: usize,
+        \\         e: []const u8,
+        \\     },
+        \\ } {
+        \\     return .{
+        \\         .a = a,
+        \\         .b = b,
+        \\         .c = .{
+        \\             .d = 0,
+        \\             .e = "Testing",
+        \\         }
+        \\     }; 
+        \\ }
+        \\
+        \\ var a<struct { a: u32, b: i32, c: struct { d: usize, e: []const u8, }, }> = thing(10, -4);
+        \\ _ = a;
+    , .Type);
 }
 
 fn testInlayHints(source: []const u8, kind: types.InlayHintKind) !void {


### PR DESCRIPTION
## Before:
![image](https://github.com/zigtools/zls/assets/101683475/9a07c7f7-c823-435d-b8c2-bb87ac6f4b0a)
## After:
![image](https://github.com/zigtools/zls/assets/101683475/48e98412-62ee-491d-bdaa-12e16202d782)