### PR TITLE
handle symbol lookup between unescaped and escaped identifiers

### DIFF
--- a/src/features/inlay_hints.zig
+++ b/src/features/inlay_hints.zig
@@ -336,8 +336,9 @@ fn writeCallNodeHint(builder: *Builder, call: Ast.full.Call) !void {
 
     switch (node_tags[call.ast.fn_expr]) {
         .identifier => {
-            const source_index = offsets.tokenToIndex(tree, main_tokens[call.ast.fn_expr]);
-            const name = offsets.tokenToSlice(tree, main_tokens[call.ast.fn_expr]);
+            const name_token = main_tokens[call.ast.fn_expr];
+            const name = offsets.identifierTokenToNameSlice(tree, name_token);
+            const source_index = offsets.tokenToIndex(tree, name_token);
 
             if (try builder.analyser.lookupSymbolGlobal(handle, name, source_index)) |decl_handle| {
                 try writeCallHint(builder, call, decl_handle);
@@ -358,7 +359,7 @@ fn writeCallNodeHint(builder: *Builder, call: Ast.full.Call) !void {
                 .end = rhs_loc.end,
             })) |type_handle| {
                 const container_handle = try builder.analyser.resolveDerefType(type_handle) orelse type_handle;
-                const symbol = offsets.locToSlice(tree.source, rhs_loc);
+                const symbol = offsets.identifierTokenToNameSlice(tree, rhsToken);
                 if (try container_handle.lookupSymbol(builder.analyser, symbol)) |decl_handle| {
                     try writeCallHint(builder, call, decl_handle);
                 }

--- a/src/features/semantic_tokens.zig
+++ b/src/features/semantic_tokens.zig
@@ -1002,14 +1002,15 @@ fn writeIdentifier(builder: *Builder, name_token: Ast.Node.Index) error{OutOfMem
     const handle = builder.handle;
     const tree = handle.tree;
 
-    std.debug.assert(tree.tokens.items(.tag)[name_token] == .identifier);
-    const name = offsets.tokenToSlice(tree, name_token);
+    const name = offsets.identifierTokenToNameSlice(tree, name_token);
+    const is_escaped_identifier = tree.source[tree.tokens.items(.start)[name_token]] == '@';
 
-    if (std.mem.eql(u8, name, "_")) return;
-
-    if (Analyser.resolvePrimitiveType(name)) |primitive| {
-        const is_type = builder.analyser.ip.indexToKey(primitive).typeOf() == .type_type;
-        return try writeToken(builder, name_token, if (is_type) .type else .keywordLiteral);
+    if (!is_escaped_identifier) {
+        if (std.mem.eql(u8, name, "_")) return;
+        if (Analyser.resolvePrimitiveType(name)) |primitive| {
+            const is_type = builder.analyser.ip.indexToKey(primitive).typeOf() == .type_type;
+            return try writeToken(builder, name_token, if (is_type) .type else .keywordLiteral);
+        }
     }
 
     if (try builder.analyser.lookupSymbolGlobal(

--- a/src/offsets.zig
+++ b/src/offsets.zig
@@ -150,6 +150,42 @@ fn identifierIndexToLoc(tree: Ast, source_index: usize) Loc {
     return .{ .start = source_index, .end = index };
 }
 
+pub fn identifierIndexToNameLoc(text: [:0]const u8, source_index: usize) Loc {
+    if (text[source_index] == '@') {
+        std.debug.assert(text[source_index + 1] == '\"');
+        const start_index = source_index + 2;
+        var index: usize = start_index;
+        while (true) : (index += 1) {
+            if (text[index] == '\"') {
+                break;
+            }
+        }
+        return .{ .start = start_index, .end = index };
+    } else {
+        var index: usize = source_index;
+        while (true) : (index += 1) {
+            switch (text[index]) {
+                'a'...'z', 'A'...'Z', '_', '0'...'9' => {},
+                else => break,
+            }
+        }
+        return .{ .start = source_index, .end = index };
+    }
+}
+
+pub fn identifierIndexToNameSlice(text: [:0]const u8, source_index: usize) []const u8 {
+    return locToSlice(text, identifierIndexToNameLoc(text, source_index));
+}
+
+pub fn identifierTokenToNameLoc(tree: Ast, identifier_token: Ast.TokenIndex) Loc {
+    std.debug.assert(tree.tokens.items(.tag)[identifier_token] == .identifier);
+    return identifierIndexToNameLoc(tree.source, tree.tokens.items(.start)[identifier_token]);
+}
+
+pub fn identifierTokenToNameSlice(tree: Ast, identifier_token: Ast.TokenIndex) []const u8 {
+    return locToSlice(tree.source, identifierTokenToNameLoc(tree, identifier_token));
+}
+
 pub fn tokenToIndex(tree: Ast, token_index: Ast.TokenIndex) usize {
     return tree.tokens.items(.start)[token_index];
 }

--- a/tests/utility/offsets.zig
+++ b/tests/utility/offsets.zig
@@ -46,6 +46,20 @@ test "offsets - tokenIndexToLoc" {
     try testTokenIndexToLoc(" bar ", 0, 1, 4);
 }
 
+test "offsets - identifierIndexToNameLoc" {
+    try std.testing.expectEqualStrings("", offsets.identifierIndexToNameSlice("", 0));
+    try std.testing.expectEqualStrings("", offsets.identifierIndexToNameSlice(" ", 0));
+    try std.testing.expectEqualStrings("", offsets.identifierIndexToNameSlice(" world", 0));
+
+    try std.testing.expectEqualStrings("hello", offsets.identifierIndexToNameSlice("hello", 0));
+    try std.testing.expectEqualStrings("hello", offsets.identifierIndexToNameSlice("hello world", 0));
+    try std.testing.expectEqualStrings("world", offsets.identifierIndexToNameSlice("hello world", 6));
+
+    try std.testing.expectEqualStrings("hello", offsets.identifierIndexToNameSlice("@\"hello\"", 0));
+    try std.testing.expectEqualStrings("hello", offsets.identifierIndexToNameSlice("@\"hello\" world", 0));
+    try std.testing.expectEqualStrings("world", offsets.identifierIndexToNameSlice("@\"hello\" @\"world\"", 9));
+}
+
 test "offsets - lineLocAtIndex" {
     try std.testing.expectEqualStrings("", offsets.lineSliceAtIndex("", 0));
     try std.testing.expectEqualStrings("", offsets.lineSliceAtIndex("\n", 0));


### PR DESCRIPTION
Most code was not taking into account that an identifier could be escaped which caused code like the following to fail:
```zig
const Outer = struct { const Inner = Bar; };
const Bar = struct { const Some = u32; };
const foo = Outer.@"Inner".<ask for completions here>
```

These new functions will check for escaped identifiers and return an identifier source without the `@"` and `"`.
```zig
fn identifierIndexToNameLoc(text: [:0]const u8, source_index: usize) Loc
fn identifierIndexToNameSlice(text: [:0]const u8, source_index: usize) []const u8
fn identifierTokenToNameLoc(tree: Ast, identifier_token: Ast.TokenIndex) Loc
fn identifierTokenToNameSlice(tree: Ast, identifier_token: Ast.TokenIndex) []const u8
```

The identifier name does not get normalized so the following code still fails:
```zig
const S = struct { alpha: u32 };
var s: @"\x53" = undefined;
const foo = @"\x73".<ask for completions here>
```