### PR TITLE
fix signature help on function with self as pointer

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -531,7 +531,7 @@ fn resolveVarDeclAliasInternal(analyser: *Analyser, node_handle: NodeWithHandle,
 }
 
 /// resolves `@field(lhs, field_name)`
-fn resolveFieldAccess(analyser: *Analyser, lhs: TypeWithHandle, field_name: []const u8) !?TypeWithHandle {
+pub fn resolveFieldAccess(analyser: *Analyser, lhs: TypeWithHandle, field_name: []const u8) !?TypeWithHandle {
     if (try analyser.resolveTaggedUnionFieldType(lhs, field_name)) |tag_type| return tag_type;
 
     // If we are accessing a pointer type, remove one pointerness level :)

--- a/src/features/signature_help.zig
+++ b/src/features/signature_help.zig
@@ -258,11 +258,7 @@ pub fn getSignatureInfo(analyser: *Analyser, arena: std.mem.Allocator, handle: *
                 const name = offsets.locToSlice(handle.tree.source, name_loc);
 
                 const skip_self_param = !type_handle.type.is_type_val;
-                const decl_handle = (try type_handle.lookupSymbol(analyser, name)) orelse {
-                    try symbol_stack.append(arena, .l_paren);
-                    continue;
-                };
-                type_handle = try decl_handle.resolveType(analyser) orelse {
+                type_handle = try analyser.resolveFieldAccess(type_handle, name) orelse {
                     try symbol_stack.append(arena, .l_paren);
                     continue;
                 };

--- a/tests/lsp_features/signature_help.zig
+++ b/tests/lsp_features/signature_help.zig
@@ -108,6 +108,8 @@ test "signature help - function pointer container field" {
 }
 
 test "signature help - self parameter" {
+    // parameter: S
+    // argument: S
     try testSignatureHelp(
         \\const S = struct {
         \\    fn foo(self: @This(), a: u32, b: void) bool {}
@@ -121,6 +123,42 @@ test "signature help - self parameter" {
         \\};
         \\const foo = S.foo(undefined,<cursor>);
     , "fn foo(self: @This(), a: u32, b: void) bool", 1);
+
+    // parameter: *S
+    // argument: S
+    try testSignatureHelp(
+        \\const S = struct {
+        \\    fn foo(self: *@This(), a: u32, b: void) bool {}
+        \\};
+        \\const s: S = undefined;
+        \\const foo = s.foo(3,<cursor>);
+    , "fn foo(self: *@This(), a: u32, b: void) bool", 2);
+    try testSignatureHelp(
+        \\const S = struct {
+        \\    fn foo(self: *@This(), a: u32, b: void) bool {}
+        \\};
+        \\const foo = S.foo(undefined,<cursor>);
+    , "fn foo(self: *@This(), a: u32, b: void) bool", 1);
+
+    // parameter: S
+    // argument: *S
+    try testSignatureHelp(
+        \\const S = struct {
+        \\    fn foo(self: @This(), a: u32, b: void) bool {}
+        \\};
+        \\const s: *S = undefined;
+        \\const foo = s.foo(3,<cursor>);
+    , "fn foo(self: @This(), a: u32, b: void) bool", 2);
+
+    // parameter: *S
+    // argument: *S
+    try testSignatureHelp(
+        \\const S = struct {
+        \\    fn foo(self: *@This(), a: u32, b: void) bool {}
+        \\};
+        \\const s: *S = undefined;
+        \\const foo = s.foo(3,<cursor>);
+    , "fn foo(self: *@This(), a: u32, b: void) bool", 2);
 }
 
 test "signature help - anytype" {


### PR DESCRIPTION
this is something that I recently broke:
```zig
const S = struct {
    fn foo(self: *S, param: u32) bool {
        _ = param;
        _ = self;
    }
};
const s: *S = undefined; // if the was `S` instead of `*S` then it would work
const foo = s.foo(<ask for signature help here>);
```