### PR TITLE
Add semicolon when it's missing

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -339,10 +339,8 @@ fn getAutofixMode(server: *Server) enum {
 
 /// caller owns returned memory.
 fn autofix(server: *Server, arena: std.mem.Allocator, handle: *DocumentStore.Handle) error{OutOfMemory}!std.ArrayListUnmanaged(types.TextEdit) {
-    if (handle.tree.errors.len != 0) return .{};
-
     var diagnostics = std.ArrayListUnmanaged(types.Diagnostic){};
-    try diagnostics_gen.getAstCheckDiagnostics(server, arena, handle, &diagnostics);
+    try diagnostics_gen.getDiagnostics(server, arena, handle, &diagnostics);
     if (diagnostics.items.len == 0) return .{};
 
     var analyser = server.initAnalyser(handle);
@@ -1534,11 +1532,8 @@ fn codeActionHandler(server: *Server, arena: std.mem.Allocator, request: types.C
         .offset_encoding = server.offset_encoding,
     };
 
-    // as of right now, only ast-check errors may get a code action
     var diagnostics = std.ArrayListUnmanaged(types.Diagnostic){};
-    if (handle.tree.errors.len == 0) {
-        try diagnostics_gen.getAstCheckDiagnostics(server, arena, handle, &diagnostics);
-    }
+    try diagnostics_gen.getDiagnostics(server, arena, handle, &diagnostics);
 
     var actions = std.ArrayListUnmanaged(types.CodeAction){};
     var remove_capture_actions = std.AutoHashMapUnmanaged(types.Range, void){};

--- a/src/features/code_actions.zig
+++ b/src/features/code_actions.zig
@@ -38,6 +38,7 @@ pub const Builder = struct {
             },
             // the undeclared identifier may be a discard
             .undeclared_identifier => try handlePointlessDiscard(builder, actions, loc),
+            .missing_semicolon => try handleMissingSemicolon(builder, actions, loc),
             .unreachable_code => {
                 // TODO
                 // autofix: comment out code
@@ -341,6 +342,20 @@ fn handlePointlessDiscard(builder: *Builder, actions: *std.ArrayListUnmanaged(ty
     });
 }
 
+fn handleMissingSemicolon(builder: *Builder, actions: *std.ArrayListUnmanaged(types.CodeAction), loc: offsets.Loc) !void {
+    const tracy_zone = tracy.trace(@src());
+    defer tracy_zone.end();
+
+    const edit_loc = offsets.Loc{ .start = loc.end, .end = loc.end };
+
+    try actions.append(builder.arena, .{
+        .title = "add missing semicolon",
+        .kind = .@"source.fixAll",
+        .isPreferred = true,
+        .edit = try builder.createWorkspaceEdit(&.{builder.createTextEditLoc(edit_loc, ";")}),
+    });
+}
+
 fn handleVariableNeverMutated(builder: *Builder, actions: *std.ArrayListUnmanaged(types.CodeAction), loc: offsets.Loc) !void {
     const source = builder.handle.tree.source;
 
@@ -521,6 +536,7 @@ const DiagnosticKind = union(enum) {
     non_camelcase_fn,
     undeclared_identifier,
     unreachable_code,
+    missing_semicolon,
     var_never_mutated,
 
     const IdCat = enum {
@@ -555,6 +571,8 @@ const DiagnosticKind = union(enum) {
             return .non_camelcase_fn;
         } else if (std.mem.startsWith(u8, msg, "use of undeclared identifier")) {
             return .undeclared_identifier;
+        } else if (std.mem.eql(u8, msg, "expected ';' after statement")) {
+            return .missing_semicolon;
         } else if (std.mem.eql(u8, msg, "local variable is never mutated")) {
             return .var_never_mutated;
         }


### PR DESCRIPTION
Closes #1475

Probably needs some fuzzing and manual testing but this is it!

I wonder if applying multiple autofixes at once would be desirable as now this can happen pretty easily (see `var a = 1`, which adds a `;` on the first save and then an unused discard on the second.)

Anyways back to my job I go! 🏃‍♂️