### PR TITLE
callsite references related optimizations

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -1240,6 +1240,9 @@ fn semanticTokensFullHandler(server: *Server, arena: std.mem.Allocator, request:
 
     var analyser = Analyser.init(server.allocator, &server.document_store, &server.ip, handle);
     defer analyser.deinit();
+    // semantic tokens can be quite expensive to compute on large files
+    // and disabling callsite references can help with bringing the cost down.
+    analyser.collect_callsite_references = false;
 
     return try semantic_tokens.writeSemanticTokens(
         arena,

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -445,6 +445,9 @@ pub fn declNameTokenToSlice(tree: Ast, name_token: Ast.TokenIndex) ?[]const u8 {
 /// const other = decl.middle.other;
 ///```
 pub fn resolveVarDeclAlias(analyser: *Analyser, node_handle: NodeWithHandle) error{OutOfMemory}!?DeclWithHandle {
+    const tracy_zone = tracy.trace(@src());
+    defer tracy_zone.end();
+
     var node_trail: NodeSet = .{};
     defer node_trail.deinit(analyser.gpa);
     return try analyser.resolveVarDeclAliasInternal(node_handle, &node_trail);
@@ -2188,6 +2191,9 @@ pub const TypeWithHandle = struct {
 };
 
 pub fn resolveTypeOfNode(analyser: *Analyser, node_handle: NodeWithHandle) error{OutOfMemory}!?TypeWithHandle {
+    const tracy_zone = tracy.trace(@src());
+    defer tracy_zone.end();
+
     analyser.bound_type_params.clearRetainingCapacity();
     return analyser.resolveTypeOfNodeInternal(node_handle);
 }
@@ -2995,6 +3001,9 @@ pub const DeclWithHandle = struct {
     }
 
     pub fn resolveType(self: DeclWithHandle, analyser: *Analyser) error{OutOfMemory}!?TypeWithHandle {
+        const tracy_zone = tracy.trace(@src());
+        defer tracy_zone.end();
+
         const tree = self.handle.tree;
         const node_tags = tree.nodes.items(.tag);
         const main_tokens = tree.nodes.items(.main_token);
@@ -3009,6 +3018,9 @@ pub const DeclWithHandle = struct {
 
                 // handle anytype
                 if (param.type_expr == 0) {
+                    const tracy_zone_inner = tracy.traceNamed(@src(), "resolveCallsiteReferences");
+                    defer tracy_zone_inner.end();
+
                     const is_cimport = std.mem.eql(u8, std.fs.path.basename(self.handle.uri), "cimport.zig");
 
                     if (is_cimport or !analyser.collect_callsite_references) return null;

--- a/src/features/references.zig
+++ b/src/features/references.zig
@@ -337,6 +337,9 @@ pub fn callsiteReferences(
     /// search other files for references
     workspace: bool,
 ) error{OutOfMemory}!std.ArrayListUnmanaged(Callsite) {
+    const tracy_zone = tracy.trace(@src());
+    defer tracy_zone.end();
+
     std.debug.assert(decl_handle.decl == .ast_node);
 
     var builder = CallBuilder{


### PR DESCRIPTION
fixes #1635
~~I will have to look if I can produce a simple reproduction to convert into a test case. Maybe I will then find a better solution for this problem.~~
I may not know what exactly is going on, but resolving recursively resolving callsite references is bad. So just stop doing that.

# Before 
![Screenshot from 2023-12-01 19-53-50](https://github.com/zigtools/zls/assets/19954306/b23dd1c2-1835-435b-b8e0-a5517b7e17f5)

# After

This graph is without disabling callsite references completely in `cimport.zig` files. So only resolving callsite references while resolving callsite references is prevented.

![Screenshot from 2023-12-01 20-43-31](https://github.com/zigtools/zls/assets/19954306/9a78d337-2545-497a-91bf-c49be2bf92ca)

---

The given `cimport.zig` in #1635 is also a good showcase of the parallelization of ZLS

![Screenshot from 2023-12-01 20-42-33-with-notes](https://github.com/zigtools/zls/assets/19954306/afe93613-e651-4155-8aa8-1ee900183777)
