### PR TITLE
analysis: support many and c pointer completions

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -754,15 +754,18 @@ fn resolveBracketAccessType(analyser: *Analyser, lhs: TypeWithHandle, rhs: enum 
             .handle = lhs.handle,
         };
     } else if (ast.fullPtrType(tree, lhs_node)) |ptr_type| {
-        if (ptr_type.size == .Slice) {
-            if (rhs == .Single) {
-                return ((try analyser.resolveTypeOfNodeInternal(.{
-                    .node = ptr_type.ast.child_type,
-                    .handle = lhs.handle,
-                })) orelse return null).instanceTypeVal();
-            }
-            return lhs;
+        switch (ptr_type.size) {
+            .Slice, .C, .Many => {
+                if (rhs == .Single) {
+                    return ((try analyser.resolveTypeOfNodeInternal(.{
+                        .node = ptr_type.ast.child_type,
+                        .handle = lhs.handle,
+                    })) orelse return null).instanceTypeVal();
+                }
+            },
+            else => {},
         }
+        return lhs;
     }
 
     return null;

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -762,10 +762,10 @@ fn resolveBracketAccessType(analyser: *Analyser, lhs: TypeWithHandle, rhs: enum 
                         .handle = lhs.handle,
                     })) orelse return null).instanceTypeVal();
                 }
+                return lhs;
             },
-            else => {},
+            .One => {},
         }
-        return lhs;
     }
 
     return null;

--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -186,6 +186,36 @@ test "completion - pointer" {
     // , &.{
     //     .{ .label = "alpha", .kind = .Field, .detail = "alpha: u32" },
     // });
+
+    try testCompletion(
+        \\const S = struct {
+        \\    alpha: u32,
+        \\};
+        \\const foo: [*]S = undefined;
+        \\const bar = foo[0].<cursor>
+    , &.{
+        .{ .label = "alpha", .kind = .Field, .detail = "alpha: u32" },
+    });
+
+    try testCompletion(
+        \\const S = struct {
+        \\    alpha: u32,
+        \\};
+        \\const foo: [*c]S = undefined;
+        \\const bar = foo[0].<cursor>
+    , &.{
+        .{ .label = "alpha", .kind = .Field, .detail = "alpha: u32" },
+    });
+
+    try testCompletion(
+        \\const S = struct {
+        \\    alpha: u32,
+        \\};
+        \\const foo: [1]S = undefined;
+        \\const bar = foo[0].<cursor>
+    , &.{
+        .{ .label = "alpha", .kind = .Field, .detail = "alpha: u32" },
+    });
 }
 
 test "completion - captures" {
@@ -240,6 +270,30 @@ test "completion - captures" {
         \\fn foo(items: []S) void {
         \\    for (items, items) |_, baz| {
         \\        baz.<cursor>
+        \\    }
+        \\}
+    , &.{
+        .{ .label = "alpha", .kind = .Field, .detail = "alpha: u32" },
+    });
+
+    try testCompletion(
+        \\const S = struct { alpha: u32 };
+        \\fn foo() void {
+        \\    const manyptr: [*]S = undefined;
+        \\    for (manyptr[0..10]) |s| {
+        \\        s.<cursor>
+        \\    }
+        \\}
+    , &.{
+        .{ .label = "alpha", .kind = .Field, .detail = "alpha: u32" },
+    });
+
+    try testCompletion(
+        \\const S = struct { alpha: u32 };
+        \\fn foo() void {
+        \\    const optmanyptr: ?[*]S = undefined;
+        \\    for (optmanyptr.?[0..10]) |s| {
+        \\        s.<cursor>
         \\    }
         \\}
     , &.{


### PR DESCRIPTION
closes #1483

previously, resolveBracketAccessType() only supported slice pointer types.  i've added supoort for many and c pointer types.  this allows for `manyptr[0].` completions.

i've added new test cases to completion.zig for bracket access to many and c pointers along with array access.  i've also added cases of slicing a many pointer and an optional many pointer in a for loop.