### PR TITLE
Nix: Use callPackage pattern

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,29 +24,14 @@
     flake-utils.lib.eachSystem systems (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-        zig = zig-overlay.packages.${system}.master;
       in
       rec {
-        formatter = nixpkgs.legacyPackages.${system}.nixpkgs-fmt;
+        formatter = pkgs.nixpkgs-fmt;
         packages.default = packages.zls;
-        packages.zls = pkgs.stdenvNoCC.mkDerivation {
-          name = "zls";
-          version = "master";
-          src = gitignoreSource ./.;
-          nativeBuildInputs = [ zig ];
-          dontConfigure = true;
-          dontInstall = true;
-          doCheck = true;
+        packages.zls = pkgs.callPackage ./zls.nix {
+          inherit (gitignore.lib) gitignoreSource;
           langref = inputs.langref;
-          buildPhase = ''
-            mkdir -p .cache
-            ln -s ${pkgs.callPackage ./deps.nix { }} .cache/p
-            zig build install --cache-dir $(pwd)/zig-cache --global-cache-dir $(pwd)/.cache -Dversion_data_path=$langref -Dcpu=baseline -Doptimize=ReleaseSafe --prefix $out
-          '';
-          checkPhase = ''
-            zig build test --cache-dir $(pwd)/zig-cache --global-cache-dir $(pwd)/.cache -Dversion_data_path=$langref -Dcpu=baseline
-          '';
+          zig = zig-overlay.packages.${system}.master;
         };
-      }
-    );
+      });
 }

--- a/zls.nix
+++ b/zls.nix
@@ -1,0 +1,19 @@
+{ callPackage, stdenvNoCC, gitignoreSource, zig, langref }:
+stdenvNoCC.mkDerivation {
+  name = "zls";
+  version = "master";
+  src = gitignoreSource ./.;
+  nativeBuildInputs = [ zig ];
+  dontConfigure = true;
+  dontInstall = true;
+  doCheck = true;
+  langref = langref;
+  buildPhase = ''
+    mkdir -p .cache
+    ln -s ${callPackage ./deps.nix { }} .cache/p
+    zig build install --cache-dir $(pwd)/zig-cache --global-cache-dir $(pwd)/.cache -Dversion_data_path=$langref -Dcpu=baseline -Doptimize=ReleaseSafe --prefix $out
+  '';
+  checkPhase = ''
+    zig build test --cache-dir $(pwd)/zig-cache --global-cache-dir $(pwd)/.cache -Dversion_data_path=$langref -Dcpu=baseline
+  '';
+}

--- a/zls.nix
+++ b/zls.nix
@@ -1,4 +1,4 @@
-{ callPackage, stdenvNoCC, gitignoreSource, zig, langref }:
+{ callPackage, stdenvNoCC, gitignoreSource, zig, langref, zigOptimize ? "ReleaseSafe" }:
 stdenvNoCC.mkDerivation {
   name = "zls";
   version = "master";
@@ -8,10 +8,11 @@ stdenvNoCC.mkDerivation {
   dontInstall = true;
   doCheck = true;
   langref = langref;
+  zigOptimize = zigOptimize;
   buildPhase = ''
     mkdir -p .cache
     ln -s ${callPackage ./deps.nix { }} .cache/p
-    zig build install --cache-dir $(pwd)/zig-cache --global-cache-dir $(pwd)/.cache -Dversion_data_path=$langref -Dcpu=baseline -Doptimize=ReleaseSafe --prefix $out
+    zig build install --cache-dir $(pwd)/zig-cache --global-cache-dir $(pwd)/.cache -Dversion_data_path=$langref -Dcpu=baseline -Doptimize=$zigOptimize --prefix $out
   '';
   checkPhase = ''
     zig build test --cache-dir $(pwd)/zig-cache --global-cache-dir $(pwd)/.cache -Dversion_data_path=$langref -Dcpu=baseline


### PR DESCRIPTION
This makes it possible for users of the flake to override the Zig version which this is built with.