### PR TITLE
add workaround for false-positive cimport header not found errors

### DIFF
--- a/src/features/goto.zig
+++ b/src/features/goto.zig
@@ -195,7 +195,7 @@ pub fn gotoDefinitionString(
             blk: {
                 if (std.fs.path.isAbsolute(import_str)) break :blk import_str;
                 var include_dirs: std.ArrayListUnmanaged([]const u8) = .{};
-                document_store.collectIncludeDirs(arena, handle.*, &include_dirs) catch |err| {
+                _ = document_store.collectIncludeDirs(arena, handle.*, &include_dirs) catch |err| {
                     log.err("failed to resolve include paths: {}", .{err});
                     return null;
                 };


### PR DESCRIPTION
When running translate-c, the set of all c include directories may not be fully resolved because build runner which is running asynchronously may not have finished yet.
These changes should detect this and not report the translate-c error.