### PR TITLE
Experiment with making ZLS build runner logic a build step

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,13 +1,15 @@
 const std = @import("std");
 const builtin = @import("builtin");
 
-const zls_version = std.SemanticVersion{ .major = 0, .minor = 12, .patch = 0 };
+pub const ExtractBuildInfo = @import("src/build_runner/ExtractBuildInfo.zig");
+
+pub const zls_version = std.SemanticVersion{ .major = 0, .minor = 12, .patch = 0 };
 
 /// document the latest breaking change that caused a change to the string below:
 /// Remove all usages of `std.mem.copy` and remove `std.mem.set` (#18143)
-const min_zig_string = "0.12.0-dev.1767+1e42a3de89";
+pub const min_zig_string = "0.12.0-dev.1767+1e42a3de89";
 
-pub fn build(b: *std.build.Builder) !void {
+pub fn build(b: *std.Build) !void {
     comptime {
         const current_zig = builtin.zig_version;
         const min_zig = std.SemanticVersion.parse(min_zig_string) catch unreachable;

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -1097,6 +1097,13 @@ fn resolveConfiguration(server: *Server, config_arena: std.mem.Allocator, config
 
         try build_config_file.writeAll(@embedFile("build_runner/BuildConfig.zig"));
 
+        const pacakges_path = try std.fs.path.resolve(config_arena, &[_][]const u8{ config.global_cache_path.?, "Packages.zig" });
+
+        const pacakges_path_file = try std.fs.createFileAbsolute(pacakges_path, .{});
+        defer pacakges_path_file.close();
+
+        try pacakges_path_file.writeAll(@embedFile("build_runner/Packages.zig"));
+
         try build_runner_file.writeAll(
             switch (build_runner_version) {
                 inline else => |tag| @embedFile("build_runner/" ++ @tagName(tag) ++ ".zig"),

--- a/src/build_runner/ExtractBuildInfo.zig
+++ b/src/build_runner/ExtractBuildInfo.zig
@@ -1,0 +1,165 @@
+//! Build step to extract build info
+
+const ExtractBuildInfo = @This();
+const std = @import("std");
+const Build = std.Build;
+const Step = Build.Step;
+const fs = std.fs;
+const mem = std.mem;
+const BuildConfig = @import("BuildConfig.zig");
+const Packages = @import("Packages.zig");
+
+const build_runner = @import("root");
+const dependencies = build_runner.dependencies;
+
+pub const Mode = enum {
+    /// Entire build graph; hacky and you shouldn't use it if you can avoid it
+    /// TODO implement this
+    all,
+    /// Steps this step depends on
+    dependencies,
+};
+
+step: Step,
+mode: Mode,
+
+pub const base_id = .custom;
+
+pub const Options = struct {
+    mode: Mode = .dependencies,
+};
+
+pub fn create(
+    owner: *Build,
+    options: Options,
+) *ExtractBuildInfo {
+    const self = owner.allocator.create(ExtractBuildInfo) catch @panic("OOM");
+    self.* = .{
+        .step = Step.init(.{
+            .id = base_id,
+            .name = "ExtractBuildInfo",
+            .owner = owner,
+            .makeFn = make,
+        }),
+        .mode = options.mode,
+    };
+    return self;
+}
+
+fn processStep(
+    builder: *std.Build,
+    packages: *Packages,
+    include_dirs: *std.StringArrayHashMapUnmanaged(void),
+    step: *Build.Step,
+) anyerror!void {
+    for (step.dependencies.items) |dependant_step| {
+        try processStep(builder, packages, include_dirs, dependant_step);
+    }
+
+    const exe = blk: {
+        if (step.cast(Build.Step.InstallArtifact)) |install_exe| break :blk install_exe.artifact;
+        if (step.cast(Build.Step.Compile)) |exe| break :blk exe;
+        return;
+    };
+
+    if (exe.root_src) |src| {
+        _ = try packages.addPackage("root", src.getPath(builder));
+    }
+    try processIncludeDirs(builder, include_dirs, exe.include_dirs.items);
+    // TODO // try processPkgConfig(builder.allocator, include_dirs, exe);
+    try processModules(builder, packages, exe.modules);
+}
+
+fn processIncludeDirs(
+    builder: *Build,
+    include_dirs: *std.StringArrayHashMapUnmanaged(void),
+    dirs: []Build.Step.Compile.IncludeDir,
+) !void {
+    for (dirs) |dir| {
+        switch (dir) {
+            .path, .path_system, .path_after => |path| {
+                try include_dirs.put(builder.allocator, path.getPath(builder), {});
+            },
+            .other_step => |other_step| {
+                if (other_step.generated_h) |header| {
+                    if (header.path) |path| {
+                        try include_dirs.put(builder.allocator, std.fs.path.dirname(path).?, {});
+                    }
+                }
+                if (other_step.installed_headers.items.len > 0) {
+                    const path = builder.pathJoin(&.{
+                        other_step.step.owner.install_prefix, "include",
+                    });
+                    try include_dirs.put(builder.allocator, path, {});
+                }
+            },
+            .config_header_step => |config_header| {
+                const full_file_path = config_header.output_file.path orelse continue;
+                const header_dir_path = full_file_path[0 .. full_file_path.len - config_header.include_path.len];
+                try include_dirs.put(builder.allocator, header_dir_path, {});
+            },
+            .framework_path, .framework_path_system => {},
+        }
+    }
+}
+
+fn processModules(
+    builder: *Build,
+    packages: *Packages,
+    modules: std.StringArrayHashMap(*Build.Module),
+) !void {
+    for (modules.keys(), modules.values()) |name, mod| {
+        const already_added = try packages.addPackage(name, mod.source_file.getPath(mod.builder));
+        // if the package has already been added short circuit here or recursive modules will ruin us
+        if (already_added) continue;
+
+        try processModules(builder, packages, mod.dependencies);
+    }
+}
+
+fn make(step: *Step, prog_node: *std.Progress.Node) !void {
+    _ = prog_node;
+    const b = step.owner;
+    const self = @fieldParentPtr(ExtractBuildInfo, "step", step);
+
+    var packages = Packages{ .allocator = b.allocator };
+    var include_dirs: std.StringArrayHashMapUnmanaged(void) = .{};
+
+    var deps_build_roots: std.ArrayListUnmanaged(BuildConfig.DepsBuildRoots) = .{};
+    for (dependencies.root_deps) |root_dep| {
+        inline for (@typeInfo(dependencies.packages).Struct.decls) |package| {
+            if (std.mem.eql(u8, package.name, root_dep[1])) {
+                const package_info = @field(dependencies.packages, package.name);
+                if (!@hasDecl(package_info, "build_root")) continue;
+                try deps_build_roots.append(b.allocator, .{
+                    .name = root_dep[0],
+                    // XXX Check if it exists?
+                    .path = try std.fs.path.resolve(b.allocator, &[_][]const u8{ package_info.build_root, "./build.zig" }),
+                });
+            }
+        }
+    }
+
+    switch (self.mode) {
+        .all => @panic("TODO :/"),
+        .dependencies => try processStep(step.owner, &packages, &include_dirs, step),
+    }
+
+    var out = try std.fs.createFileAbsolute(try b.cache_root.join(b.allocator, &.{"zls-build-info.json"}), .{});
+    defer out.close();
+
+    var bufw = std.io.bufferedWriter(out.writer());
+
+    try std.json.stringify(
+        BuildConfig{
+            .deps_build_roots = try deps_build_roots.toOwnedSlice(b.allocator),
+            .packages = try packages.toPackageList(),
+            .include_dirs = include_dirs.keys(),
+        },
+        .{
+            .whitespace = .indent_1,
+        },
+        bufw.writer(),
+    );
+    try bufw.flush();
+}

--- a/src/build_runner/Packages.zig
+++ b/src/build_runner/Packages.zig
@@ -1,0 +1,43 @@
+const std = @import("std");
+const BuildConfig = @import("BuildConfig.zig");
+
+const Packages = @This();
+
+allocator: std.mem.Allocator,
+
+/// Outer key is the package name, inner key is the file path.
+packages: std.StringArrayHashMapUnmanaged(std.StringArrayHashMapUnmanaged(void)) = .{},
+
+/// Returns true if the package was already present.
+pub fn addPackage(self: *Packages, name: []const u8, path: []const u8) !bool {
+    const name_gop_result = try self.packages.getOrPut(self.allocator, name);
+    if (!name_gop_result.found_existing) {
+        name_gop_result.value_ptr.* = .{};
+    }
+
+    const path_gop_result = try name_gop_result.value_ptr.getOrPut(self.allocator, path);
+    return path_gop_result.found_existing;
+}
+
+pub fn toPackageList(self: *Packages) ![]BuildConfig.Pkg {
+    var result: std.ArrayListUnmanaged(BuildConfig.Pkg) = .{};
+    errdefer result.deinit(self.allocator);
+
+    var name_iter = self.packages.iterator();
+    while (name_iter.next()) |path_hashmap| {
+        var path_iter = path_hashmap.value_ptr.iterator();
+        while (path_iter.next()) |path| {
+            try result.append(self.allocator, .{ .name = path_hashmap.key_ptr.*, .path = path.key_ptr.* });
+        }
+    }
+
+    return try result.toOwnedSlice(self.allocator);
+}
+
+pub fn deinit(self: *Packages) void {
+    var outer_iter = self.packages.iterator();
+    while (outer_iter.next()) |inner| {
+        inner.value_ptr.deinit(self.allocator);
+    }
+    self.packages.deinit(self.allocator);
+}

--- a/src/build_runner/master.zig
+++ b/src/build_runner/master.zig
@@ -4,6 +4,7 @@ const log = std.log;
 const process = std.process;
 const builtin = @import("builtin");
 
+const Packages = @import("Packages.zig");
 const BuildConfig = @import("BuildConfig.zig");
 
 pub const dependencies = @import("@dependencies");
@@ -189,47 +190,6 @@ fn reifyOptions(step: *Build.Step) anyerror!void {
         try reifyOptions(unknown_step);
     }
 }
-
-const Packages = struct {
-    allocator: std.mem.Allocator,
-
-    /// Outer key is the package name, inner key is the file path.
-    packages: std.StringArrayHashMapUnmanaged(std.StringArrayHashMapUnmanaged(void)) = .{},
-
-    /// Returns true if the package was already present.
-    pub fn addPackage(self: *Packages, name: []const u8, path: []const u8) !bool {
-        const name_gop_result = try self.packages.getOrPut(self.allocator, name);
-        if (!name_gop_result.found_existing) {
-            name_gop_result.value_ptr.* = .{};
-        }
-
-        const path_gop_result = try name_gop_result.value_ptr.getOrPut(self.allocator, path);
-        return path_gop_result.found_existing;
-    }
-
-    pub fn toPackageList(self: *Packages) ![]BuildConfig.Pkg {
-        var result: std.ArrayListUnmanaged(BuildConfig.Pkg) = .{};
-        errdefer result.deinit(self.allocator);
-
-        var name_iter = self.packages.iterator();
-        while (name_iter.next()) |path_hashmap| {
-            var path_iter = path_hashmap.value_ptr.iterator();
-            while (path_iter.next()) |path| {
-                try result.append(self.allocator, .{ .name = path_hashmap.key_ptr.*, .path = path.key_ptr.* });
-            }
-        }
-
-        return try result.toOwnedSlice(self.allocator);
-    }
-
-    pub fn deinit(self: *Packages) void {
-        var outer_iter = self.packages.iterator();
-        while (outer_iter.next()) |inner| {
-            inner.value_ptr.deinit(self.allocator);
-        }
-        self.packages.deinit(self.allocator);
-    }
-};
 
 fn processStep(
     builder: *std.Build,


### PR DESCRIPTION
Solves many versioning issues as well as custom steps/generated files. Thanks @andrewrk for the suggestion. :)

Try it out with https://github.com/zigtools/zls-as-step-demo

- [x] Refresh build config when JSON manifest is changed
- [ ] Add test based on demo repo
- [ ] Add back pkg-config logic

~~Add extension integration (behavior: when possible, run `zig build install-zls` and use ZLS from `zig-out`)~~