### PR TITLE
Remove extra comment check in `getPositionConntext`

### DIFF
--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -502,6 +502,21 @@ test "completion - struct" {
     });
 
     try testCompletion(
+        \\const Foo = struct {
+        \\    fn add(foo: Foo) Foo {}
+        \\};
+        \\test {
+        \\    var builder = Foo{};
+        \\    builder
+        \\        // Comments should
+        \\        // get ignored
+        \\        .<cursor>
+        \\}
+    , &.{
+        .{ .label = "add", .kind = .Function, .detail = "fn add(foo: Foo) Foo" },
+    });
+
+    try testCompletion(
         \\fn doNothingWithInteger(a: u32) void { _ = a; }
         \\const S = struct {
         \\    alpha: u32,

--- a/tests/lsp_features/definition.zig
+++ b/tests/lsp_features/definition.zig
@@ -33,6 +33,27 @@ test "definition - cursor is at the start of an identifier" {
     );
 }
 
+test "definition - multiline builder pattern" {
+    try testDefinition(
+        \\const Foo = struct {
+        \\    fn add(foo: Foo) Foo {}
+        \\    fn remove(foo: Foo) Foo {}
+        \\    fn process(foo: Foo) Foo {}
+        \\    fn <def>finalize</def>(_: Foo) void {}
+        \\};
+        \\test {
+        \\    var builder = Foo{};
+        \\    builder
+        \\        .add()
+        \\        .remove()
+        \\        .process()
+        \\        // Comments should
+        \\        // get ignored
+        \\        .finalize<>();
+        \\}
+    );
+}
+
 fn testDefinition(source: []const u8) !void {
     var phr = try helper.collectClearPlaceholders(allocator, source);
     defer phr.deinit(allocator);


### PR DESCRIPTION
I had intended this as a safety cut off, but it breaks struct init

```zig
const exe = b.addExecutable(.{
        .name = "Example",
        // no hover/completions/go to definition below a comment.. oops
        .root_source_file = .{ .path = "src/main.zig" },
        .target = target,
        .optimize = optimize,
    });
```