### PR TITLE
goto test coverage + improvements

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -1390,7 +1390,7 @@ fn gotoDeclarationHandler(server: *Server, arena: std.mem.Allocator, request: ty
     })) orelse return null;
     return switch (response) {
         .array_of_DefinitionLink => |adl| .{ .array_of_DeclarationLink = adl },
-        .Definition => |def| .{ .Declaration = .{ .array_of_Location = def.array_of_Location } },
+        .Definition => |def| .{ .Declaration = .{ .Location = def.Location } },
     };
 }
 

--- a/tests/helper.zig
+++ b/tests/helper.zig
@@ -45,7 +45,7 @@ pub fn clearPlaceholders(allocator: std.mem.Allocator, source: []const u8) ![]co
     return replacePlaceholders(allocator, source, "");
 }
 
-const CollectPlaceholdersResult = struct {
+pub const CollectPlaceholdersResult = struct {
     /// list of all placeholder with old and new location
     locations: std.MultiArrayList(LocPair),
     /// equivalent to calling `replacePlaceholders(source, new_name)`

--- a/tests/lsp_features/definition.zig
+++ b/tests/lsp_features/definition.zig
@@ -63,10 +63,16 @@ fn testDefinition(source: []const u8) !void {
     var phr = try helper.collectClearPlaceholders(allocator, source);
     defer phr.deinit(allocator);
 
+    var ctx = try Context.init();
+    defer ctx.deinit();
+
+    const test_uri = try ctx.addDocument(phr.new_source);
+
     var error_builder = ErrorBuilder.init(allocator);
     defer error_builder.deinit();
     errdefer error_builder.writeDebug();
 
+    try error_builder.addFile(test_uri, phr.new_source);
     try error_builder.addFile("old_source", source);
     try error_builder.addFile("new_source", phr.new_source);
 
@@ -117,12 +123,6 @@ fn testDefinition(source: []const u8) !void {
         std.debug.print("must specify at least one sub-test with <decl>, <def> or <tdef>\n", .{});
         return error.NoChecksSpecified;
     }
-
-    var ctx = try Context.init();
-    defer ctx.deinit();
-
-    const test_uri = try ctx.addDocument(phr.new_source);
-    try error_builder.addFile(test_uri, phr.new_source);
 
     const cursor_position = offsets.indexToPosition(phr.new_source, cursor_index, ctx.server.offset_encoding);
 


### PR DESCRIPTION
These changes allow testing all 3 goto requests individually:
- textDocument/declaration
- textDocument/definition
- textDocument/typeDefinition

Here is one example of all three in action:
```zig
test {
    // - use `<>` to indicate the cursor position
    // - use `<decl>content</decl>` to set the expected range of the declaration
    // - use `<def>content</def>` to set the expected range of the definition
    // - use `<tdef>content</tdef>` to set the expected range of the type definition
    try testDefinition(
        \\const <def>foo</def> = 5;
        \\const <decl>bar</decl>: <tdef>u32</tdef> = foo;
        \\comptime {
        \\    _ = <>bar;
        \\}
    );
}
```


I've also made `textDocument/typeDefinition` give the type declaration instead of type definition because otherwise goto on primitive types would be completely broken.