### PR TITLE
Updates deps.nix and flake.lock

### DIFF
--- a/deps.nix
+++ b/deps.nix
@@ -4,17 +4,17 @@
 
 linkFarm "zig-packages" [
   {
+    name = "122002462f37b67a54fa1ab712d870d4637dae0d94437c0077b148e1fb75616c573d";
+    path = fetchzip {
+      url = "https://github.com/ziglibs/known-folders/archive/8bb4bf761bab20ffed74ffac83c3a9eb4456f28d.tar.gz";
+      hash = "sha256-t5nZi7HmBy0tLBYphlyrPHTSr5HStobgdZbISi5hjno=";
+    };
+  }
+  {
     name = "122014b1776beda990cdc7bdbecc6960bdce9eb762d6dc7cc6664517f171becc17dd";
     path = fetchzip {
       url = "https://github.com/ziglibs/diffz/archive/86f5435f63961dcdba8b76e47b44e2381671fb09.tar.gz";
       hash = "sha256-JXQQfyzDwSQ7+H8rWTdb0GrN5Rgeo3kCIYmW5QiWX9w=";
-    };
-  }
-  {
-    name = "1220f9d9dd88b1352b1a2bde4a96f547a1591d66ad0a9d76854d0c2c7fa59eef2508";
-    path = fetchzip {
-      url = "https://github.com/ziglibs/known-folders/archive/855473062efac722624737f1adc56f9c0dd92017.tar.gz";
-      hash = "sha256-+W0Gx8l6Q9+9SK/968vunccNtRBZfCbOSjQnGB7H3os=";
     };
   }
 ]

--- a/flake.lock
+++ b/flake.lock
@@ -83,11 +83,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1700538105,
-        "narHash": "sha256-uZhOCmwv8VupEmPZm3erbr9XXmyg7K67Ul3+Rx2XMe0=",
+        "lastModified": 1700856099,
+        "narHash": "sha256-RnEA7iJ36Ay9jI0WwP+/y4zjEhmeN6Cjs9VOFBH7eVQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "51a01a7e5515b469886c120e38db325c96694c2f",
+        "rev": "0bd59c54ef06bc34eca01e37d689f5e46b3fe2f1",
         "type": "github"
       },
       "original": {
@@ -130,11 +130,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1700654922,
-        "narHash": "sha256-n3e7QAGhEDV1Ttu8m+VVt3oJwYVBat1KM29IKxIJlxM=",
+        "lastModified": 1701000474,
+        "narHash": "sha256-M/nfodghuNn9nhIYLiRWyddqIAVBHox32FimE1iUink=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "f7a7dc4699f7342e5a61e65de6756952fbac3d8f",
+        "rev": "a8b011878747485fed674ef7d0b34bd59f164aff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Are we back to doing this manually? I searched for code in the github workflows that runs the nix commands to update those files and couldn't find any. If the modification was done because it stopped working in the last zig update, I have a fork that is up-to-date and generating the `deps.nix` just fine. I opened pull-requests to `nix-community/zon2nix` a few days ago but didn't get any response yet.