### PR TITLE
don't add snippets when the client does not support it.

### DIFF
--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -498,22 +498,23 @@ fn completeLabel(
 }
 
 fn populateSnippedCompletions(
+    server: *Server,
     allocator: std.mem.Allocator,
     completions: *std.ArrayListUnmanaged(types.CompletionItem),
     snippets: []const snipped_data.Snipped,
-    config: Config,
 ) error{OutOfMemory}!void {
     try completions.ensureUnusedCapacity(allocator, snippets.len);
 
+    const use_snippets = server.config.enable_snippets and server.client_capabilities.supports_snippets;
     for (snippets) |snipped| {
-        if (!config.enable_snippets and snipped.kind == .Snippet) continue;
+        if (!use_snippets and snipped.kind == .Snippet) continue;
 
         completions.appendAssumeCapacity(.{
             .label = snipped.label,
             .kind = snipped.kind,
-            .detail = if (config.enable_snippets) snipped.text else null,
-            .insertText = if (config.enable_snippets) snipped.text else null,
-            .insertTextFormat = if (config.enable_snippets and snipped.text != null) .Snippet else .PlainText,
+            .detail = if (use_snippets) snipped.text else null,
+            .insertText = if (use_snippets) snipped.text else null,
+            .insertTextFormat = if (use_snippets and snipped.text != null) .Snippet else .PlainText,
         });
     }
 }
@@ -561,7 +562,7 @@ fn completeGlobal(server: *Server, analyser: *Analyser, arena: std.mem.Allocator
         .orig_handle = handle,
     };
     try analyser.iterateSymbolsGlobal(handle, pos_index, declToCompletion, context);
-    try populateSnippedCompletions(arena, &completions, &snipped_data.generic, server.config);
+    try populateSnippedCompletions(server, arena, &completions, &snipped_data.generic);
     try formatCompletionDetails(server, arena, completions.items);
 
     return completions.toOwnedSlice(arena);
@@ -931,7 +932,7 @@ pub fn completionAtIndex(server: *Server, analyser: *Analyser, arena: std.mem.Al
     const at_line_start = offsets.lineSliceUntilIndex(source, source_index).len < 2;
     if (at_line_start) {
         var completions = std.ArrayListUnmanaged(types.CompletionItem){};
-        try populateSnippedCompletions(arena, &completions, &snipped_data.top_level_decl_data, server.config);
+        try populateSnippedCompletions(server, arena, &completions, &snipped_data.top_level_decl_data);
 
         return .{ .isIncomplete = false, .items = completions.items };
     }


### PR DESCRIPTION
Using Neovim with YouCompleteMe failed this assertion
```python
  # We do not support completion types of "Snippet". This is implicit in that we
  # don't say it is a "capability" in the initialize request.
  # Abort this request if the server is buggy and ignores us.
  assert lsp.INSERT_TEXT_FORMAT[
    item.get( 'insertTextFormat' ) or 1 ] == 'PlainText'
```
```
Traceback (most recent call last):
  File ".vim/bundle/YouCompleteMe/third_party/ycmd/ycmd/handlers.py", line 120, in GetCompletions
    completions = filetype_completer.ComputeCandidates( request_data )
  File ".vim/bundle/YouCompleteMe/third_party/ycmd/ycmd/completers/completer.py", line 303, in ComputeCandidates
    candidates = self._GetCandidatesFromSubclass( request_data )
  File ".vim/bundle/YouCompleteMe/third_party/ycmd/ycmd/completers/language_server/language_server_completer.py", line 1328, in _GetCandidatesFromSubclass
    raw_completions, is_incomplete = self.ComputeCandidatesInner( request_data,
  File ".vim/bundle/YouCompleteMe/third_party/ycmd/ycmd/completers/language_server/language_server_completer.py", line 1313, in ComputeCandidatesInner
    return ( self._CandidatesFromCompletionItems(
  File ".vim/bundle/YouCompleteMe/third_party/ycmd/ycmd/completers/language_server/language_server_completer.py", line 1450, in _CandidatesFromCompletionItems
    _InsertionTextForItem( request_data, item ) )
  File ".vim/bundle/YouCompleteMe/third_party/ycmd/ycmd/completers/language_server/language_server_completer.py", line 2996, in _InsertionTextForItem
    assert lsp.INSERT_TEXT_FORMAT[
AssertionError
```
Reviewing the code i think it is because in nodeToCompletion use_snippets check both server and client support for snippet, but in populateSnippedCompletions only server support was checked, so i changed it to do the same check as in nodeToCompletion