### PR TITLE
lazily compute resources of DocumentStore handles

### DIFF
--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -23,7 +23,7 @@ fn typeToCompletion(
     arena: std.mem.Allocator,
     list: *std.ArrayListUnmanaged(types.CompletionItem),
     field_access: Analyser.FieldAccessReturn,
-    orig_handle: *const DocumentStore.Handle,
+    orig_handle: *DocumentStore.Handle,
     either_descriptor: ?[]const u8,
 ) error{OutOfMemory}!void {
     const tracy_zone = tracy.trace(@src());
@@ -121,7 +121,7 @@ fn nodeToCompletion(
     list: *std.ArrayListUnmanaged(types.CompletionItem),
     node_handle: Analyser.NodeWithHandle,
     unwrapped: ?Analyser.TypeWithHandle,
-    orig_handle: *const DocumentStore.Handle,
+    orig_handle: *DocumentStore.Handle,
     orig_name: ?[]const u8,
     orig_doc: ?[]const u8,
     is_type_val: bool,
@@ -372,7 +372,7 @@ const DeclToCompletionContext = struct {
     analyser: *Analyser,
     arena: std.mem.Allocator,
     completions: *std.ArrayListUnmanaged(types.CompletionItem),
-    orig_handle: *const DocumentStore.Handle,
+    orig_handle: *DocumentStore.Handle,
     orig_name: ?[]const u8 = null,
     orig_doc: ?[]const u8 = null,
     parent_is_type_val: ?bool = null,
@@ -478,7 +478,7 @@ fn completeLabel(
     server: *Server,
     analyser: *Analyser,
     arena: std.mem.Allocator,
-    handle: *const DocumentStore.Handle,
+    handle: *DocumentStore.Handle,
     pos_index: usize,
 ) error{OutOfMemory}![]types.CompletionItem {
     const tracy_zone = tracy.trace(@src());
@@ -549,7 +549,7 @@ fn completeBuiltin(server: *Server, arena: std.mem.Allocator) error{OutOfMemory}
     return completions;
 }
 
-fn completeGlobal(server: *Server, analyser: *Analyser, arena: std.mem.Allocator, handle: *const DocumentStore.Handle, pos_index: usize) error{OutOfMemory}![]types.CompletionItem {
+fn completeGlobal(server: *Server, analyser: *Analyser, arena: std.mem.Allocator, handle: *DocumentStore.Handle, pos_index: usize) error{OutOfMemory}![]types.CompletionItem {
     const tracy_zone = tracy.trace(@src());
     defer tracy_zone.end();
 
@@ -569,7 +569,7 @@ fn completeGlobal(server: *Server, analyser: *Analyser, arena: std.mem.Allocator
     return completions.toOwnedSlice(arena);
 }
 
-fn completeFieldAccess(server: *Server, analyser: *Analyser, arena: std.mem.Allocator, handle: *const DocumentStore.Handle, source_index: usize, loc: offsets.Loc) error{OutOfMemory}!?[]types.CompletionItem {
+fn completeFieldAccess(server: *Server, analyser: *Analyser, arena: std.mem.Allocator, handle: *DocumentStore.Handle, source_index: usize, loc: offsets.Loc) error{OutOfMemory}!?[]types.CompletionItem {
     const tracy_zone = tracy.trace(@src());
     defer tracy_zone.end();
 
@@ -763,7 +763,7 @@ fn formatDetailedLabel(item: *types.CompletionItem, arena: std.mem.Allocator) er
     //     logger.info("labelDetails: {s}  ::  {s}", .{item.labelDetails.?.detail, item.labelDetails.?.description});
 }
 
-fn completeError(server: *Server, arena: std.mem.Allocator, handle: *const DocumentStore.Handle) error{OutOfMemory}![]types.CompletionItem {
+fn completeError(server: *Server, arena: std.mem.Allocator, handle: *DocumentStore.Handle) error{OutOfMemory}![]types.CompletionItem {
     const tracy_zone = tracy.trace(@src());
     defer tracy_zone.end();
 
@@ -799,7 +799,7 @@ fn kindToSortScore(kind: types.CompletionItemKind) ?[]const u8 {
     };
 }
 
-fn completeDot(document_store: *DocumentStore, analyser: *Analyser, arena: std.mem.Allocator, handle: *const DocumentStore.Handle, source_index: usize) error{OutOfMemory}![]types.CompletionItem {
+fn completeDot(document_store: *DocumentStore, analyser: *Analyser, arena: std.mem.Allocator, handle: *DocumentStore.Handle, source_index: usize) error{OutOfMemory}![]types.CompletionItem {
     const tracy_zone = tracy.trace(@src());
     defer tracy_zone.end();
 
@@ -925,7 +925,7 @@ fn completeFileSystemStringLiteral(
     return completions.keys();
 }
 
-pub fn completionAtIndex(server: *Server, analyser: *Analyser, arena: std.mem.Allocator, handle: *const DocumentStore.Handle, source_index: usize) error{OutOfMemory}!?types.CompletionList {
+pub fn completionAtIndex(server: *Server, analyser: *Analyser, arena: std.mem.Allocator, handle: *DocumentStore.Handle, source_index: usize) error{OutOfMemory}!?types.CompletionList {
     const source = handle.tree.source;
 
     // Provide `top_level_decl_data` only if `offsets.lineSliceUntilIndex(handle.tree.source, source_index).len` is
@@ -1255,7 +1255,7 @@ pub fn collectContainerFields(
 fn collectContainerNodes(
     analyser: *Analyser,
     arena: std.mem.Allocator,
-    handle: *const DocumentStore.Handle,
+    handle: *DocumentStore.Handle,
     source_index: usize,
     dot_context: *const EnumLiteralContext,
 ) error{OutOfMemory}![]Analyser.TypeWithHandle {
@@ -1276,7 +1276,7 @@ fn collectContainerNodes(
 fn collectVarAccessContainerNodes(
     analyser: *Analyser,
     arena: std.mem.Allocator,
-    handle: *const DocumentStore.Handle,
+    handle: *DocumentStore.Handle,
     loc: offsets.Loc,
     dot_context: *const EnumLiteralContext,
     types_with_handles: *std.ArrayListUnmanaged(Analyser.TypeWithHandle),
@@ -1310,7 +1310,7 @@ fn collectVarAccessContainerNodes(
 fn collectFieldAccessContainerNodesHelper(
     analyser: *Analyser,
     arena: std.mem.Allocator,
-    handle: *const DocumentStore.Handle,
+    handle: *DocumentStore.Handle,
     loc: offsets.Loc,
     types_with_handles: *std.ArrayListUnmanaged(Analyser.TypeWithHandle),
 ) error{OutOfMemory}!void {
@@ -1344,7 +1344,7 @@ fn collectFieldAccessContainerNodesHelper(
 fn collectFieldAccessContainerNodes(
     analyser: *Analyser,
     arena: std.mem.Allocator,
-    handle: *const DocumentStore.Handle,
+    handle: *DocumentStore.Handle,
     loc: offsets.Loc,
     dot_context: *const EnumLiteralContext,
     types_with_handles: *std.ArrayListUnmanaged(Analyser.TypeWithHandle),
@@ -1405,7 +1405,7 @@ fn collectFieldAccessContainerNodes(
 fn collectEnumLiteralContainerNodes(
     analyser: *Analyser,
     arena: std.mem.Allocator,
-    handle: *const DocumentStore.Handle,
+    handle: *DocumentStore.Handle,
     loc: offsets.Loc,
     types_with_handles: *std.ArrayListUnmanaged(Analyser.TypeWithHandle),
 ) error{OutOfMemory}!void {

--- a/src/features/folding_range.zig
+++ b/src/features/folding_range.zig
@@ -246,7 +246,7 @@ pub fn generateFoldingRanges(allocator: std.mem.Allocator, tree: Ast, encoding: 
                     try builder.add(null, start_tok, end_tok, .exclusive, .exclusive);
                 } else { // no members (yet), ie `const T = type {};`
                     var start_tok = tree.firstToken(node);
-                    while(token_tags[start_tok] != .l_brace) start_tok += 1;
+                    while (token_tags[start_tok] != .l_brace) start_tok += 1;
                     const end_tok = ast.lastToken(tree, node);
                     try builder.add(null, start_tok, end_tok, .exclusive, .exclusive);
                 }

--- a/src/features/inlay_hints.zig
+++ b/src/features/inlay_hints.zig
@@ -33,7 +33,7 @@ const Builder = struct {
     arena: std.mem.Allocator,
     analyser: *Analyser,
     config: *const Config,
-    handle: *const DocumentStore.Handle,
+    handle: *DocumentStore.Handle,
     hints: std.ArrayListUnmanaged(InlayHint) = .{},
     hover_kind: types.MarkupKind,
 
@@ -351,7 +351,7 @@ fn writeCallNodeHint(builder: *Builder, call: Ast.full.Call) !void {
             const start = offsets.tokenToIndex(tree, lhsToken);
             const rhs_loc = offsets.tokenToLoc(tree, rhsToken);
 
-            var held_range = try builder.arena.dupeZ(u8, handle.text[start..rhs_loc.end]);
+            var held_range = try builder.arena.dupeZ(u8, handle.tree.source[start..rhs_loc.end]);
             var tokenizer = std.zig.Tokenizer.init(held_range);
 
             // note: we have the ast node, traversing it would probably yield better results
@@ -478,7 +478,7 @@ pub fn writeRangeInlayHint(
     arena: std.mem.Allocator,
     config: Config,
     analyser: *Analyser,
-    handle: *const DocumentStore.Handle,
+    handle: *DocumentStore.Handle,
     loc: offsets.Loc,
     hover_kind: types.MarkupKind,
     offset_encoding: offsets.Encoding,

--- a/src/features/references.zig
+++ b/src/features/references.zig
@@ -68,21 +68,21 @@ const Builder = struct {
 
     const Context = struct {
         builder: *Builder,
-        handle: *const DocumentStore.Handle,
+        handle: *DocumentStore.Handle,
     };
 
     fn deinit(self: *Builder) void {
         self.locations.deinit(self.allocator);
     }
 
-    fn add(self: *Builder, handle: *const DocumentStore.Handle, token_index: Ast.TokenIndex) error{OutOfMemory}!void {
+    fn add(self: *Builder, handle: *DocumentStore.Handle, token_index: Ast.TokenIndex) error{OutOfMemory}!void {
         try self.locations.append(self.allocator, .{
             .uri = handle.uri,
             .range = offsets.tokenToRange(handle.tree, token_index, self.encoding),
         });
     }
 
-    fn collectReferences(self: *Builder, handle: *const DocumentStore.Handle, node: Ast.Node.Index) error{OutOfMemory}!void {
+    fn collectReferences(self: *Builder, handle: *DocumentStore.Handle, node: Ast.Node.Index) error{OutOfMemory}!void {
         const context = Context{
             .builder = self,
             .handle = handle,
@@ -137,7 +137,7 @@ const Builder = struct {
 fn gatherReferences(
     allocator: std.mem.Allocator,
     analyser: *Analyser,
-    curr_handle: *const DocumentStore.Handle,
+    curr_handle: *DocumentStore.Handle,
     skip_std_references: bool,
     include_decl: bool,
     builder: anytype,
@@ -247,21 +247,21 @@ const CallBuilder = struct {
 
     const Context = struct {
         builder: *CallBuilder,
-        handle: *const DocumentStore.Handle,
+        handle: *DocumentStore.Handle,
     };
 
     fn deinit(self: *CallBuilder) void {
         self.callsites.deinit(self.allocator);
     }
 
-    fn add(self: *CallBuilder, handle: *const DocumentStore.Handle, call_node: Ast.Node.Index) error{OutOfMemory}!void {
+    fn add(self: *CallBuilder, handle: *DocumentStore.Handle, call_node: Ast.Node.Index) error{OutOfMemory}!void {
         try self.callsites.append(self.allocator, .{
             .uri = handle.uri,
             .call_node = call_node,
         });
     }
 
-    fn collectReferences(self: *CallBuilder, handle: *const DocumentStore.Handle, node: Ast.Node.Index) error{OutOfMemory}!void {
+    fn collectReferences(self: *CallBuilder, handle: *DocumentStore.Handle, node: Ast.Node.Index) error{OutOfMemory}!void {
         const context = Context{
             .builder = self,
             .handle = handle,

--- a/src/features/selection_range.zig
+++ b/src/features/selection_range.zig
@@ -7,7 +7,7 @@ const offsets = @import("../offsets.zig");
 
 pub fn generateSelectionRanges(
     arena: std.mem.Allocator,
-    handle: *const DocumentStore.Handle,
+    handle: *DocumentStore.Handle,
     positions: []const types.Position,
     offset_encoding: offsets.Encoding,
 ) error{OutOfMemory}!?[]types.SelectionRange {
@@ -21,7 +21,7 @@ pub fn generateSelectionRanges(
     var result = try arena.alloc(types.SelectionRange, positions.len);
     var locs = try std.ArrayListUnmanaged(offsets.Loc).initCapacity(arena, 32);
     for (positions, result) |position, *out| {
-        const index = offsets.positionToIndex(handle.text, position, offset_encoding);
+        const index = offsets.positionToIndex(handle.tree.source, position, offset_encoding);
 
         locs.clearRetainingCapacity();
         for (0..handle.tree.nodes.len) |i| {
@@ -46,7 +46,7 @@ pub fn generateSelectionRanges(
 
         var selection_ranges = try arena.alloc(types.SelectionRange, locs.items.len);
         for (selection_ranges, 0..) |*range, i| {
-            range.range = offsets.locToRange(handle.text, locs.items[i], offset_encoding);
+            range.range = offsets.locToRange(handle.tree.source, locs.items[i], offset_encoding);
             range.parent = if (i + 1 < selection_ranges.len) &selection_ranges[i + 1] else null;
         }
         out.* = selection_ranges[0];

--- a/src/features/semantic_tokens.zig
+++ b/src/features/semantic_tokens.zig
@@ -60,7 +60,7 @@ pub const TokenModifiers = packed struct(u16) {
 const Builder = struct {
     arena: std.mem.Allocator,
     analyser: *Analyser,
-    handle: *const DocumentStore.Handle,
+    handle: *DocumentStore.Handle,
     previous_source_index: usize = 0,
     token_buffer: std.ArrayListUnmanaged(u32) = .{},
     encoding: offsets.Encoding,
@@ -166,9 +166,10 @@ const Builder = struct {
             => if (self.limited) return,
         }
 
-        const delta_text = self.handle.tree.source[self.previous_source_index..loc.start];
+        const source = self.handle.tree.source;
+        const delta_text = source[self.previous_source_index..loc.start];
         const delta = offsets.indexToPosition(delta_text, delta_text.len, self.encoding);
-        const length = offsets.locLength(self.handle.tree.source, loc, self.encoding);
+        const length = offsets.locLength(source, loc, self.encoding);
 
         try self.token_buffer.appendSlice(self.arena, &.{
             @as(u32, @truncate(delta.line)),
@@ -203,7 +204,7 @@ fn writeDocComments(builder: *Builder, tree: Ast, doc: Ast.TokenIndex) !void {
 
 fn fieldTokenType(
     container_decl: Ast.Node.Index,
-    handle: *const DocumentStore.Handle,
+    handle: *DocumentStore.Handle,
     is_static_access: bool,
 ) ?TokenType {
     if (!ast.isContainer(handle.tree, container_decl))
@@ -1035,7 +1036,7 @@ fn writeIdentifier(builder: *Builder, name_token: Ast.Node.Index) error{OutOfMem
 pub fn writeSemanticTokens(
     arena: std.mem.Allocator,
     analyser: *Analyser,
-    handle: *const DocumentStore.Handle,
+    handle: *DocumentStore.Handle,
     loc: ?offsets.Loc,
     encoding: offsets.Encoding,
     limited: bool,

--- a/src/features/signature_help.zig
+++ b/src/features/signature_help.zig
@@ -57,8 +57,9 @@ fn fnProtoToSignatureInfo(
     };
 }
 
-pub fn getSignatureInfo(analyser: *Analyser, arena: std.mem.Allocator, handle: *const DocumentStore.Handle, absolute_index: usize) !?types.SignatureInformation {
-    const innermost_block = Analyser.innermostBlockScope(handle.*, absolute_index);
+pub fn getSignatureInfo(analyser: *Analyser, arena: std.mem.Allocator, handle: *DocumentStore.Handle, absolute_index: usize) !?types.SignatureInformation {
+    const document_scope = try handle.getDocumentScope();
+    const innermost_block = Analyser.innermostBlockScope(document_scope, absolute_index);
     const tree = handle.tree;
     const token_tags = tree.tokens.items(.tag);
     const token_starts = tree.tokens.items(.start);
@@ -239,7 +240,7 @@ pub fn getSignatureInfo(analyser: *Analyser, arena: std.mem.Allocator, handle: *
                 const last_token_slice = tree.tokenSlice(expr_last_token);
                 const expr_end = token_starts[expr_last_token] + last_token_slice.len;
 
-                var held_expr = try arena.dupeZ(u8, handle.text[expr_start..expr_end]);
+                var held_expr = try arena.dupeZ(u8, handle.tree.source[expr_start..expr_end]);
 
                 // Resolve the expression.
                 var tokenizer = std.zig.Tokenizer.init(held_expr);
@@ -264,7 +265,7 @@ pub fn getSignatureInfo(analyser: *Analyser, arena: std.mem.Allocator, handle: *
                         try symbol_stack.append(arena, .l_paren);
                         continue;
                     };
-                    const name = offsets.locToSlice(handle.text, name_loc);
+                    const name = offsets.locToSlice(handle.tree.source, name_loc);
 
                     const skip_self_param = !type_handle.type.is_type_val;
                     const decl_handle = (try type_handle.lookupSymbol(analyser, name)) orelse {

--- a/tests/lsp_features/code_actions.zig
+++ b/tests/lsp_features/code_actions.zig
@@ -139,7 +139,7 @@ fn testAutofix(before: []const u8, after: []const u8) !void {
     const handle = ctx.server.document_store.getHandle(uri).?;
 
     var diagnostics: std.ArrayListUnmanaged(types.Diagnostic) = .{};
-    try zls.diagnostics.getAstCheckDiagnostics(ctx.server, ctx.arena.allocator(), handle.*, &diagnostics);
+    try zls.diagnostics.getAstCheckDiagnostics(ctx.server, ctx.arena.allocator(), handle, &diagnostics);
 
     const params = types.CodeActionParams{
         .textDocument = .{ .uri = uri },


### PR DESCRIPTION
Instead creating the DocumentStore (and ZIR if needed) whenever the document gets modified, it is more efficient
to compute them lazily needed. This will mean that series of text edits without any requests on them which often occur while typing will be processed quicker with less latency.

I've also tested lazily computing the Ast but it turned out that the Ast was (almost) always needed which made this unnecessary.