### PR TITLE
resolve config options in tests through the build system

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -74,7 +74,6 @@ pub fn build(b: *std.build.Builder) !void {
     exe_options.addOption(bool, "enable_failing_allocator", b.option(bool, "enable_failing_allocator", "Whether to use a randomly failing allocator.") orelse false);
     exe_options.addOption(u32, "enable_failing_allocator_likelihood", b.option(u32, "enable_failing_allocator_likelihood", "The chance that an allocation will fail is `1/likelihood`") orelse 256);
     exe_options.addOption(bool, "use_gpa", b.option(bool, "use_gpa", "Good for debugging") orelse (optimize == .Debug));
-    exe_options.addOption(bool, "coverage", coverage);
     exe_options.addOption([]const u8, "version_string", version_string);
     exe_options.addOption(std.SemanticVersion, "version", try std.SemanticVersion.parse(version_string));
     exe_options.addOption([]const u8, "min_zig_string", min_zig_string);

--- a/flake.nix
+++ b/flake.nix
@@ -36,11 +36,15 @@
           nativeBuildInputs = [ zig ];
           dontConfigure = true;
           dontInstall = true;
+          doCheck = true;
           langref = inputs.langref;
           buildPhase = ''
             mkdir -p .cache
             ln -s ${pkgs.callPackage ./deps.nix { }} .cache/p
             zig build install --cache-dir $(pwd)/zig-cache --global-cache-dir $(pwd)/.cache -Dversion_data_path=$langref -Dcpu=baseline -Doptimize=ReleaseSafe --prefix $out
+          '';
+          checkPhase = ''
+            zig build test --cache-dir $(pwd)/zig-cache --global-cache-dir $(pwd)/.cache -Dversion_data_path=$langref -Dcpu=baseline
           '';
         };
       }

--- a/src/DocumentStore.zig
+++ b/src/DocumentStore.zig
@@ -1039,6 +1039,9 @@ pub fn resolveCImport(self: *DocumentStore, handle: Handle, node: Ast.Node.Index
     defer tracy_zone.end();
 
     if (!std.process.can_spawn) return null;
+    if (self.config.zig_exe_path == null) return null;
+    if (self.config.zig_lib_path == null) return null;
+    if (self.config.global_cache_path == null) return null;
 
     self.lock.lock();
     defer self.lock.unlock();

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -1006,12 +1006,13 @@ fn validateConfiguration(server: *Server, config: *configuration.Configuration) 
 
 fn resolveConfiguration(server: *Server, config_arena: std.mem.Allocator, config: *configuration.Configuration) !void {
     if (config.zig_exe_path == null) blk: {
-        comptime if (!std.process.can_spawn) break :blk;
+        std.debug.assert(!zig_builtin.is_test);
+        if (!std.process.can_spawn) break :blk;
         config.zig_exe_path = try configuration.findZig(config_arena);
     }
 
     if (config.zig_exe_path) |exe_path| blk: {
-        comptime if (!std.process.can_spawn) break :blk;
+        if (!std.process.can_spawn) break :blk;
         const env = configuration.getZigEnv(server.allocator, exe_path) orelse break :blk;
         defer env.deinit();
 
@@ -1045,6 +1046,7 @@ fn resolveConfiguration(server: *Server, config_arena: std.mem.Allocator, config
     }
 
     if (config.global_cache_path == null) {
+        std.debug.assert(!zig_builtin.is_test);
         const cache_dir_path = (try known_folders.getPath(server.allocator, .cache)) orelse {
             log.warn("Known-folders could not fetch the cache path", .{});
             return;
@@ -1086,7 +1088,7 @@ fn resolveConfiguration(server: *Server, config_arena: std.mem.Allocator, config
     }
 
     if (config.builtin_path == null) blk: {
-        comptime if (!std.process.can_spawn) break :blk;
+        if (!std.process.can_spawn) break :blk;
         if (config.zig_exe_path == null) break :blk;
         if (config.global_cache_path == null) break :blk;
 

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -1906,12 +1906,6 @@ pub fn waitAndWork(server: *Server) void {
     server.wait_group.reset();
 }
 
-comptime {
-    if (build_options.coverage) {
-        std.testing.refAllDecls(@This());
-    }
-}
-
 pub fn loop(server: *Server) !void {
     std.debug.assert(server.transport != null);
     while (server.keepRunning()) {

--- a/src/translate_c.zig
+++ b/src/translate_c.zig
@@ -154,11 +154,11 @@ pub fn translate(
     };
 
     const base_args = &[_][]const u8{
-        config.zig_exe_path orelse return null,
+        config.zig_exe_path.?,
         "translate-c",
         "--zig-lib-dir",
-        config.zig_lib_path orelse return null,
-        "--cache-dir",
+        config.zig_lib_path.?,
+        "--global-cache-dir",
         config.global_cache_path.?,
         "-lc",
         "--listen=-",

--- a/tests/context.zig
+++ b/tests/context.zig
@@ -6,15 +6,6 @@ const Config = zls.Config;
 const Server = zls.Server;
 const types = zls.types;
 
-/// initialize request taken from Visual Studio Code with the following changes:
-/// - removed locale, rootPath, rootUri, trace, workspaceFolders
-/// - removed capabilities.workspace.configuration
-/// - removed capabilities.workspace.didChangeConfiguration
-/// - removed capabilities.textDocument.publishDiagnostics
-const initialize_msg =
-    \\{"processId":0,"clientInfo":{"name":"Visual Studio Code","version":"1.73.1"},"capabilities":{"workspace":{"applyEdit":true,"workspaceEdit":{"documentChanges":true,"resourceOperations":["create","rename","delete"],"failureHandling":"textOnlyTransactional","normalizesLineEndings":true,"changeAnnotationSupport":{"groupsOnLabel":true}},"didChangeWatchedFiles":{"dynamicRegistration":true,"relativePatternSupport":true},"symbol":{"dynamicRegistration":true,"symbolKind":{"valueSet":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26]},"tagSupport":{"valueSet":[1]},"resolveSupport":{"properties":["location.range"]}},"codeLens":{"refreshSupport":true},"executeCommand":{"dynamicRegistration":true},"workspaceFolders":true,"semanticTokens":{"refreshSupport":true},"fileOperations":{"dynamicRegistration":true,"didCreate":true,"didRename":true,"didDelete":true,"willCreate":true,"willRename":true,"willDelete":true},"inlineValue":{"refreshSupport":true},"inlayHint":{"refreshSupport":true},"diagnostics":{"refreshSupport":true}},"textDocument":{"synchronization":{"dynamicRegistration":true,"willSave":true,"willSaveWaitUntil":true,"didSave":true},"completion":{"dynamicRegistration":true,"contextSupport":true,"completionItem":{"snippetSupport":true,"commitCharactersSupport":true,"documentationFormat":["markdown","plaintext"],"deprecatedSupport":true,"preselectSupport":true,"tagSupport":{"valueSet":[1]},"insertReplaceSupport":true,"resolveSupport":{"properties":["documentation","detail","additionalTextEdits"]},"insertTextModeSupport":{"valueSet":[1,2]},"labelDetailsSupport":true},"insertTextMode":2,"completionItemKind":{"valueSet":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25]},"completionList":{"itemDefaults":["commitCharacters","editRange","insertTextFormat","insertTextMode"]}},"hover":{"dynamicRegistration":true,"contentFormat":["markdown","plaintext"]},"signatureHelp":{"dynamicRegistration":true,"signatureInformation":{"documentationFormat":["markdown","plaintext"],"parameterInformation":{"labelOffsetSupport":true},"activeParameterSupport":true},"contextSupport":true},"definition":{"dynamicRegistration":true,"linkSupport":true},"references":{"dynamicRegistration":true},"documentHighlight":{"dynamicRegistration":true},"documentSymbol":{"dynamicRegistration":true,"symbolKind":{"valueSet":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26]},"hierarchicalDocumentSymbolSupport":true,"tagSupport":{"valueSet":[1]},"labelSupport":true},"codeAction":{"dynamicRegistration":true,"isPreferredSupport":true,"disabledSupport":true,"dataSupport":true,"resolveSupport":{"properties":["edit"]},"codeActionLiteralSupport":{"codeActionKind":{"valueSet":["","quickfix","refactor","refactor.extract","refactor.inline","refactor.rewrite","source","source.organizeImports"]}},"honorsChangeAnnotations":false},"codeLens":{"dynamicRegistration":true},"formatting":{"dynamicRegistration":true},"rangeFormatting":{"dynamicRegistration":true},"onTypeFormatting":{"dynamicRegistration":true},"rename":{"dynamicRegistration":true,"prepareSupport":true,"prepareSupportDefaultBehavior":1,"honorsChangeAnnotations":true},"documentLink":{"dynamicRegistration":true,"tooltipSupport":true},"typeDefinition":{"dynamicRegistration":true,"linkSupport":true},"implementation":{"dynamicRegistration":true,"linkSupport":true},"colorProvider":{"dynamicRegistration":true},"foldingRange":{"dynamicRegistration":true,"rangeLimit":5000,"lineFoldingOnly":true,"foldingRangeKind":{"valueSet":["comment","imports","region"]},"foldingRange":{"collapsedText":false}},"declaration":{"dynamicRegistration":true,"linkSupport":true},"selectionRange":{"dynamicRegistration":true},"callHierarchy":{"dynamicRegistration":true},"semanticTokens":{"dynamicRegistration":true,"tokenTypes":["namespace","type","class","enum","interface","struct","typeParameter","parameter","variable","property","enumMember","event","function","method","macro","keyword","modifier","comment","string","number","regexp","operator","decorator"],"tokenModifiers":["declaration","definition","readonly","static","deprecated","abstract","async","modification","documentation","defaultLibrary"],"formats":["relative"],"requests":{"range":true,"full":{"delta":true}},"multilineTokenSupport":false,"overlappingTokenSupport":false,"serverCancelSupport":true,"augmentsSyntaxTokens":true},"linkedEditingRange":{"dynamicRegistration":true},"typeHierarchy":{"dynamicRegistration":true},"inlineValue":{"dynamicRegistration":true},"inlayHint":{"dynamicRegistration":true,"resolveSupport":{"properties":["tooltip","textEdits","label.tooltip","label.location","label.command"]}},"diagnostic":{"dynamicRegistration":true,"relatedDocumentSupport":false}},"window":{"showMessage":{"messageActionItem":{"additionalPropertiesSupport":true}},"showDocument":{"support":true},"workDoneProgress":true},"general":{"staleRequestSupport":{"cancel":true,"retryOnContentModified":["textDocument/semanticTokens/full","textDocument/semanticTokens/range","textDocument/semanticTokens/full/delta"]},"regularExpressions":{"engine":"ECMAScript","version":"ES2020"},"markdown":{"parser":"marked","version":"1.1.0"},"positionEncodings":["utf-16"]},"notebookDocument":{"synchronization":{"dynamicRegistration":true,"executionSummarySupport":true}}}}
-;
-
 const default_config: Config = .{
     .enable_ast_check_diagnostics = false,
     .semantic_tokens = .full,
@@ -44,15 +35,13 @@ pub const Context = struct {
         _ = try context.server.sendRequestSync(context.arena.allocator(), "initialize", .{ .capabilities = .{} });
         _ = try context.server.sendNotificationSync(context.arena.allocator(), "initialized", .{});
 
-        // TODO this line shouldn't be needed
-        context.server.client_capabilities.label_details_support = false;
-        context.server.client_capabilities.supports_textDocument_definition_linkSupport = true;
-
         return context;
     }
 
     pub fn deinit(self: *Context) void {
-        _ = self.server.sendRequestSync(self.arena.allocator(), "shutdown", {}) catch {};
+        _ = self.server.sendRequestSync(self.arena.allocator(), "shutdown", {}) catch unreachable;
+        self.server.sendNotificationSync(self.arena.allocator(), "exit", {}) catch unreachable;
+        std.debug.assert(self.server.status == .exiting_success);
         self.server.destroy();
         self.arena.deinit();
     }

--- a/tests/context.zig
+++ b/tests/context.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const zls = @import("zls");
 const builtin = @import("builtin");
+const test_options = @import("test_options");
 
 const Config = zls.Config;
 const Server = zls.Server;
@@ -12,6 +13,10 @@ const default_config: Config = .{
     .enable_inlay_hints = true,
     .inlay_hints_exclude_single_argument = false,
     .inlay_hints_show_builtin = true,
+
+    .zig_exe_path = test_options.zig_exe_path,
+    .zig_lib_path = null,
+    .global_cache_path = test_options.global_cache_path,
 };
 
 const allocator = std.testing.allocator;

--- a/tests/language_features/cimport.zig
+++ b/tests/language_features/cimport.zig
@@ -109,10 +109,6 @@ fn testTranslate(c_source: []const u8) !translate_c.Result {
     var ctx = try Context.init();
     defer ctx.deinit();
 
-    if (ctx.server.config.global_cache_path == null or
-        ctx.server.config.zig_exe_path == null or
-        ctx.server.config.zig_lib_path == null) return error.SkipZigTest;
-
     const result = (try translate_c.translate(allocator, ctx.server.config, &.{}, c_source)).?;
 
     switch (result) {

--- a/tests/lifecycle.zig
+++ b/tests/lifecycle.zig
@@ -1,11 +1,18 @@
 const std = @import("std");
 const zls = @import("zls");
+const test_options = @import("test_options");
 
 const allocator = std.testing.allocator;
 
 test "LSP lifecycle" {
     var server = try zls.Server.create(allocator);
     defer server.destroy();
+
+    try server.updateConfiguration2(.{
+        .zig_exe_path = test_options.zig_exe_path,
+        .zig_lib_path = null,
+        .global_cache_path = test_options.global_cache_path,
+    });
 
     var arena_allocator = std.heap.ArenaAllocator.init(allocator);
     defer arena_allocator.deinit();

--- a/tests/lsp_features/definition.zig
+++ b/tests/lsp_features/definition.zig
@@ -53,6 +53,8 @@ fn testDefinition(source: []const u8) !void {
     var ctx = try Context.init();
     defer ctx.deinit();
 
+    ctx.server.client_capabilities.supports_textDocument_definition_linkSupport = true;
+
     const cursor_lsp = offsets.locToRange(phr.new_source, cursor.?, ctx.server.offset_encoding).start;
     const def_range_lsp = offsets.locToRange(phr.new_source, .{ .start = def_start.?.end, .end = def_end.?.start }, ctx.server.offset_encoding);
 


### PR DESCRIPTION
previously when running tests, the zig path, zig lib path and global cache path where all resolved the same way they would be when running ZLS normally that is by looking in PATH and using known_folders.

This means that as an example the zig version that was used to run `zig build` may not be same as the zig version used by ZLS in its tests. Instead these config options are now resolved through the build system and supplied as an option module.

This achieved my goal of running tests in nix which wasn't possible before.