### PR TITLE
extend CompletionItemKind and DiagnosticTag enums

### DIFF
--- a/src/lsp.zig
+++ b/src/lsp.zig
@@ -684,6 +684,7 @@ pub const CompletionItemKind = enum(u32) {
     Event = 23,
     Operator = 24,
     TypeParameter = 25,
+    _,
     pub usingnamespace EnumStringifyAsInt(@This());
 };
 
@@ -930,7 +931,7 @@ pub const DiagnosticSeverity = enum(u32) {
 /// The diagnostic tags.
 ///
 /// @since 3.15.0
-pub const DiagnosticTag = enum(u32) {
+pub const DiagnosticTag = enum(i32) {
     /// Unused or unnecessary code.
     ///
     /// Clients are allowed to render diagnostics with this tag faded out instead of having
@@ -940,6 +941,7 @@ pub const DiagnosticTag = enum(u32) {
     ///
     /// Clients are allowed to rendered diagnostics with this tag strike through.
     Deprecated = 2,
+    _,
     pub usingnamespace EnumStringifyAsInt(@This());
 };
 


### PR DESCRIPTION
supports forward and backward compatibility according to LSP specification (also allows VS 2022 clients to use zls)