### PR TITLE
CI: don't fetch git submodules

### DIFF
--- a/.github/workflows/build_runner.yml
+++ b/.github/workflows/build_runner.yml
@@ -27,7 +27,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          submodules: true
 
       - name: Grab zig
         uses: goto-bus-stop/setup-zig@v2

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -67,7 +67,6 @@ jobs:
         with:
           path: zls
           fetch-depth: 0
-          submodules: true
 
       - name: Checkout zls (PR)
         if: github.event_name == 'pull_request_target'
@@ -75,7 +74,6 @@ jobs:
         with:
           path: zls
           fetch-depth: 0
-          submodules: true
           ref: "refs/pull/${{ github.event.number }}/merge"
 
       - name: Build zls
@@ -90,7 +88,6 @@ jobs:
           path: sus
           repository: "zigtools/sus"
           fetch-depth: 0
-          submodules: recursive
 
       - name: Build sus
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          submodules: true
       - uses: goto-bus-stop/setup-zig@v2
         with:
           version: master


### PR DESCRIPTION
ZLS only has tracy as a submodule which is not used anymore in our CI