### PR TITLE
fix invalid unwrap when failing to create build file

### DIFF
--- a/src/DocumentStore.zig
+++ b/src/DocumentStore.zig
@@ -1423,7 +1423,7 @@ pub fn uriFromImportStr(self: *DocumentStore, allocator: std.mem.Allocator, hand
                 }
             }
         } else if (isBuildFile(handle.uri)) blk: {
-            const build_file = self.getBuildFile(handle.uri).?;
+            const build_file = self.getBuildFile(handle.uri) orelse break :blk;
             const build_config = build_file.tryLockConfig() orelse break :blk;
             defer build_file.unlockConfig();
 

--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -890,7 +890,7 @@ fn completeFileSystemStringLiteral(
                 }, {});
             }
         } else if (DocumentStore.isBuildFile(handle.uri)) blk: {
-            const build_file = store.getBuildFile(handle.uri).?;
+            const build_file = store.getBuildFile(handle.uri) orelse break :blk;
             const build_config = build_file.tryLockConfig() orelse break :blk;
             defer build_file.unlockConfig();
 


### PR DESCRIPTION
`getBuildFile` may return null when creating the build file failed.