### PR TITLE
Support load http proxy environment variables

### DIFF
--- a/src/config_gen/config_gen.zig
+++ b/src/config_gen/config_gen.zig
@@ -949,6 +949,9 @@ fn httpGET(allocator: std.mem.Allocator, uri: std.Uri) !Response {
     defer client.deinit();
     try client.ca_bundle.rescan(allocator);
 
+    if (@hasDecl(std.http.Client, "loadDefaultProxies"))
+        try client.loadDefaultProxies();
+
     var request = try client.open(.GET, uri, .{ .allocator = allocator }, .{});
     defer request.deinit();
 


### PR DESCRIPTION
zig project (https://github.com/ziglang/zig/pull/17407) add client.loadDefaultProxies to loads proxy environment variables (http_proxy, HTTP_PROXY, https_proxy, HTTPS_PROXY, all_proxy, ALL_PROXY).