### PR TITLE
completion fixes

### DIFF
--- a/src/analyser/completions.zig
+++ b/src/analyser/completions.zig
@@ -168,7 +168,7 @@ pub fn dotCompletions(
         .float_80_value,
         .float_128_value,
         .float_comptime_value,
-        => unreachable,
+        => {},
 
         .bytes,
         .optional_value,
@@ -178,7 +178,7 @@ pub fn dotCompletions(
         .null_value,
         .undefined_value,
         .unknown_value,
-        => unreachable,
+        => {},
     }
 }
 

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -2747,7 +2747,7 @@ pub const Declaration = union(enum) {
         param_index: u16,
         func: Ast.Node.Index,
 
-        pub fn get(self: Param, tree: Ast) Ast.full.FnProto.Param {
+        pub fn get(self: Param, tree: Ast) ?Ast.full.FnProto.Param {
             var buffer: [1]Ast.Node.Index = undefined;
             const func = tree.fullFnProto(&buffer, self.func).?;
             var param_index: u16 = 0;
@@ -2755,7 +2755,7 @@ pub const Declaration = union(enum) {
             while (ast.nextFnParam(&it)) |param| : (param_index += 1) {
                 if (self.param_index == param_index) return param;
             }
-            unreachable;
+            return null;
         }
     };
 
@@ -2798,7 +2798,7 @@ pub const Declaration = union(enum) {
     pub fn nameToken(decl: Declaration, tree: Ast) Ast.TokenIndex {
         return switch (decl) {
             .ast_node => |n| getDeclNameToken(tree, n).?,
-            .param_payload => |pp| pp.get(tree).name_token.?,
+            .param_payload => |pp| pp.get(tree).?.name_token.?,
             .pointer_payload => |pp| pp.name,
             .error_union_payload => |ep| ep.name,
             .error_union_error => |ep| ep.name,
@@ -2859,7 +2859,7 @@ pub const DeclWithHandle = struct {
             // TODO: delete redundant `Analyser.`
             .ast_node => |node| try Analyser.getDocComments(allocator, tree, node),
             .param_payload => |pay| {
-                const param = pay.get(tree);
+                const param = pay.get(tree).?;
                 const doc_comments = param.first_doc_comment orelse return null;
                 return try Analyser.collectDocComments(allocator, tree, doc_comments, false);
             },
@@ -2884,7 +2884,9 @@ pub const DeclWithHandle = struct {
                 .{ .node = node, .handle = self.handle },
             ),
             .param_payload => |pay| {
-                const param = pay.get(tree);
+                // the `get` function never fails on declarations from the DocumentScope but
+                // there may be manually created Declarations with invalid parameter indicies.
+                const param = pay.get(tree) orelse return null;
 
                 // handle anytype
                 if (param.type_expr == 0) {

--- a/src/features/code_actions.zig
+++ b/src/features/code_actions.zig
@@ -125,7 +125,7 @@ fn handleUnusedFunctionParameter(builder: *Builder, actions: *std.ArrayListUnman
         .title = "remove function parameter",
         .kind = .quickfix,
         .isPreferred = false,
-        .edit = try builder.createWorkspaceEdit(&.{builder.createTextEditLoc(getParamRemovalRange(tree, payload.get(tree)), "")}),
+        .edit = try builder.createWorkspaceEdit(&.{builder.createTextEditLoc(getParamRemovalRange(tree, payload.get(tree).?), "")}),
     };
 
     try actions.appendSlice(builder.arena, &.{ action1, action2 });

--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -418,7 +418,7 @@ fn declToCompletion(context: DeclToCompletionContext, decl_handle: Analyser.Decl
             context.either_descriptor,
         ),
         .param_payload => |pay| {
-            const param = pay.get(tree);
+            const param = pay.get(tree).?;
             const name = tree.tokenSlice(param.name_token.?);
             const doc = try completionDoc(
                 context.server,

--- a/src/features/hover.zig
+++ b/src/features/hover.zig
@@ -76,7 +76,7 @@ fn hoverSymbol(
             }
         },
         .param_payload => |pay| def: {
-            const param = pay.get(tree);
+            const param = pay.get(tree).?;
 
             if (param.type_expr != 0) // zero for `anytype` and extern C varargs `...`
                 try analyser.referencedTypesFromNode(

--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -1406,6 +1406,13 @@ test "completion - integer overflow in dot completions at beginning of file" {
     , &.{});
 }
 
+test "completion - enum completion on out of bound parameter index" {
+    try testCompletion(
+        \\fn foo() void {}
+        \\const foo = foo(,.<cursor>);
+    , &.{});
+}
+
 fn testCompletion(source: []const u8, expected_completions: []const Completion) !void {
     const cursor_idx = std.mem.indexOf(u8, source, "<cursor>").?;
     const text = try std.mem.concat(allocator, u8, &.{ source[0..cursor_idx], source[cursor_idx + "<cursor>".len ..] });


### PR DESCRIPTION
The invalid parameter index comes from [here](https://github.com/zigtools/zls/blob/86475a820e94e886e80bee87a795c25e94f4284a/src/features/completions.zig#L1298)
```zig
fn foo() void {}
const foo = foo(,.<cursor>);
```