### PR TITLE
semantic token test coverage + minor fixes

### DIFF
--- a/src/features/semantic_tokens.zig
+++ b/src/features/semantic_tokens.zig
@@ -498,7 +498,7 @@ fn writeNodeTokens(builder: *Builder, node: Ast.Node.Index) error{OutOfMemory}!v
         .while_cont,
         => {
             const while_node = ast.fullWhile(tree, node).?;
-            try writeToken(builder, while_node.label_token, .label);
+            try writeTokenMod(builder, while_node.label_token, .label, .{ .declaration = true });
             try writeToken(builder, while_node.inline_token, .keyword);
             try writeToken(builder, while_node.ast.while_token, .keyword);
             try writeNodeTokens(builder, while_node.ast.cond_expr);
@@ -524,7 +524,7 @@ fn writeNodeTokens(builder: *Builder, node: Ast.Node.Index) error{OutOfMemory}!v
         .@"for",
         => {
             const for_node = ast.fullFor(tree, node).?;
-            try writeToken(builder, for_node.label_token, .label);
+            try writeTokenMod(builder, for_node.label_token, .label, .{ .declaration = true });
             try writeToken(builder, for_node.inline_token, .keyword);
             try writeToken(builder, for_node.ast.for_token, .keyword);
 

--- a/src/features/semantic_tokens.zig
+++ b/src/features/semantic_tokens.zig
@@ -955,7 +955,7 @@ fn writeNodeTokens(builder: *Builder, node: Ast.Node.Index) error{OutOfMemory}!v
             try writeToken(builder, main_token, .keyword);
             try writeNodeTokens(builder, node_data[node].lhs);
         },
-        .anyframe_literal => try writeToken(builder, main_token, .keyword),
+        .anyframe_literal => try writeToken(builder, main_token, .type),
     }
 }
 

--- a/src/features/semantic_tokens.zig
+++ b/src/features/semantic_tokens.zig
@@ -432,8 +432,6 @@ fn writeNodeTokens(builder: *Builder, node: Ast.Node.Index) error{OutOfMemory}!v
 
             var it = fn_proto.iterate(&tree);
             while (ast.nextFnParam(&it)) |param_decl| {
-                if (param_decl.first_doc_comment) |docs| try writeDocComments(builder, tree, docs);
-
                 try writeToken(builder, param_decl.comptime_noalias, .keyword);
 
                 const token_type: TokenType = if (Analyser.isMetaType(tree, param_decl.type_expr)) .typeParameter else .parameter;

--- a/src/features/semantic_tokens.zig
+++ b/src/features/semantic_tokens.zig
@@ -900,13 +900,6 @@ fn writeNodeTokens(builder: *Builder, node: Ast.Node.Index) error{OutOfMemory}!v
         => {
             const ptr_type = ast.fullPtrType(tree, node).?;
 
-            if (ptr_type.size == .One and token_tags[main_token] == .asterisk_asterisk and
-                main_token == main_tokens[ptr_type.ast.child_type])
-            {
-                return try writeNodeTokens(builder, ptr_type.ast.child_type);
-            }
-
-            if (ptr_type.size == .One) try writeToken(builder, main_token, .operator);
             if (ptr_type.ast.sentinel != 0) {
                 try writeNodeTokens(builder, ptr_type.ast.sentinel);
             }

--- a/src/features/semantic_tokens.zig
+++ b/src/features/semantic_tokens.zig
@@ -192,16 +192,6 @@ inline fn writeTokenMod(builder: *Builder, token_idx: ?Ast.TokenIndex, tok_type:
     }
 }
 
-fn writeDocComments(builder: *Builder, tree: Ast, doc: Ast.TokenIndex) !void {
-    const token_tags = tree.tokens.items(.tag);
-    var tok_idx = doc;
-    while (token_tags[tok_idx] == .doc_comment or
-        token_tags[tok_idx] == .container_doc_comment) : (tok_idx += 1)
-    {
-        try builder.add(tok_idx, .comment, .{ .documentation = true });
-    }
-}
-
 fn fieldTokenType(
     container_decl: Ast.Node.Index,
     handle: *DocumentStore.Handle,
@@ -344,10 +334,10 @@ fn writeNodeTokens(builder: *Builder, node: Ast.Node.Index) error{OutOfMemory}!v
             try writeNodeTokens(builder, var_decl.ast.init_node);
         },
         .@"usingnamespace" => {
-            const first_tok = tree.firstToken(node);
-            if (first_tok > 0 and token_tags[first_tok - 1] == .doc_comment)
-                try writeDocComments(builder, tree, first_tok - 1);
-            try writeToken(builder, if (token_tags[first_tok] == .keyword_pub) first_tok else null, .keyword);
+            const first_token = tree.firstToken(node);
+            if (token_tags[first_token] == .keyword_pub) {
+                try writeToken(builder, first_token, .keyword);
+            }
             try writeToken(builder, main_token, .keyword);
             try writeNodeTokens(builder, node_data[node].lhs);
         },

--- a/tests/lsp_features/semantic_tokens.zig
+++ b/tests/lsp_features/semantic_tokens.zig
@@ -690,6 +690,42 @@ test "semantic tokens - usingnamespace" {
         .{ "usingnamespace", .keyword, .{} },
     });
 }
+
+test "semantic tokens - container declarations" {
+    try testSemanticTokens(
+        \\const Foo = struct {
+        \\    /// some
+        \\    /// comment
+        \\    pub const Bar = u32;
+        \\    comptime {
+        \\        return;
+        \\    }
+        \\    test {
+        \\        return;
+        \\    }
+        \\};
+    , &.{
+        .{ "const", .keyword, .{} },
+        .{ "Foo", .namespace, .{ .declaration = true } },
+        .{ "=", .operator, .{} },
+        .{ "struct", .keyword, .{} },
+
+        .{ "/// some", .comment, .{ .documentation = true } },
+        .{ "/// comment", .comment, .{ .documentation = true } },
+        .{ "pub", .keyword, .{} },
+        .{ "const", .keyword, .{} },
+        .{ "Bar", .type, .{ .declaration = true } },
+        .{ "=", .operator, .{} },
+        .{ "u32", .type, .{} },
+
+        .{ "comptime", .keyword, .{} },
+        .{ "return", .keyword, .{} },
+
+        .{ "test", .keyword, .{} },
+        .{ "return", .keyword, .{} },
+    });
+}
+
 test "semantic tokens - struct" {
     try testSemanticTokens(
         \\const Foo = struct {};

--- a/tests/lsp_features/semantic_tokens.zig
+++ b/tests/lsp_features/semantic_tokens.zig
@@ -43,6 +43,26 @@ test "semantic tokens - comment" {
         .{ "a", .variable, .{ .declaration = true } },
     });
 }
+test "semantic tokens - doc comment" {
+    try testSemanticTokens(
+        \\/// line 1
+        \\/// line 2
+        \\const foo = struct {
+        \\    /// some comment
+        \\    alpha: u32,
+        \\};
+    , &.{
+        .{ "/// line 1", .comment, .{ .documentation = true } },
+        .{ "/// line 2", .comment, .{ .documentation = true } },
+        .{ "const", .keyword, .{} },
+        .{ "foo", .@"struct", .{ .declaration = true } },
+        .{ "=", .operator, .{} },
+        .{ "struct", .keyword, .{} },
+        .{ "/// some comment", .comment, .{ .documentation = true } },
+        .{ "alpha", .property, .{ .declaration = true } },
+        .{ "u32", .type, .{} },
+    });
+}
 
 test "semantic tokens - string literals" {
     try testSemanticTokens(

--- a/tests/lsp_features/semantic_tokens.zig
+++ b/tests/lsp_features/semantic_tokens.zig
@@ -84,11 +84,13 @@ test "semantic tokens - type literals" {
         \\f16,
         \\u8,
         \\u15,
+        \\anyframe,
     , &.{
         .{ "bool", .type, .{} },
         .{ "f16", .type, .{} },
         .{ "u8", .type, .{} },
         .{ "u15", .type, .{} },
+        .{ "anyframe", .type, .{} },
     });
 }
 

--- a/tests/lsp_features/semantic_tokens.zig
+++ b/tests/lsp_features/semantic_tokens.zig
@@ -99,11 +99,13 @@ test "semantic tokens - value literals" {
         \\true,
         \\false,
         \\undefined,
+        \\unreachable,
         \\null,
     , &.{
         .{ "true", .keywordLiteral, .{} },
         .{ "false", .keywordLiteral, .{} },
         .{ "undefined", .keywordLiteral, .{} },
+        .{ "unreachable", .keywordLiteral, .{} },
         .{ "null", .keywordLiteral, .{} },
     });
 }

--- a/tests/lsp_features/semantic_tokens.zig
+++ b/tests/lsp_features/semantic_tokens.zig
@@ -607,6 +607,39 @@ test "semantic tokens - error union types" {
     });
 }
 
+test "semantic tokens - usingnamespace" {
+    try testSemanticTokens(
+        \\const Foo = struct {
+        \\    usingnamespace {};
+        \\    pub usingnamespace {};
+        \\    /// aaa
+        \\    /// bbb
+        \\    pub usingnamespace {};
+        \\    /// ccc
+        \\    /// ddd
+        \\    usingnamespace {};
+        \\};
+    , &.{
+        .{ "const", .keyword, .{} },
+        .{ "Foo", .namespace, .{ .declaration = true } },
+        .{ "=", .operator, .{} },
+        .{ "struct", .keyword, .{} },
+
+        .{ "usingnamespace", .keyword, .{} },
+
+        .{ "pub", .keyword, .{} },
+        .{ "usingnamespace", .keyword, .{} },
+
+        .{ "/// aaa", .comment, .{ .documentation = true } },
+        .{ "/// bbb", .comment, .{ .documentation = true } },
+        .{ "pub", .keyword, .{} },
+        .{ "usingnamespace", .keyword, .{} },
+
+        .{ "/// ccc", .comment, .{ .documentation = true } },
+        .{ "/// ddd", .comment, .{ .documentation = true } },
+        .{ "usingnamespace", .keyword, .{} },
+    });
+}
 test "semantic tokens - struct" {
     try testSemanticTokens(
         \\const Foo = struct {};

--- a/tests/lsp_features/semantic_tokens.zig
+++ b/tests/lsp_features/semantic_tokens.zig
@@ -879,6 +879,29 @@ test "semantic tokens - function" {
         .{ "void", .type, .{} },
     });
     try testSemanticTokens(
+        \\fn foo(
+        \\    /// some comment
+        \\    alpha: u32,
+        \\    /// some
+        \\    /// comment
+        \\    beta: anytype,
+        \\) void {}
+    , &.{
+        .{ "fn", .keyword, .{} },
+        .{ "foo", .function, .{ .declaration = true, .generic = true } },
+
+        .{ "/// some comment", .comment, .{ .documentation = true } },
+        .{ "alpha", .parameter, .{ .declaration = true } },
+        .{ "u32", .type, .{} },
+
+        .{ "/// some", .comment, .{ .documentation = true } },
+        .{ "/// comment", .comment, .{ .documentation = true } },
+        .{ "beta", .parameter, .{ .declaration = true } },
+        .{ "anytype", .type, .{} },
+
+        .{ "void", .type, .{} },
+    });
+    try testSemanticTokens(
         \\extern fn foo() align(4) callconv(.C) void;
     , &.{
         .{ "extern", .keyword, .{} },

--- a/tests/lsp_features/semantic_tokens.zig
+++ b/tests/lsp_features/semantic_tokens.zig
@@ -246,6 +246,17 @@ test "semantic tokens - operators" {
         .{ "and", .keyword, .{} },
         .{ "false", .keywordLiteral, .{} },
     });
+    try testSemanticTokens(
+        \\var alpha = (undefined).?.*;
+    , &.{
+        .{ "var", .keyword, .{} },
+        .{ "alpha", .variable, .{ .declaration = true } },
+        .{ "=", .operator, .{} },
+        .{ "undefined", .keywordLiteral, .{} },
+        // TODO these should be either (.? and .*) or (? and *)
+        .{ "?", .operator, .{} },
+        .{ ".*", .operator, .{} },
+    });
 }
 
 test "semantic tokens - field access with @import" {

--- a/tests/lsp_features/semantic_tokens.zig
+++ b/tests/lsp_features/semantic_tokens.zig
@@ -538,7 +538,6 @@ test "semantic tokens - pointer types" {
         .{ "const", .keyword, .{} },
         .{ "alpha", .type, .{ .declaration = true } },
         .{ "=", .operator, .{} },
-        .{ "*", .operator, .{} },
         .{ "u32", .type, .{} },
     });
     try testSemanticTokens(
@@ -547,7 +546,6 @@ test "semantic tokens - pointer types" {
         .{ "const", .keyword, .{} },
         .{ "alpha", .type, .{ .declaration = true } },
         .{ "=", .operator, .{} },
-        .{ "*", .operator, .{} },
         .{ "allowzero", .keyword, .{} },
         .{ "u32", .type, .{} },
     });
@@ -562,12 +560,21 @@ test "semantic tokens - pointer types" {
         .{ "u32", .type, .{} },
     });
     try testSemanticTokens(
+        \\const alpha = [*c]const volatile u32;
+    , &.{
+        .{ "const", .keyword, .{} },
+        .{ "alpha", .type, .{ .declaration = true } },
+        .{ "=", .operator, .{} },
+        .{ "const", .keyword, .{} },
+        .{ "volatile", .keyword, .{} },
+        .{ "u32", .type, .{} },
+    });
+    try testSemanticTokens(
         \\const alpha = *align(1:2:3) u32;
     , &.{
         .{ "const", .keyword, .{} },
         .{ "alpha", .type, .{ .declaration = true } },
         .{ "=", .operator, .{} },
-        .{ "*", .operator, .{} },
         .{ "align", .keyword, .{} },
         .{ "1", .number, .{} },
         .{ "2", .number, .{} },

--- a/tests/lsp_features/semantic_tokens.zig
+++ b/tests/lsp_features/semantic_tokens.zig
@@ -1263,6 +1263,11 @@ test "semantic tokens - test decl" {
         .{ "\"test inside a test\"", .string, .{} },
     });
     try testSemanticTokens(
+        \\test {}
+    , &.{
+        .{ "test", .keyword, .{} },
+    });
+    try testSemanticTokens(
         \\test foo {}
     , &.{
         .{ "test", .keyword, .{} },

--- a/tests/lsp_features/semantic_tokens.zig
+++ b/tests/lsp_features/semantic_tokens.zig
@@ -1047,6 +1047,24 @@ test "semantic tokens - while" {
         .{ "else", .keyword, .{} },
         .{ "true", .keywordLiteral, .{} },
     });
+    try testSemanticTokens(
+        \\const foo = blk: while (undefined) {
+        \\    continue :blk;
+        \\} else |err| return err;
+    , &.{
+        .{ "const", .keyword, .{} },
+        .{ "foo", .variable, .{ .declaration = true } },
+        .{ "=", .operator, .{} },
+        .{ "blk", .label, .{ .declaration = true } },
+        .{ "while", .keyword, .{} },
+        .{ "undefined", .keywordLiteral, .{} },
+        .{ "continue", .keyword, .{} },
+        .{ "blk", .label, .{} },
+        .{ "else", .keyword, .{} },
+        .{ "err", .variable, .{ .declaration = true } },
+        .{ "return", .keyword, .{} },
+        .{ "err", .variable, .{} },
+    });
 }
 
 test "semantic tokens - for" {
@@ -1068,6 +1086,23 @@ test "semantic tokens - for" {
         .{ "for", .keyword, .{} },
         .{ "\"\"", .string, .{} },
         .{ "val", .variable, .{ .declaration = true } },
+    });
+    try testSemanticTokens(
+        \\const foo = blk: for ("") |val| {} else {
+        \\    break :blk null;
+        \\};
+    , &.{
+        .{ "const", .keyword, .{} },
+        .{ "foo", .variable, .{ .declaration = true } },
+        .{ "=", .operator, .{} },
+        .{ "blk", .label, .{ .declaration = true } },
+        .{ "for", .keyword, .{} },
+        .{ "\"\"", .string, .{} },
+        .{ "val", .variable, .{ .declaration = true } },
+        .{ "else", .keyword, .{} },
+        .{ "break", .keyword, .{} },
+        .{ "blk", .label, .{} },
+        .{ "null", .keywordLiteral, .{} },
     });
 }
 

--- a/tests/lsp_features/semantic_tokens.zig
+++ b/tests/lsp_features/semantic_tokens.zig
@@ -508,6 +508,23 @@ test "semantic tokens - struct literal" {
         .{ "1", .number, .{} },
         .{ "2", .number, .{} },
     });
+    try testSemanticTokens(
+        \\var alpha = .{ .foo = 1, .bar = 2 };
+    , &.{
+        .{ "var", .keyword, .{} },
+        .{ "alpha", .variable, .{ .declaration = true } },
+        .{ "=", .operator, .{} },
+
+        .{ ".", .property, .{} },
+        .{ "foo", .property, .{} },
+        .{ "=", .operator, .{} },
+        .{ "1", .number, .{} },
+
+        .{ ".", .property, .{} },
+        .{ "bar", .property, .{} },
+        .{ "=", .operator, .{} },
+        .{ "2", .number, .{} },
+    });
 }
 
 test "semantic tokens - optional types" {


### PR DESCRIPTION
The individual commit messages should explain all the changes.
This increases test coverage of semantic tokens from 91.7% to 97.9%.