### PR TITLE
build_runners: Attempt to make GeneratedFile steps

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -334,7 +334,7 @@ fn autofix(server: *Server, arena: std.mem.Allocator, handle: *DocumentStore.Han
     try diagnostics_gen.getAstCheckDiagnostics(server, arena, handle, &diagnostics);
     if (diagnostics.items.len == 0) return .{};
 
-    var analyser = Analyser.init(server.allocator, &server.document_store, &server.ip);
+    var analyser = Analyser.init(server.allocator, &server.document_store, &server.ip, handle);
     defer analyser.deinit();
 
     var builder = code_actions.Builder{
@@ -1231,7 +1231,7 @@ fn semanticTokensFullHandler(server: *Server, arena: std.mem.Allocator, request:
 
     const handle = server.document_store.getHandle(request.textDocument.uri) orelse return null;
 
-    var analyser = Analyser.init(server.allocator, &server.document_store, &server.ip);
+    var analyser = Analyser.init(server.allocator, &server.document_store, &server.ip, handle);
     defer analyser.deinit();
 
     return try semantic_tokens.writeSemanticTokens(
@@ -1250,7 +1250,7 @@ fn semanticTokensRangeHandler(server: *Server, arena: std.mem.Allocator, request
     const handle = server.document_store.getHandle(request.textDocument.uri) orelse return null;
     const loc = offsets.rangeToLoc(handle.tree.source, request.range, server.offset_encoding);
 
-    var analyser = Analyser.init(server.allocator, &server.document_store, &server.ip);
+    var analyser = Analyser.init(server.allocator, &server.document_store, &server.ip, handle);
     defer analyser.deinit();
 
     return try semantic_tokens.writeSemanticTokens(
@@ -1268,7 +1268,7 @@ fn completionHandler(server: *Server, arena: std.mem.Allocator, request: types.C
 
     const source_index = offsets.positionToIndex(handle.tree.source, request.position, server.offset_encoding);
 
-    var analyser = Analyser.init(server.allocator, &server.document_store, &server.ip);
+    var analyser = Analyser.init(server.allocator, &server.document_store, &server.ip, handle);
     defer analyser.deinit();
 
     return .{
@@ -1283,7 +1283,7 @@ fn signatureHelpHandler(server: *Server, arena: std.mem.Allocator, request: type
 
     const source_index = offsets.positionToIndex(handle.tree.source, request.position, server.offset_encoding);
 
-    var analyser = Analyser.init(server.allocator, &server.document_store, &server.ip);
+    var analyser = Analyser.init(server.allocator, &server.document_store, &server.ip, handle);
     defer analyser.deinit();
 
     const signature_info = (try signature_help.getSignatureInfo(
@@ -1322,7 +1322,7 @@ fn gotoHandler(
     const handle = server.document_store.getHandle(request.textDocument.uri) orelse return null;
     const source_index = offsets.positionToIndex(handle.tree.source, request.position, server.offset_encoding);
 
-    var analyser = Analyser.init(server.allocator, &server.document_store, &server.ip);
+    var analyser = Analyser.init(server.allocator, &server.document_store, &server.ip, handle);
     defer analyser.deinit();
 
     const response = try goto.goto(&analyser, &server.document_store, arena, handle, source_index, kind, server.offset_encoding) orelse return null;
@@ -1389,7 +1389,7 @@ fn hoverHandler(server: *Server, arena: std.mem.Allocator, request: types.HoverP
 
     const markup_kind: types.MarkupKind = if (server.client_capabilities.hover_supports_md) .markdown else .plaintext;
 
-    var analyser = Analyser.init(server.allocator, &server.document_store, &server.ip);
+    var analyser = Analyser.init(server.allocator, &server.document_store, &server.ip, handle);
     defer analyser.deinit();
 
     const response = hover_handler.hover(&analyser, arena, handle, source_index, markup_kind, server.offset_encoding);
@@ -1482,7 +1482,7 @@ fn generalReferencesHandler(server: *Server, arena: std.mem.Allocator, request: 
     const name = offsets.locToSlice(handle.tree.source, name_loc);
     const pos_context = try Analyser.getPositionContext(server.allocator, handle.tree.source, source_index, true);
 
-    var analyser = Analyser.init(server.allocator, &server.document_store, &server.ip);
+    var analyser = Analyser.init(server.allocator, &server.document_store, &server.ip, handle);
     defer analyser.deinit();
 
     // TODO: Make this work with branching types
@@ -1566,7 +1566,7 @@ fn inlayHintHandler(server: *Server, arena: std.mem.Allocator, request: types.In
     const hover_kind: types.MarkupKind = if (server.client_capabilities.hover_supports_md) .markdown else .plaintext;
     const loc = offsets.rangeToLoc(handle.tree.source, request.range, server.offset_encoding);
 
-    var analyser = Analyser.init(server.allocator, &server.document_store, &server.ip);
+    var analyser = Analyser.init(server.allocator, &server.document_store, &server.ip, handle);
     defer analyser.deinit();
 
     return try inlay_hints.writeRangeInlayHint(
@@ -1583,7 +1583,7 @@ fn inlayHintHandler(server: *Server, arena: std.mem.Allocator, request: types.In
 fn codeActionHandler(server: *Server, arena: std.mem.Allocator, request: types.CodeActionParams) Error!ResultType("textDocument/codeAction") {
     const handle = server.document_store.getHandle(request.textDocument.uri) orelse return null;
 
-    var analyser = Analyser.init(server.allocator, &server.document_store, &server.ip);
+    var analyser = Analyser.init(server.allocator, &server.document_store, &server.ip, handle);
     defer analyser.deinit();
 
     var builder = code_actions.Builder{

--- a/src/build_runner/0.11.0.zig
+++ b/src/build_runner/0.11.0.zig
@@ -315,6 +315,18 @@ fn getPkgConfigIncludes(
     } else |err| return err;
 }
 
+fn reify(step: *Build.Step) anyerror!void {
+    var progress: std.Progress = .{};
+    const main_progress_node = progress.start("", 0);
+    defer main_progress_node.end();
+
+    for (step.dependencies.items) |unknown_step| {
+        try reify(unknown_step);
+    }
+
+    try step.make(main_progress_node);
+}
+
 // TODO: Having a copy of this is not very nice
 const copied_from_zig = struct {
     /// Copied from `std.Build.LazyPath.getPath2` and massaged a bit.
@@ -322,7 +334,17 @@ const copied_from_zig = struct {
         switch (path) {
             .path => |p| return builder.pathFromRoot(p),
             .cwd_relative => |p| return pathFromCwd(builder, p),
-            .generated => |gen| return builder.pathFromRoot(gen.path orelse return null),
+            .generated => |gen| {
+                if (gen.path) |gen_path|
+                    return builder.pathFromRoot(gen_path)
+                else {
+                    reify(gen.step) catch return null;
+                    if (gen.path) |gen_path|
+                        return builder.pathFromRoot(gen_path)
+                    else
+                        return null;
+                }
+            },
         }
     }
 


### PR DESCRIPTION
+ Use `original handle` when trying to resolve field access, ie the `microzig` case, where a dep requests the app to import one of it's own app modules - `app_dep.app_mod.some`.