### PR TITLE
Fix build runner module crawler

### DIFF
--- a/src/build_runner/0.11.0.zig
+++ b/src/build_runner/0.11.0.zig
@@ -237,7 +237,7 @@ fn processModules(
 
         const already_added = try packages.addPackage(name, path);
         // if the package has already been added short circuit here or recursive modules will ruin us
-        if (already_added) return;
+        if (already_added) continue;
 
         try processModules(builder, packages, mod.dependencies);
     }


### PR DESCRIPTION
The build runner was returning when it found a default module, which is a bug; it was missing some modules in projects with more complicated module graphs.