### PR TITLE
BUGFIX | Fix `autofix` misplacing `}` when resolving unused function parameters, and captures.

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -346,8 +346,9 @@ fn autofix(server: *Server, arena: std.mem.Allocator, handle: *DocumentStore.Han
 
     var actions = std.ArrayListUnmanaged(types.CodeAction){};
     var remove_capture_actions = std.AutoHashMapUnmanaged(types.Range, void){};
-    for (diagnostics.items) |diagnostic| {
-        try builder.generateCodeAction(diagnostic, &actions, &remove_capture_actions);
+    for (diagnostics.items, 0..) |diagnostic, i| {
+        log.debug("what is the code action?! {s}", .{diagnostic.message});
+        try builder.generateCodeAction(diagnostic, &actions, i, &remove_capture_actions);
     }
 
     var text_edits = std.ArrayListUnmanaged(types.TextEdit){};
@@ -364,6 +365,10 @@ fn autofix(server: *Server, arena: std.mem.Allocator, handle: *DocumentStore.Han
         const edits: []const types.TextEdit = changes.get(handle.uri) orelse continue;
 
         try text_edits.appendSlice(arena, edits);
+    }
+
+    for (text_edits.items) |edit| {
+        log.debug("updating with new text: {s}", .{edit.newText});
     }
 
     return text_edits;
@@ -1153,6 +1158,8 @@ fn changeDocumentHandler(server: *Server, _: std.mem.Allocator, notification: ty
 
     const new_text = try diff.applyContentChanges(server.allocator, handle.tree.source, notification.contentChanges, server.offset_encoding);
 
+    log.debug("the new text from didChange ? {s}", .{new_text});
+
     try server.document_store.refreshDocument(handle.uri, new_text);
 
     if (server.client_capabilities.supports_publish_diagnostics) {
@@ -1402,6 +1409,8 @@ fn formattingHandler(server: *Server, arena: std.mem.Allocator, request: types.D
 
     const formatted = try handle.tree.render(arena);
 
+    log.info("requested reformat!! formatted:\n{s}", .{formatted});
+
     if (std.mem.eql(u8, handle.tree.source, formatted)) return null;
 
     return if (diff.edits(arena, handle.tree.source, formatted, server.offset_encoding)) |text_edits| text_edits.items else |_| null;
@@ -1565,6 +1574,8 @@ fn inlayHintHandler(server: *Server, arena: std.mem.Allocator, request: types.In
 fn codeActionHandler(server: *Server, arena: std.mem.Allocator, request: types.CodeActionParams) Error!ResultType("textDocument/codeAction") {
     const handle = server.document_store.getHandle(request.textDocument.uri) orelse return null;
 
+    log.debug("this is the code action {any}", .{request});
+
     var analyser = Analyser.init(server.allocator, &server.document_store, &server.ip);
     defer analyser.deinit();
 
@@ -1583,8 +1594,9 @@ fn codeActionHandler(server: *Server, arena: std.mem.Allocator, request: types.C
 
     var actions = std.ArrayListUnmanaged(types.CodeAction){};
     var remove_capture_actions = std.AutoHashMapUnmanaged(types.Range, void){};
-    for (diagnostics.items) |diagnostic| {
-        try builder.generateCodeAction(diagnostic, &actions, &remove_capture_actions);
+    for (diagnostics.items, 0..) |diagnostic, i| {
+        log.debug("what is the code action?! {s}", .{diagnostic.message});
+        try builder.generateCodeAction(diagnostic, &actions, i, &remove_capture_actions);
     }
 
     const Result = getRequestMetadata("textDocument/codeAction").?.Result;

--- a/src/features/code_actions.zig
+++ b/src/features/code_actions.zig
@@ -120,7 +120,8 @@ fn handleUnusedFunctionParameter(builder: *Builder, actions: *std.ArrayListUnman
     //     c: i32,
     // ) void { ... }
     // We have to be able to detect both cases.
-    var param_end = offsets.tokenToLoc(tree, ast.paramLastToken(tree, payload.get(tree).?)).end;
+    const fn_proto_param = payload.get(tree).?;
+    var param_end = offsets.tokenToLoc(tree, ast.paramLastToken(tree, fn_proto_param)).end;
     var found_comma: bool = false;
     while (param_end < tree.source.len) : (param_end += 1) {
         switch (tree.source[param_end]) {
@@ -153,7 +154,7 @@ fn handleUnusedFunctionParameter(builder: *Builder, actions: *std.ArrayListUnman
         .title = "remove function parameter",
         .kind = .quickfix,
         .isPreferred = false,
-        .edit = try builder.createWorkspaceEdit(&.{builder.createTextEditLoc(getParamRemovalRange(tree, payload.get(tree).?), "")}),
+        .edit = try builder.createWorkspaceEdit(&.{builder.createTextEditLoc(getParamRemovalRange(tree, fn_proto_param), "")}),
     };
 
     try actions.insertSlice(builder.arena, 0, &.{ action1, action2 });

--- a/src/features/code_actions.zig
+++ b/src/features/code_actions.zig
@@ -1,8 +1,6 @@
 const std = @import("std");
 const Ast = std.zig.Ast;
 
-const log = std.log.scoped(.zls_server);
-
 const DocumentStore = @import("../DocumentStore.zig");
 const Analyser = @import("../analysis.zig");
 const ast = @import("../ast.zig");

--- a/src/features/code_actions.zig
+++ b/src/features/code_actions.zig
@@ -156,7 +156,7 @@ fn handleUnusedFunctionParameter(builder: *Builder, actions: *std.ArrayListUnman
         .edit = try builder.createWorkspaceEdit(&.{builder.createTextEditLoc(getParamRemovalRange(tree, payload.get(tree).?), "")}),
     };
 
-    try prependSlice(actions, builder.arena, &.{ action1, action2 });
+    try actions.insertSlice(builder.arena, 0, &.{ action1, action2 });
 }
 
 fn handleUnusedVariableOrConstant(builder: *Builder, actions: *std.ArrayListUnmanaged(types.CodeAction), loc: offsets.Loc) !void {
@@ -269,7 +269,7 @@ fn handleUnusedCapture(
     const remove_cap_loc = builder.createTextEditLoc(capture_loc, "");
     const gop = try remove_capture_actions.getOrPut(builder.arena, remove_cap_loc.range);
     if (gop.found_existing)
-        try prependSlice(actions, builder.arena, &.{ action1, action2 })
+        try actions.insertSlice(builder.arena, 0, &.{ action1, action2 })
     else {
         const action0 = types.CodeAction{
             .title = "remove capture",
@@ -277,7 +277,7 @@ fn handleUnusedCapture(
             .isPreferred = false,
             .edit = try builder.createWorkspaceEdit(&.{remove_cap_loc}),
         };
-        try prependSlice(actions, builder.arena, &.{ action0, action1, action2 });
+        try actions.insertSlice(builder.arena, 0, &.{ action0, action1, action2 });
     }
 }
 
@@ -556,16 +556,6 @@ fn getCaptureLoc(text: []const u8, loc: offsets.Loc) ?offsets.Loc {
     if (trimmed.len == 0) return null;
 
     return .{ .start = start_pipe_position, .end = end_pipe_position };
-}
-
-fn prependSlice(list: *std.ArrayListUnmanaged(types.CodeAction), arena: std.mem.Allocator, values: []const types.CodeAction) !void {
-    const old_len = list.items.len;
-    try list.resize(arena, list.items.len + values.len);
-    var i = old_len + values.len - 1;
-    while (i >= values.len) : (i -= 1) {
-        list.items[i] = list.items[i - values.len];
-    }
-    std.mem.copy(types.CodeAction, list.items[0..values.len], values);
 }
 
 test "getCaptureLoc" {

--- a/src/features/code_actions.zig
+++ b/src/features/code_actions.zig
@@ -122,21 +122,12 @@ fn handleUnusedFunctionParameter(builder: *Builder, actions: *std.ArrayListUnman
     // We have to be able to detect both cases.
     const fn_proto_param = payload.get(tree).?;
     var param_end = offsets.tokenToLoc(tree, ast.paramLastToken(tree, fn_proto_param)).end;
-    var found_comma: bool = false;
-    while (param_end < tree.source.len) : (param_end += 1) {
-        switch (tree.source[param_end]) {
-            ' ', '\n' => continue,
-            ',' => if (!found_comma) {
-                found_comma = true;
-                continue;
-            } else {
-                param_end += 1;
-                break;
-            },
-            ')' => break,
-            else => break,
-        }
-    }
+
+    var found_comma = std.mem.startsWith(
+        u8,
+        std.mem.trimLeft(u8, tree.source[param_end..], " \n"),
+        ",",
+    );
 
     const new_text = try createDiscardText(builder, identifier_name, token_starts[node_tokens[payload.func]], true, !found_comma);
 

--- a/tests/lsp_features/code_actions.zig
+++ b/tests/lsp_features/code_actions.zig
@@ -85,10 +85,11 @@ test "code actions - discard captures" {
 test "code actions - discard capture with comment" {
     try testAutofix(
         \\test {
-        \\  if (1 == 1) |a|
-        \\      //a
-        \\      {}
+        \\    if (1 == 1) |a|
+        \\    //a
+        \\    {}
         \\}
+        \\
     ,
         \\test {
         \\    if (1 == 1) |a|
@@ -174,9 +175,5 @@ fn testAutofix(before: []const u8, after: []const u8) !void {
     defer allocator.free(actual);
     try ctx.server.document_store.refreshDocument(uri, try allocator.dupeZ(u8, actual));
 
-    try std.testing.expect(handle.tree.errors.len == 0);
-    const formatted_actual = try handle.tree.render(allocator);
-    defer allocator.free(formatted_actual);
-
-    try std.testing.expectEqualStrings(after, formatted_actual);
+    try std.testing.expectEqualStrings(after, handle.tree.source);
 }

--- a/tests/lsp_features/code_actions.zig
+++ b/tests/lsp_features/code_actions.zig
@@ -33,9 +33,9 @@ test "code actions - discard function parameter" {
         \\
     ,
         \\fn foo(a: void, b: void, c: void) void {
-        \\    _ = c;
-        \\    _ = b;
         \\    _ = a;
+        \\    _ = b;
+        \\    _ = c;
         \\}
         \\
     );
@@ -56,14 +56,14 @@ test "code actions - discard captures" {
     ,
         \\test {
         \\    for (0..10, 0..10, 0..10) |i, j, k| {
-        \\        _ = k;
-        \\        _ = j;
         \\        _ = i;
+        \\        _ = j;
+        \\        _ = k;
         \\    }
         \\    switch (union(enum) {}{}) {
         \\        inline .a => |cap, tag| {
-        \\            _ = tag;
         \\            _ = cap;
+        \\            _ = tag;
         \\        },
         \\    }
         \\    if (null) |x| {


### PR DESCRIPTION
# What is this ? 

Hi All :wave: 

This is my first PR contributing to `zls`, and it's also my first Zig PR (ever), so if at any point during this PR process I'm a little slow to pick things up please forgive me :pray:

This PR is aimed at resolving issue https://github.com/zigtools/zls/issues/1543 

The issue occurs when you use the `autofix` functionality of `zls` to automatically provide discarded variable usages inside your function block, or inside your capture block. 

An example can be seen like so: 

```zig 

pub fn format(a: u8, b: u8, c: u8) !void {
}

// Then after you save:


pub fn format(a: u8, b: u8, c: u8) !void {
    _ = c;
    _ = b;
    _ = a;}

```

This PR addresses this issue so the output of the `autofix` should now be like: 

```zig

pub fn format(a: u8, b: u8, c: u8) !void {
    _ = a;
    _ = b;
    _ = c;
}
```

This behaviour can also be noted for the capture discards: 

```zig

// old

pub fn format(a: u8, b: u8, c: u8) !void {
    _ = c;
    _ = b;
    _ = a;

    for (0..10) |ix| {
        _ = ix;}
}

// new

pub fn format(a: u8, b: u8, c: u8) !void {
    _ = a;
    _ = b;
    _ = c;

    for (0..10) |ix| {
        _ = ix;
    }
}

```

Let me know if I've missed anything here! Thanks! 
