### PR TITLE
Inlay Hints for Control Flow Capture Values

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The following options are currently available.
 | `semantic_tokens` | `enum` | `.full` | Set level of semantic tokens. Partial only includes information that requires semantic analysis. |
 | `enable_inlay_hints` | `bool` | `true` | Enables inlay hint support when the client also supports it |
 | `inlay_hints_show_variable_declaration` | `bool` | `true` | Enable inlay hints for variable declarations |
+| `inlay_hints_show_capture_variables` | `bool` | `true` | Enable inlay hints for control flow capture payloads (e.g. `if (optional) \|capture_payload: InlayHint\| {}`) |
 | `inlay_hints_show_parameter_name` | `bool` | `true` | Enable inlay hints for parameter names |
 | `inlay_hints_show_builtin` | `bool` | `true` | Enable inlay hints for builtin functions |
 | `inlay_hints_exclude_single_argument` | `bool` | `true` | Don't show inlay hints for single argument calls |

--- a/README.md
+++ b/README.md
@@ -63,8 +63,7 @@ The following options are currently available.
 | `enable_autofix` | `bool` | `true` | Whether to automatically fix errors on save. Currently supports adding and removing discards. |
 | `semantic_tokens` | `enum` | `.full` | Set level of semantic tokens. Partial only includes information that requires semantic analysis. |
 | `enable_inlay_hints` | `bool` | `true` | Enables inlay hint support when the client also supports it |
-| `inlay_hints_show_variable_declaration` | `bool` | `true` | Enable inlay hints for variable declarations |
-| `inlay_hints_show_capture_variables` | `bool` | `true` | Enable inlay hints for control flow capture payloads (e.g. `if (optional) \|capture_payload: InlayHint\| {}`) |
+| `inlay_hints_show_variable_type_hints` | `bool` | `true` | Enable inlay hints for variable types |
 | `inlay_hints_show_parameter_name` | `bool` | `true` | Enable inlay hints for parameter names |
 | `inlay_hints_show_builtin` | `bool` | `true` | Enable inlay hints for builtin functions |
 | `inlay_hints_exclude_single_argument` | `bool` | `true` | Don't show inlay hints for single argument calls |

--- a/schema.json
+++ b/schema.json
@@ -49,6 +49,11 @@
             "type": "boolean",
             "default": "true"
         },
+        "inlay_hints_show_capture_variables": {
+            "description": "Enable inlay hints for control flow capture payloads (e.g. `if (optional) |capture_payload: InlayHint| {}`)",
+            "type": "boolean",
+            "default": "true"
+        },
         "inlay_hints_show_parameter_name": {
             "description": "Enable inlay hints for parameter names",
             "type": "boolean",

--- a/schema.json
+++ b/schema.json
@@ -44,13 +44,8 @@
             "type": "boolean",
             "default": "true"
         },
-        "inlay_hints_show_variable_declaration": {
-            "description": "Enable inlay hints for variable declarations",
-            "type": "boolean",
-            "default": "true"
-        },
-        "inlay_hints_show_capture_variables": {
-            "description": "Enable inlay hints for control flow capture payloads (e.g. `if (optional) |capture_payload: InlayHint| {}`)",
+        "inlay_hints_show_variable_type_hints": {
+            "description": "Enable inlay hints for variable types",
             "type": "boolean",
             "default": "true"
         },

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -29,11 +29,8 @@ semantic_tokens: enum {
 /// Enables inlay hint support when the client also supports it
 enable_inlay_hints: bool = true,
 
-/// Enable inlay hints for variable declarations
-inlay_hints_show_variable_declaration: bool = true,
-
-/// Enable inlay hints for control flow capture payloads (e.g. `if (optional) |capture_payload: InlayHint| {}`)
-inlay_hints_show_capture_variables: bool = true,
+/// Enable inlay hints for variable types
+inlay_hints_show_variable_type_hints: bool = true,
 
 /// Enable inlay hints for parameter names
 inlay_hints_show_parameter_name: bool = true,

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -32,6 +32,9 @@ enable_inlay_hints: bool = true,
 /// Enable inlay hints for variable declarations
 inlay_hints_show_variable_declaration: bool = true,
 
+/// Enable inlay hints for control flow capture payloads (e.g. `if (optional) |capture_payload: InlayHint| {}`)
+inlay_hints_show_capture_variables: bool = true,
+
 /// Enable inlay hints for parameter names
 inlay_hints_show_parameter_name: bool = true,
 

--- a/src/config_gen/config.json
+++ b/src/config_gen/config.json
@@ -54,6 +54,12 @@
             "default": "true"
         },
         {
+            "name": "inlay_hints_show_capture_variables",
+            "description": "Enable inlay hints for control flow capture payloads (e.g. `if (optional) |capture_payload: InlayHint| {}`)",
+            "type": "bool",
+            "default": "true"
+        },
+        {
             "name": "inlay_hints_show_parameter_name",
             "description": "Enable inlay hints for parameter names",
             "type": "bool",

--- a/src/config_gen/config.json
+++ b/src/config_gen/config.json
@@ -48,14 +48,8 @@
             "default": "true"
         },
         {
-            "name": "inlay_hints_show_variable_declaration",
-            "description": "Enable inlay hints for variable declarations",
-            "type": "bool",
-            "default": "true"
-        },
-        {
-            "name": "inlay_hints_show_capture_variables",
-            "description": "Enable inlay hints for control flow capture payloads (e.g. `if (optional) |capture_payload: InlayHint| {}`)",
+            "name": "inlay_hints_show_variable_type_hints",
+            "description": "Enable inlay hints for variable types",
             "type": "bool",
             "default": "true"
         },

--- a/src/features/inlay_hints.zig
+++ b/src/features/inlay_hints.zig
@@ -216,10 +216,8 @@ fn writeBuiltinHint(builder: *Builder, parameters: []const Ast.Node.Index, argum
 // Restrict whitespace to only one space at a time.
 fn reduceTypeWhitespace(str: []const u8, arena: std.mem.Allocator) ![]const u8 {
     // Overallocates by a small amount if whitespace is reduced, but it should be fine.
-    var reduced_type_str = try std.ArrayListUnmanaged(u8).initCapacity(arena, str.len + 4);
+    var reduced_type_str = try std.ArrayListUnmanaged(u8).initCapacity(arena, str.len);
     var skip = false;
-    var depth: i32 = 0;
-    var depth_lo_cap: i32 = 10;
     for (str) |char| {
         if (char == '\n' or char == ' ') {
             if (!skip) {
@@ -227,22 +225,7 @@ fn reduceTypeWhitespace(str: []const u8, arena: std.mem.Allocator) ![]const u8 {
             }
             skip = true;
         } else {
-            if (char == '{') {
-                depth += 1;
-            } else if (char == '}') {
-                depth -= 1;
-            }
-            if (depth != 0) {
-                if (depth_lo_cap == 0) {
-                    continue;
-                } else {
-                    depth_lo_cap -= 1;
-                }
-            }
             reduced_type_str.appendAssumeCapacity(char);
-            if (depth_lo_cap == 0 and depth != 0) {
-                reduced_type_str.appendSliceAssumeCapacity(" ...");
-            }
             skip = false;
         }
     }

--- a/tests/lsp_features/inlay_hints.zig
+++ b/tests/lsp_features/inlay_hints.zig
@@ -134,12 +134,55 @@ test "inlayhints - var decl" {
         \\ var a<struct { a: u32, b: i32, c: struct { d: usize, e: []const u8, }, }> = thing(10, -4);
         \\ _ = a;
     , .Type);
+}
+
+test "inlayhints - capture values" {
     try testInlayHints(
         \\fn a() void {
-        \\ const foo: []const u8 = "abc";
-        \\ for (foo) |bar<u8>| {
-        \\  _ = bar;
+        \\  const foo: []const u8 = "abc";
+        \\      for (foo) |bar<u8>| {
+        \\      _ = bar;
+        \\  }
         \\}
+    , .Type);
+    try testInlayHints(
+        \\const FooError<type> = error{
+        \\  Err1,
+        \\};
+        \\fn testFn() void {
+        \\const foo: FooError!?[]const u8 = null;
+        \\    if (foo) |f<?[]const u8>| {
+        \\        if (f) |g<[]const u8>| {
+        \\            for (g) |c<u8>| {
+        \\               _ = c;
+        \\            }
+        \\        }
+        \\    } else |e<FooError>| {
+        \\        _ = e;
+        \\    }
+        \\}
+    , .Type);
+    try testInlayHints(
+        \\const FooError<type> = error{
+        \\  Err1,
+        \\};
+        \\const Foo<type> = struct {
+        \\    counter: usize,
+        \\    pub fn next(self: *Foo) FooError!?usize {
+        \\        if (self.counter == 0) {
+        \\            return null;
+        \\        }
+        \\        self.counter -= 1;
+        \\        return self.counter;
+        \\    }
+        \\};
+        \\fn a() void {
+        \\    var foo<Foo> = Foo {
+        \\        .counter = 10,
+        \\    };
+        \\    while (foo.next()) |val<?usize>| {
+        \\        if (val) |v<usize>| { _ = v; }
+        \\    } else |e<FooError>| { _ = e; }
         \\}
     , .Type);
 }

--- a/tests/lsp_features/inlay_hints.zig
+++ b/tests/lsp_features/inlay_hints.zig
@@ -135,9 +135,11 @@ test "inlayhints - var decl" {
         \\ _ = a;
     , .Type);
     try testInlayHints(
+        \\fn a() void {
         \\ const foo: []const u8 = "abc";
         \\ for (foo) |bar<u8>| {
-        \\
+        \\  _ = bar;
+        \\}
         \\}
     , .Type);
 }

--- a/tests/lsp_features/inlay_hints.zig
+++ b/tests/lsp_features/inlay_hints.zig
@@ -185,6 +185,18 @@ test "inlayhints - capture values" {
         \\    } else |e<FooError>| { _ = e; }
         \\}
     , .Type);
+
+    try testInlayHints(
+        \\fn foo() void {
+        \\  const bar: []const u8 = "test";
+        \\  for (bar, 0..3) |_, u<usize>| {
+        \\      _ = u;
+        \\  }
+        \\  for (bar, 0..3) |ch<u8>, _| {
+        \\      _ = ch;
+        \\  }
+        \\}
+    , .Type);
 }
 
 fn testInlayHints(source: []const u8, kind: types.InlayHintKind) !void {

--- a/tests/lsp_features/inlay_hints.zig
+++ b/tests/lsp_features/inlay_hints.zig
@@ -104,7 +104,7 @@ test "inlayhints - var decl" {
         \\const Error<type> = error{e};
         \\fn test_context() !void {
         \\    const baz: ?Foo = Foo{ .bar = 42 };
-        \\    if (baz) |b| {
+        \\    if (baz) |b<Foo>| {
         \\        const d: Error!?Foo = b;
         \\        const e<*Error!?Foo> = &d;
         \\        const f<Foo> = (try e.*).?;
@@ -133,6 +133,12 @@ test "inlayhints - var decl" {
         \\
         \\ var a<struct { a: u32, b: i32, c: struct { d: usize, e: []const u8, }, }> = thing(10, -4);
         \\ _ = a;
+    , .Type);
+    try testInlayHints(
+        \\ const foo: []const u8 = "abc";
+        \\ for (foo) |bar<u8>| {
+        \\
+        \\}
     , .Type);
 }
 


### PR DESCRIPTION
Adds inlay hints hints for the capture values of the control flow statements (`if`, `while`, `for`, `switch`).
![image](https://github.com/zigtools/zls/assets/101683475/78e30759-9df5-4850-8fb7-3bf657a1f16c)
![image](https://github.com/zigtools/zls/assets/101683475/c2ed8891-0328-4770-af16-1c943e0ccaaa)
![image](https://github.com/zigtools/zls/assets/101683475/b857dbff-7352-4785-b444-222648124a44)


Fixed multiple capture values not working
![image](https://github.com/zigtools/zls/assets/101683475/4f1b67eb-959b-4947-8204-4c10dfa02585)

