### PR TITLE
document scope dod follow-up

### DIFF
--- a/src/DocumentScope.zig
+++ b/src/DocumentScope.zig
@@ -1,7 +1,3 @@
-//! ZLS has a [DocumentScope](https://github.com/zigtools/zls/blob/61fec01a2006c5d509dee11c6f0d32a6dfbbf44e/src/analysis.zig#L3811) data structure that represents a high-level Ast used for looking up declarations and finding the current scope at a given source location.
-//! I recently had a discussion with @SuperAuguste about the DocumentScope and we were both agreed that it was in need of a rework.
-//! I took some of his suggestions and this what I came up with:
-
 const std = @import("std");
 const ast = @import("ast.zig");
 const Ast = std.zig.Ast;
@@ -9,7 +5,6 @@ const types = @import("lsp.zig");
 const tracy = @import("tracy.zig");
 const offsets = @import("offsets.zig");
 const Analyser = @import("analysis.zig");
-/// this a tagged union.
 const Declaration = Analyser.Declaration;
 
 const DocumentScope = @This();
@@ -45,12 +40,8 @@ pub const CompletionSet = std.ArrayHashMapUnmanaged(
     false,
 );
 
-/// alternative representation:
-///
-/// if we add every `Declaration` to `DocumentScope.declarations` in the same order we
-/// insert into this Map then there is no need to store the `Declaration.Index`
-/// because it matches the index inside the Map.
-/// this only works if every `Declaration` has only added to a single scope
+/// Every `index` inside this `ArrayhashMap` is equivalent to a `Declaration.Index`
+/// This means that every declaration is only the child of a single scope
 pub const DeclarationLookupMap = std.ArrayHashMapUnmanaged(
     DeclarationLookup,
     void,
@@ -138,12 +129,12 @@ pub const Scope = struct {
         data: Data,
     },
     // offsets.Loc store `usize` instead of `u32`
-    // zig only allows files up to std.math.maxInt(u32) bytes to do this kind of optimization. ZLS should also follow this.
+    // zig only allows files up to `std.math.maxInt(u32)` bytes to do this kind of optimization.
+    // TODO ZLS should check this.
     loc: SmallLoc,
     parent_scope: OptionalIndex,
     // child scopes have contiguous indices
-    // used only by the EnclosingScopeIterator
-    // https://github.com/zigtools/zls/blob/61fec01a2006c5d509dee11c6f0d32a6dfbbf44e/src/analysis.zig#L3127
+    // used only by the `EnclosingScopeIterator`
     child_scopes: ChildScopes,
     child_declarations: ChildDeclarations,
 

--- a/src/DocumentScope.zig
+++ b/src/DocumentScope.zig
@@ -434,6 +434,7 @@ fn walkNodeEnsureScope(
                 undefined,
                 locToSmallLoc(offsets.tokensToLoc(tree, start_token, ast.lastToken(tree, node_idx))),
             );
+            try walkNode(context, tree, node_idx);
             return new_scope;
         },
     }

--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -389,6 +389,16 @@ test "completion - captures" {
     , &.{
         .{ .label = "alpha", .kind = .Field, .detail = "alpha: u32" },
     });
+    try testCompletion(
+        \\const S = struct { alpha: u32 };
+        \\fn foo(maybe_maybe_s: ??S) void {
+        \\    if (maybe_maybe_s) |maybe_s| if (maybe_s) |s| {
+        \\        s.<cursor>
+        \\    };
+        \\}
+    , &.{
+        .{ .label = "alpha", .kind = .Field, .detail = "alpha: u32" },
+    });
 
     try testCompletion(
         \\const S = struct { alpha: u32 };


### PR DESCRIPTION
fixes #1554
```
Benchmark 1 (67 runs): ./document_scope_master
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          1.82s  ± 30.5ms    1.78s  … 1.96s           3 ( 4%)        0%
  peak_rss           8.20MB ± 49.5KB    8.09MB … 8.33MB          0 ( 0%)        0%
  cpu_cycles         7.02G  ±  118M     6.90G  … 7.59G           3 ( 4%)        0%
  instructions       9.86G  ± 1.80K     9.86G  … 9.86G           0 ( 0%)        0%
  cache_references   45.8M  ±  315K     45.3M  … 47.1M           3 ( 4%)        0%
  cache_misses       1.24M  ±  381K      665K  … 2.06M           0 ( 0%)        0%
  branch_misses      77.4M  ± 1.32M     74.8M  … 80.6M           0 ( 0%)        0%
Benchmark 2 (65 runs): ./document_scope_deez_nuts
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          1.85s  ± 16.1ms    1.83s  … 1.92s           5 ( 8%)        💩+  2.1% ±  0.5%
  peak_rss           7.92MB ± 49.7KB    7.82MB … 8.06MB          0 ( 0%)        ⚡-  3.4% ±  0.2%
  cpu_cycles         7.17G  ± 62.7M     7.07G  … 7.45G           5 ( 8%)        💩+  2.1% ±  0.5%
  instructions       10.1G  ± 2.10K     10.1G  … 10.1G           0 ( 0%)        💩+  2.4% ±  0.0%
  cache_references   45.6M  ±  272K     45.1M  … 46.5M           1 ( 2%)          -  0.5% ±  0.2%
  cache_misses       1.54M  ±  409K      610K  … 2.30M           2 ( 3%)        💩+ 23.8% ± 10.9%
  branch_misses      76.9M  ± 1.43M     75.1M  … 83.8M           4 ( 6%)          -  0.6% ±  0.6
```
This performance pessimization is mostly from https://github.com/zigtools/zls/commit/54c0c18b73f837e2194c8f0152a4ee87343e059b which was required to fix #1554.