### PR TITLE
refactor representation of resolved pointer and optional types

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -448,10 +448,6 @@ fn resolveVarDeclAliasInternal(analyser: *Analyser, node_handle: NodeWithHandle,
     const gop = try node_trail.getOrPut(analyser.gpa, node_with_uri);
     if (gop.found_existing) return null;
 
-    return try analyser.resolveVarDeclAliasUncached(node_handle, node_trail);
-}
-
-fn resolveVarDeclAliasUncached(analyser: *Analyser, node_handle: NodeWithHandle, node_trail: *NodeSet) error{OutOfMemory}!?DeclWithHandle {
     const handle = node_handle.handle;
     const tree = handle.tree;
     const node_tags = tree.nodes.items(.tag);
@@ -527,7 +523,7 @@ fn resolveVarDeclAliasUncached(analyser: *Analyser, node_handle: NodeWithHandle,
         return null;
     }
 
-    if (try analyser.resolveVarDeclAliasUncached(.{ .node = resolved_node, .handle = resolved.handle }, node_trail)) |result| {
+    if (try analyser.resolveVarDeclAliasInternal(.{ .node = resolved_node, .handle = resolved.handle }, node_trail)) |result| {
         return result;
     } else {
         return resolved;

--- a/src/features/references.zig
+++ b/src/features/references.zig
@@ -118,12 +118,11 @@ const Builder = struct {
                 }
             },
             .field_access => {
-                const left_type = try builder.analyser.resolveFieldAccessLhsType(
-                    (try builder.analyser.resolveTypeOfNode(.{ .node = datas[node].lhs, .handle = handle })) orelse return,
-                );
+                const lhs = try builder.analyser.resolveTypeOfNode(.{ .node = datas[node].lhs, .handle = handle }) orelse return;
+                const deref_lhs = try builder.analyser.resolveDerefType(lhs) orelse lhs;
 
                 const symbol = offsets.tokenToSlice(tree, datas[node].rhs);
-                const child = (try left_type.lookupSymbol(builder.analyser, symbol)) orelse return;
+                const child = (try deref_lhs.lookupSymbol(builder.analyser, symbol)) orelse return;
 
                 if (builder.decl_handle.eql(child)) {
                     try builder.add(handle, datas[node].rhs);
@@ -308,12 +307,11 @@ const CallBuilder = struct {
                         }
                     },
                     .field_access => {
-                        const left_type = try builder.analyser.resolveFieldAccessLhsType(
-                            (try builder.analyser.resolveTypeOfNode(.{ .node = datas[called_node].lhs, .handle = handle })) orelse return,
-                        );
+                        const lhs = (try builder.analyser.resolveTypeOfNode(.{ .node = datas[called_node].lhs, .handle = handle })) orelse return;
+                        const deref_lhs = try builder.analyser.resolveDerefType(lhs) orelse lhs;
 
                         const symbol = offsets.tokenToSlice(tree, datas[called_node].rhs);
-                        const child = (try left_type.lookupSymbol(builder.analyser, symbol)) orelse return;
+                        const child = (try deref_lhs.lookupSymbol(builder.analyser, symbol)) orelse return;
 
                         if (builder.decl_handle.eql(child)) {
                             try builder.add(handle, node);

--- a/src/features/semantic_tokens.zig
+++ b/src/features/semantic_tokens.zig
@@ -861,9 +861,8 @@ fn writeNodeTokens(builder: *Builder, node: Ast.Node.Index) error{OutOfMemory}!v
             // TODO This is basically exactly the same as what is done in analysis.resolveTypeOfNode, with the added
             //      writeToken code.
             // Maybe we can hook into it instead? Also applies to Identifier and VarDecl
-            const lhs_type = try builder.analyser.resolveFieldAccessLhsType(
-                (try builder.analyser.resolveTypeOfNode(.{ .node = data.lhs, .handle = handle })) orelse return,
-            );
+            const lhs = try builder.analyser.resolveTypeOfNode(.{ .node = data.lhs, .handle = handle }) orelse return;
+            const lhs_type = try builder.analyser.resolveDerefType(lhs) orelse lhs;
             if (try lhs_type.lookupSymbol(builder.analyser, tree.tokenSlice(data.rhs))) |decl_type| {
                 switch (decl_type.decl) {
                     .ast_node => |decl_node| {


### PR DESCRIPTION
Adds a separate representation for optional types instead of
falling back to ast nodes in `Analyser.Type`.
Unifies pointer types into a single union field in `Analyser.Type`
which avoids duplicating some code.

I've also included some refactoring I had lying around.