### PR TITLE
completions: Unwrap the field's type if it's an optional

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -615,7 +615,7 @@ fn resolveReturnType(analyser: *Analyser, fn_decl: Ast.full.FnProto, handle: *co
 }
 
 /// Resolves the child type of an optional type
-fn resolveUnwrapOptionalType(analyser: *Analyser, opt: TypeWithHandle) !?TypeWithHandle {
+pub fn resolveUnwrapOptionalType(analyser: *Analyser, opt: TypeWithHandle) !?TypeWithHandle {
     const opt_node = switch (opt.type.data) {
         .other => |n| n,
         else => return null,

--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -1361,9 +1361,7 @@ fn collectFieldAccessContainerNodes(
         var node_type = try decl.resolveType(analyser) orelse continue;
         // Unwrap `identifier.opt_enum_field = .` or `identifier.opt_cont_field = .{.`
         if (dot_context.likely == .enum_assignment or dot_context.likely == .struct_field) {
-            if (node_type.type.data == .other and node_type.handle.tree.nodes.items(.tag)[node_type.type.data.other] == .optional_type) {
-                node_type = try analyser.resolveTypeOfNode(.{ .node = node_type.handle.tree.nodes.items(.data)[node_type.type.data.other].lhs, .handle = node_type.handle }) orelse return;
-            }
+            if (try analyser.resolveUnwrapOptionalType(node_type)) |unwrapped| node_type = unwrapped;
         }
         if (node_type.isFunc()) {
             var buf: [1]Ast.Node.Index = undefined;
@@ -1424,7 +1422,9 @@ fn collectEnumLiteralContainerNodes(
             else => continue,
         };
         const member_decl = try analyser.lookupSymbolContainer(.{ .node = node, .handle = container.handle }, alleged_field_name, .field) orelse continue;
-        const member_type = try member_decl.resolveType(analyser) orelse continue;
+        var member_type = try member_decl.resolveType(analyser) orelse continue;
+        // Unwrap `x{ .fld_w_opt_type =`
+        if (try analyser.resolveUnwrapOptionalType(member_type)) |unwrapped| member_type = unwrapped;
         try types_with_handles.append(arena, member_type);
     }
 }

--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -1012,6 +1012,18 @@ test "completion - struct init" {
         // TODO `alpha` should be excluded
         .{ .label = "alpha", .kind = .Field, .detail = "alpha: *const S" },
     });
+    try testCompletion(
+        \\const S = struct {
+        \\    alpha: *const S,
+        \\    beta: u32,
+        \\    gamma: ?S,
+        \\};
+        \\const foo = S{ .gamma = .{.<cursor>};
+    , &.{
+        .{ .label = "gamma", .kind = .Field, .detail = "gamma: ?S" },
+        .{ .label = "beta", .kind = .Field, .detail = "beta: u32" },
+        .{ .label = "alpha", .kind = .Field, .detail = "alpha: *const S" },
+    });
     // Aliases
     try testCompletion(
         \\pub const Outer = struct {


### PR DESCRIPTION
Handles `x{.a_field_with_an_optional_type =`