### PR TITLE
Minor build runners update

### DIFF
--- a/src/build_runner/BuildConfig.zig
+++ b/src/build_runner/BuildConfig.zig
@@ -1,8 +1,10 @@
 pub const BuildConfig = @This();
 
+deps_build_roots: []DepsBuildRoots,
 packages: []Pkg,
 include_dirs: []const []const u8,
 
+pub const DepsBuildRoots = Pkg;
 pub const Pkg = struct {
     name: []const u8,
     path: []const u8,

--- a/src/build_runner/master.zig
+++ b/src/build_runner/master.zig
@@ -13,13 +13,15 @@ const Build = std.Build;
 ///! This is a modified build runner to extract information out of build.zig
 ///! Modified version of lib/build_runner.zig
 pub fn main() !void {
+    // Here we use an ArenaAllocator backed by a DirectAllocator because a build is a short-lived,
+    // one shot program. We don't need to waste time freeing memory and finding places to squish
+    // bytes into. So we free everything all at once at the very end.
     var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
     defer arena.deinit();
 
     const allocator = arena.allocator();
 
     var args = try process.argsAlloc(allocator);
-    defer process.argsFree(allocator, args);
 
     // skip my own exe name
     var arg_idx: usize = 1;
@@ -110,10 +112,7 @@ pub fn main() !void {
     try runBuild(builder);
 
     var packages = Packages{ .allocator = allocator };
-    defer packages.deinit();
-
     var include_dirs: std.StringArrayHashMapUnmanaged(void) = .{};
-    defer include_dirs.deinit(allocator);
 
     // This scans the graph of Steps to find all `OptionsStep`s then reifies them
     // Doing this before the loop to find packages ensures their `GeneratedFile`s have been given paths
@@ -162,16 +161,10 @@ pub fn main() !void {
         }
     }
 
-    const deps_build_roots_list = try deps_build_roots.toOwnedSlice(allocator);
-    defer allocator.free(deps_build_roots_list);
-
-    const package_list = try packages.toPackageList();
-    defer allocator.free(package_list);
-
     try std.json.stringify(
         BuildConfig{
-            .deps_build_roots = deps_build_roots_list,
-            .packages = package_list,
+            .deps_build_roots = try deps_build_roots.toOwnedSlice(allocator),
+            .packages = try packages.toPackageList(),
             .include_dirs = include_dirs.keys(),
         },
         .{

--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -889,6 +889,19 @@ fn completeFileSystemStringLiteral(
                     .detail = pkg.path,
                 }, {});
             }
+        } else if (DocumentStore.isBuildFile(handle.uri)) blk: {
+            const build_file = store.getBuildFile(handle.uri).?;
+            const build_config = build_file.tryLockConfig() orelse break :blk;
+            defer build_file.unlockConfig();
+
+            try completions.ensureUnusedCapacity(arena, build_config.deps_build_roots.len);
+            for (build_config.deps_build_roots) |dbr| {
+                completions.putAssumeCapacity(.{
+                    .label = dbr.name,
+                    .kind = .Module,
+                    .detail = dbr.path,
+                }, {});
+            }
         }
 
         try completions.ensureUnusedCapacity(arena, 2);


### PR DESCRIPTION
0.11.0
- Fix `getPath() was called on a GeneratedFile that wasn't built yet.`
- Add missing `cache.hash.addBytes(builtin.zig_version_string);`

0.11.0, master:
- Resolve mod imports in `build.zig`s
- Show completions for mod imports in `build.zig`s

<details>
<summary>As already known, anything that depends on a generated path cannot be resolved.. unless:</summary>

```diff
diff --git a/src/build_runner/0.11.0.zig b/src/build_runner/0.11.0.zig
index 27ad44c..bf35faa 100644
--- a/src/build_runner/0.11.0.zig
+++ b/src/build_runner/0.11.0.zig
@@ -313,6 +313,18 @@ fn getPkgConfigIncludes(
     } else |err| return err;
 }
 
+fn reify(step: *Build.Step) anyerror!void {
+    var progress: std.Progress = .{};
+    const main_progress_node = progress.start("", 0);
+    defer main_progress_node.end();
+
+    for (step.dependencies.items) |unknown_step| {
+        try reify(unknown_step);
+    }
+
+    try step.make(main_progress_node);
+}
+
 // TODO: Having a copy of this is not very nice
 const copied_from_zig = struct {
     /// Copied from `std.Build.LazyPath.getPath2` and massaged a bit.
@@ -320,7 +332,19 @@ const copied_from_zig = struct {
         switch (path) {
             .path => |p| return builder.pathFromRoot(p),
             .cwd_relative => |p| return pathFromCwd(builder, p),
-            .generated => |gen| return builder.pathFromRoot(gen.path orelse return null),
+            .generated => |gen| {
+                if (gen.path) |gen_path|
+                    return builder.pathFromRoot(gen_path)
+                else {
+                    for (gen.step.owner.top_level_steps.values()) |tls| {
+                        reify(&tls.step) catch return null;
+                    }
+                    if (gen.path) |gen_path|
+                        return builder.pathFromRoot(gen_path)
+                    else
+                        return null;
+                }
+            },

```

</details>

<details>
<summary>And in the case of `microzig`, where `microzig` is a dep of an app, but imports `chip` which is a module of `app`</summary>

```diff
diff --git a/src/DocumentStore.zig b/src/DocumentStore.zig
index 5fc212a..50b03ea 100644
--- a/src/DocumentStore.zig
+++ b/src/DocumentStore.zig
@@ -1403,14 +1403,17 @@ pub fn uriFromImportStr(self: *DocumentStore, allocator: std.mem.Allocator, hand
         }
         return null;
     } else if (!std.mem.endsWith(u8, import_str, ".zig")) {
-        if (handle.associated_build_file) |build_file_uri| blk: {
-            const build_file = self.getBuildFile(build_file_uri).?;
-            const build_config = build_file.tryLockConfig() orelse break :blk;
-            defer build_file.unlockConfig();
-
-            for (build_config.packages) |pkg| {
-                if (std.mem.eql(u8, import_str, pkg.name)) {
-                    return try URI.fromPath(allocator, pkg.path);
+        // lock?
+        for (self.handles.values()) |h| {
+            if (h.associated_build_file) |build_file_uri| blk: {
+                const build_file = self.getBuildFile(build_file_uri).?;
+                const build_config = build_file.tryLockConfig() orelse break :blk;
+                defer build_file.unlockConfig();
+
+                for (build_config.packages) |pkg| {
+                    if (std.mem.eql(u8, import_str, pkg.name)) {
+                        return try URI.fromPath(allocator, pkg.path);
+                    }
                 }
             }
         } else if (isBuildFile(handle.uri)) blk: {

```

</details>