### PR TITLE
set minimum build version to `0.12.0-dev.1125+63f9af87d`

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -4,8 +4,8 @@ const builtin = @import("builtin");
 const zls_version = std.SemanticVersion{ .major = 0, .minor = 12, .patch = 0 };
 
 /// document the latest breaking change that caused a change to the string below:
-/// drop for loop syntax upgrade mechanisms
-const min_zig_string = "0.12.0-dev.899+027aabf49";
+/// zig env: back to json output
+const min_zig_string = "0.12.0-dev.1125+63f9af87d";
 
 pub fn build(b: *std.build.Builder) !void {
     comptime {

--- a/flake.lock
+++ b/flake.lock
@@ -83,11 +83,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1697009197,
-        "narHash": "sha256-viVRhBTFT8fPJTb1N3brQIpFZnttmwo3JVKNuWRVc3s=",
+        "lastModified": 1697793076,
+        "narHash": "sha256-02e7sCuqLtkyRgrZmdOyvAcQTQdcXj+vpyp9bca6cY4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "01441e14af5e29c9d27ace398e6dd0b293e25a54",
+        "rev": "038b2922be3fc096e1d456f93f7d0f4090628729",
         "type": "github"
       },
       "original": {
@@ -130,11 +130,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1697285248,
-        "narHash": "sha256-CPV/LWV/2nJKasawkshdCX1bLRsKGtSSiDoy14jix8c=",
+        "lastModified": 1697890054,
+        "narHash": "sha256-rtIWkj0XrXmBjl0tuWVibOfDoFiNvV//g/GyPAuQS/Q=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "ee376d4012e3c853123ca7083af852313235407c",
+        "rev": "5095445e952028c48dc6b93b09fa8280a1ccd23b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Just in case someone is using a zig build where `zig env` doesn't output json.