### PR TITLE
Delay finding and associating a build file with a (handle) uri

### DIFF
--- a/src/ComptimeInterpreter.zig
+++ b/src/ComptimeInterpreter.zig
@@ -892,10 +892,10 @@ pub fn interpret(
                     } };
                 }
 
-                const import_uri = (try interpreter.document_store.uriFromImportStr(interpreter.allocator, interpreter.getHandle().*, import_str[1 .. import_str.len - 1])) orelse return error.ImportFailure;
+                const import_uri = (try interpreter.document_store.uriFromImportStr(interpreter.allocator, interpreter.getHandle(), import_str[1 .. import_str.len - 1])) orelse return error.ImportFailure;
                 defer interpreter.allocator.free(import_uri);
 
-                const import_handle = interpreter.document_store.getOrLoadHandle(import_uri) orelse return error.ImportFailure;
+                const import_handle = interpreter.document_store.getOrLoadHandle(import_uri, true) orelse return error.ImportFailure;
                 const import_interpreter = try import_handle.getComptimeInterpreter(interpreter.document_store, interpreter.ip);
 
                 if (import_interpreter.mutex.tryLock()) {

--- a/src/features/goto.zig
+++ b/src/features/goto.zig
@@ -204,13 +204,13 @@ fn gotoDefinitionString(
     const uri = switch (pos_context) {
         .import_string_literal,
         .embedfile_string_literal,
-        => try document_store.uriFromImportStr(arena, handle.*, import_str),
+        => try document_store.uriFromImportStr(arena, handle, import_str),
         .cinclude_string_literal => try URI.fromPath(
             arena,
             blk: {
                 if (std.fs.path.isAbsolute(import_str)) break :blk import_str;
                 var include_dirs: std.ArrayListUnmanaged([]const u8) = .{};
-                _ = document_store.collectIncludeDirs(arena, handle.*, &include_dirs) catch |err| {
+                _ = document_store.collectIncludeDirs(arena, handle, &include_dirs) catch |err| {
                     log.err("failed to resolve include paths: {}", .{err});
                     return null;
                 };

--- a/src/features/references.zig
+++ b/src/features/references.zig
@@ -159,7 +159,7 @@ fn gatherReferences(
 
         var handle_dependencies = std.ArrayListUnmanaged([]const u8){};
         defer handle_dependencies.deinit(allocator);
-        try analyser.store.collectDependencies(allocator, handle.*, &handle_dependencies);
+        try analyser.store.collectDependencies(allocator, handle, &handle_dependencies);
 
         try dependencies.ensureUnusedCapacity(allocator, handle_dependencies.items.len);
         for (handle_dependencies.items) |uri| {
@@ -174,7 +174,7 @@ fn gatherReferences(
         if (std.mem.eql(u8, uri, curr_handle.uri)) continue;
         const handle = switch (handle_behavior) {
             .get => analyser.store.getHandle(uri),
-            .get_or_load => analyser.store.getOrLoadHandle(uri),
+            .get_or_load => analyser.store.getOrLoadHandle(uri, true),
         } orelse continue;
 
         try builder.collectReferences(handle, 0);


### PR DESCRIPTION
Current logic requires the modules available in a build.zig file to be known in order to correctly associate the file with an uri.

See #1629 

Take N2