### PR TITLE
more test coverage + minor fixes

### DIFF
--- a/src/features/folding_range.zig
+++ b/src/features/folding_range.zig
@@ -214,9 +214,15 @@ pub fn generateFoldingRanges(allocator: std.mem.Allocator, tree: Ast, encoding: 
             => {
                 const switch_case = tree.fullSwitchCase(node).?.ast;
                 if (switch_case.values.len >= 4) {
-                    const first_value = tree.firstToken(switch_case.values[0]);
-                    const last_value = ast.lastToken(tree, switch_case.values[switch_case.values.len - 1]);
-                    try builder.add(null, first_value, last_value, .inclusive, .inclusive);
+                    const first_value = switch_case.values[0];
+                    const last_value = switch_case.values[switch_case.values.len - 1];
+
+                    const last_token = ast.lastToken(tree, last_value);
+                    const last_value_has_comma = last_token + 1 < tree.tokens.len and token_tags[last_token + 1] == .comma;
+
+                    const start_tok = tree.firstToken(first_value);
+                    const end_tok = last_token + @intFromBool(last_value_has_comma);
+                    try builder.add(null, start_tok, end_tok, .inclusive, .inclusive);
                 }
             },
 

--- a/src/features/semantic_tokens.zig
+++ b/src/features/semantic_tokens.zig
@@ -364,10 +364,10 @@ fn writeNodeTokens(builder: *Builder, node: Ast.Node.Index) error{OutOfMemory}!v
             try writeToken(builder, decl.layout_token, .keyword);
             try writeToken(builder, decl.ast.main_token, .keyword);
             if (decl.ast.enum_token) |enum_token| {
-                if (decl.ast.arg != 0)
-                    try writeNodeTokens(builder, decl.ast.arg)
-                else
-                    try writeToken(builder, enum_token, .keyword);
+                try writeToken(builder, enum_token, .keyword);
+                if (decl.ast.arg != 0) {
+                    try writeNodeTokens(builder, decl.ast.arg);
+                }
             } else try writeNodeTokens(builder, decl.ast.arg);
 
             for (decl.ast.members) |child| {

--- a/src/features/semantic_tokens.zig
+++ b/src/features/semantic_tokens.zig
@@ -978,6 +978,7 @@ fn writeContainerField(builder: *Builder, node: Ast.Node.Index, container_decl: 
         else
             container_field.ast.main_token + 1;
 
+        std.debug.assert(token_tags[eq_tok] == .equal);
         try writeToken(builder, eq_tok, .operator);
         try writeNodeTokens(builder, container_field.ast.value_expr);
     }

--- a/src/features/semantic_tokens.zig
+++ b/src/features/semantic_tokens.zig
@@ -853,7 +853,10 @@ fn writeNodeTokens(builder: *Builder, node: Ast.Node.Index) error{OutOfMemory}!v
             // TODO This is basically exactly the same as what is done in analysis.resolveTypeOfNode, with the added
             //      writeToken code.
             // Maybe we can hook into it instead? Also applies to Identifier and VarDecl
-            const lhs = try builder.analyser.resolveTypeOfNode(.{ .node = data.lhs, .handle = handle }) orelse return;
+            const lhs = try builder.analyser.resolveTypeOfNode(.{ .node = data.lhs, .handle = handle }) orelse {
+                try writeTokenMod(builder, data.rhs, .variable, .{});
+                return;
+            };
             const lhs_type = try builder.analyser.resolveDerefType(lhs) orelse lhs;
             if (try lhs_type.lookupSymbol(builder.analyser, tree.tokenSlice(data.rhs))) |decl_type| {
                 switch (decl_type.decl) {

--- a/src/features/semantic_tokens.zig
+++ b/src/features/semantic_tokens.zig
@@ -174,10 +174,13 @@ const Builder = struct {
         const delta = offsets.indexToPosition(delta_text, delta_text.len, self.encoding);
         const length = offsets.locLength(source, loc, self.encoding);
 
+        // assert that the `@intCast(length)` below is safe
+        comptime std.debug.assert(DocumentStore.max_document_size == std.math.maxInt(u32));
+
         try self.token_buffer.appendSlice(self.arena, &.{
-            @as(u32, @truncate(delta.line)),
-            @as(u32, @truncate(delta.character)),
-            @as(u32, @truncate(length)),
+            delta.line,
+            delta.character,
+            @intCast(length),
             @intFromEnum(token_type),
             @as(u16, @bitCast(token_modifiers)),
         });

--- a/src/features/semantic_tokens.zig
+++ b/src/features/semantic_tokens.zig
@@ -264,13 +264,14 @@ fn colorIdentifierBasedOnType(
 }
 
 fn writeNodeTokens(builder: *Builder, node: Ast.Node.Index) error{OutOfMemory}!void {
+    if (node == 0) return;
+
     const handle = builder.handle;
     const tree = handle.tree;
     const node_tags = tree.nodes.items(.tag);
     const token_tags = tree.tokens.items(.tag);
     const node_data = tree.nodes.items(.data);
     const main_tokens = tree.nodes.items(.main_token);
-    if (node == 0 or node >= node_data.len) return;
 
     const tag = node_tags[node];
     const main_token = main_tokens[node];

--- a/tests/lsp_features/code_actions.zig
+++ b/tests/lsp_features/code_actions.zig
@@ -146,11 +146,16 @@ test "code actions - correct unnecessary uses of var" {
     );
 }
 
-/// does not check for correct formatting
 fn testAutofix(before: []const u8, after: []const u8) !void {
+    try testAutofixOptions(before, after, true); // diagnostics come from our AstGen fork
+    try testAutofixOptions(before, after, false); // diagnostics come from calling zig ast-check
+}
+
+fn testAutofixOptions(before: []const u8, after: []const u8, want_zir: bool) !void {
     var ctx = try Context.init();
     defer ctx.deinit();
     ctx.server.config.enable_ast_check_diagnostics = true;
+    ctx.server.config.prefer_ast_check_as_child_process = !want_zir;
 
     const uri = try ctx.addDocument(before);
     const handle = ctx.server.document_store.getHandle(uri).?;

--- a/tests/lsp_features/folding_range.zig
+++ b/tests/lsp_features/folding_range.zig
@@ -102,19 +102,33 @@ test "foldingRange - for/while" {
 test "foldingRange - switch" {
     try testFoldingRange(
         \\const foo = switch (5) {
-        \\  0 => {},
-        \\  1 => {}
+        \\    0 => {},
+        \\    1 => {}
         \\};
     , &.{
         .{ .startLine = 0, .startCharacter = 24, .endLine = 3, .endCharacter = 0 },
     });
     try testFoldingRange(
         \\const foo = switch (5) {
-        \\  0 => {},
-        \\  1 => {},
+        \\    0 => {},
+        \\    1 => {},
         \\};
     , &.{
         .{ .startLine = 0, .startCharacter = 24, .endLine = 3, .endCharacter = 0 },
+    });
+    try testFoldingRange(
+        \\const foo = switch (5) {
+        \\    0,
+        \\    1,
+        \\    2,
+        \\    3,
+        \\    4,
+        \\    => {},
+        \\    else => {},
+        \\};
+    , &.{
+        .{ .startLine = 1, .startCharacter = 4, .endLine = 5, .endCharacter = 6 },
+        .{ .startLine = 0, .startCharacter = 24, .endLine = 8, .endCharacter = 0 },
     });
 }
 
@@ -282,5 +296,5 @@ fn testFoldingRange(source: []const u8, expect: []const types.FoldingRange) !voi
         return error.InvalidResponse;
     };
 
-    try std.testing.expectEqualDeep(expect, response);
+    try std.testing.expectEqualSlices(types.FoldingRange, expect, response);
 }

--- a/tests/lsp_features/semantic_tokens.zig
+++ b/tests/lsp_features/semantic_tokens.zig
@@ -783,6 +783,7 @@ test "semantic tokens - struct" {
         \\const T = u32;
         \\const Foo = struct {
         \\    u32,
+        \\    []const u8 align(8) = undefined,
         \\    T align(4),
         \\};
     , &.{
@@ -794,7 +795,16 @@ test "semantic tokens - struct" {
         .{ "Foo", .@"struct", .{ .declaration = true } },
         .{ "=", .operator, .{} },
         .{ "struct", .keyword, .{} },
+
         .{ "u32", .type, .{} },
+
+        .{ "const", .keyword, .{} },
+        .{ "u8", .type, .{} },
+        .{ "align", .keyword, .{} },
+        .{ "8", .number, .{} },
+        .{ "=", .operator, .{} },
+        .{ "undefined", .keywordLiteral, .{} },
+
         .{ "T", .type, .{} },
         .{ "align", .keyword, .{} },
         .{ "4", .number, .{} },

--- a/tests/lsp_features/semantic_tokens.zig
+++ b/tests/lsp_features/semantic_tokens.zig
@@ -432,6 +432,18 @@ test "semantic tokens - catch" {
     });
 }
 
+test "semantic tokens - try" {
+    try testSemanticTokens(
+        \\var alpha = try undefined;
+    , &.{
+        .{ "var", .keyword, .{} },
+        .{ "alpha", .variable, .{ .declaration = true } },
+        .{ "=", .operator, .{} },
+        .{ "try", .keyword, .{} },
+        .{ "undefined", .keywordLiteral, .{} },
+    });
+}
+
 test "semantic tokens - slicing" {
     try testSemanticTokens(
         \\var alpha = a[0..1];

--- a/tests/lsp_features/semantic_tokens.zig
+++ b/tests/lsp_features/semantic_tokens.zig
@@ -1467,21 +1467,39 @@ test "semantic tokens - assembly" {
         .{ "arg1", .parameter, .{ .declaration = true } },
         .{ "usize", .type, .{} },
         .{ "usize", .type, .{} },
+
         .{ "return", .keyword, .{} },
         .{ "asm", .keyword, .{} },
         .{ "volatile", .keyword, .{} },
         .{ "\"syscall\"", .string, .{} },
+
         .{ "ret", .variable, .{} },
         .{ "\"={rax}\"", .string, .{} },
         .{ "usize", .type, .{} },
+
         .{ "number", .variable, .{} },
         .{ "\"{rax}\"", .string, .{} },
         .{ "number", .parameter, .{} },
+
         .{ "arg1", .variable, .{} },
         .{ "\"{rdi}\"", .string, .{} },
         .{ "arg1", .parameter, .{} },
+
         .{ "\"rcx\"", .string, .{} },
         .{ "\"r11\"", .string, .{} },
+    });
+    try testSemanticTokens(
+        \\const alpha = asm volatile ("foo" ::: "a", "b",);
+    , &.{
+        .{ "const", .keyword, .{} },
+        .{ "alpha", .variable, .{ .declaration = true } },
+        .{ "=", .operator, .{} },
+
+        .{ "asm", .keyword, .{} },
+        .{ "volatile", .keyword, .{} },
+        .{ "\"foo\"", .string, .{} },
+        .{ "\"a\"", .string, .{} },
+        .{ "\"b\"", .string, .{} },
     });
 }
 

--- a/tests/lsp_features/semantic_tokens.zig
+++ b/tests/lsp_features/semantic_tokens.zig
@@ -334,6 +334,33 @@ test "semantic tokens - field access" {
     });
 }
 
+test "semantic tokens - field access on unknown" {
+    try testSemanticTokens(
+        \\const alpha = Unknown.foo;
+    , &.{
+        .{ "const", .keyword, .{} },
+        .{ "alpha", .variable, .{ .declaration = true } },
+        .{ "=", .operator, .{} },
+        .{ "Unknown", .variable, .{} },
+        .{ "foo", .variable, .{} },
+    });
+    try testSemanticTokens(
+        \\const S = struct {};
+        \\const alpha = S.unknown;
+    , &.{
+        .{ "const", .keyword, .{} },
+        .{ "S", .namespace, .{ .declaration = true } },
+        .{ "=", .operator, .{} },
+        .{ "struct", .keyword, .{} },
+
+        .{ "const", .keyword, .{} },
+        .{ "alpha", .variable, .{ .declaration = true } },
+        .{ "=", .operator, .{} },
+        .{ "S", .namespace, .{} },
+        .{ "unknown", .variable, .{} },
+    });
+}
+
 test "semantic tokens - alias" {
     try testSemanticTokens(
         \\extern fn foo() u32;
@@ -1464,6 +1491,7 @@ test "semantic tokens - weird code" {
         \\0"" (}; @compileErrors.a
     , &.{
         .{ "0", .number, .{} },
+        .{ "a", .variable, .{} },
     });
     try testSemanticTokens(
         \\foo = asm (fn bar())

--- a/tests/lsp_features/semantic_tokens.zig
+++ b/tests/lsp_features/semantic_tokens.zig
@@ -821,6 +821,16 @@ test "semantic tokens - union" {
         .{ "enum", .keyword, .{} },
     });
     try testSemanticTokens(
+        \\const Foo = union(enum(u8)) {};
+    , &.{
+        .{ "const", .keyword, .{} },
+        .{ "Foo", .type, .{ .declaration = true } },
+        .{ "=", .operator, .{} },
+        .{ "union", .keyword, .{} },
+        .{ "enum", .keyword, .{} },
+        .{ "u8", .type, .{} },
+    });
+    try testSemanticTokens(
         \\const Foo = union(E) {
         \\    alpha,
         \\};

--- a/tests/lsp_features/signature_help.zig
+++ b/tests/lsp_features/signature_help.zig
@@ -178,6 +178,24 @@ test "signature help - nested function call" {
     , "fn bar(c: bool) bool", 0);
 }
 
+test "signature help - builtin" {
+    try testSignatureHelp(
+        \\test {
+        \\    @panic(<cursor>)
+        \\}
+    , "@panic(message: []const u8) noreturn", 0);
+    try testSignatureHelp(
+        \\test {
+        \\    @as(?u32,<cursor>)
+        \\}
+    , "@as(comptime T: type, expression) T", 1);
+    try testSignatureHelp(
+        \\test {
+        \\    @as(?u32,@intCast(<cursor>))
+        \\}
+    , "@intCast(int: anytype) anytype", 0);
+}
+
 fn testSignatureHelp(source: []const u8, expected_label: []const u8, expected_active_parameter: ?u32) !void {
     const cursor_idx = std.mem.indexOf(u8, source, "<cursor>").?;
     const text = try std.mem.concat(allocator, u8, &.{ source[0..cursor_idx], source[cursor_idx + "<cursor>".len ..] });


### PR DESCRIPTION
Mostly meant to increase test coverage except for the following fixes (which were visually unnoticeable in VS Code)
- incorrect semantic tokens on `union(enum(u8))`
- folding range on multi switch cases did not include trailing comma
- field access on unknown lhs or unknown field missed a semantic token 