### PR TITLE
folding range fixes on anytype parameters and trailing comments

### DIFF
--- a/tests/lsp_features/folding_range.zig
+++ b/tests/lsp_features/folding_range.zig
@@ -19,6 +19,13 @@ test "foldingRange - container type without members" {
     , &.{
         .{ .startLine = 0, .startCharacter = 18, .endLine = 1, .endCharacter = 0 },
     });
+    try testFoldingRange(
+        \\const S = struct {
+        \\    // hello there
+        \\};
+    , &.{
+        .{ .startLine = 0, .startCharacter = 18, .endLine = 2, .endCharacter = 0 },
+    });
 }
 
 test "foldingRange - doc comment" {
@@ -173,7 +180,7 @@ test "foldingRange - container decl" {
         \\const Foo = struct {
         \\  /// doc comment
         \\  alpha: u32,
-        \\  beta: []const u8,
+        \\  // beta: []const u8,
         \\};
     , &.{
         .{ .startLine = 0, .startCharacter = 20, .endLine = 4, .endCharacter = 0 },
@@ -201,6 +208,22 @@ test "foldingRange - container decl" {
         \\};
     , &.{
         .{ .startLine = 0, .startCharacter = 25, .endLine = 3, .endCharacter = 0 },
+    });
+    try testFoldingRange(
+        \\const Foo = struct {
+        \\  fn foo() void {}
+        \\};
+    , &.{
+        .{ .startLine = 0, .startCharacter = 20, .endLine = 2, .endCharacter = 0 },
+    });
+    try testFoldingRange(
+        \\const Foo = struct {
+        \\  fn foo() void {}
+        \\  fn bar() void {}
+        \\  // some comment
+        \\};
+    , &.{
+        .{ .startLine = 0, .startCharacter = 20, .endLine = 4, .endCharacter = 0 },
     });
 }
 

--- a/tests/lsp_features/folding_range.zig
+++ b/tests/lsp_features/folding_range.zig
@@ -122,6 +122,14 @@ test "foldingRange - function" {
     try testFoldingRange(
         \\fn main(
         \\  a: ?u32,
+        \\  b: anytype,
+        \\) !u32 {}
+    , &.{
+        .{ .startLine = 0, .startCharacter = 8, .endLine = 2, .endCharacter = 13 },
+    });
+    try testFoldingRange(
+        \\fn main(
+        \\  a: ?u32,
         \\) !u32 {
         \\    return 1 + 1;
         \\}


### PR DESCRIPTION
- add folding range test coverage on trailing comments (see #1528 which has been fixed by 27562655530923b178f37664c05ab15a11c26645)
- fixes folding range on anytype function parameters [linked issue comment](https://github.com/zigtools/zls/issues/1131#issuecomment-1510829408)
