### PR TITLE
disable autofix for var never mutated

### DIFF
--- a/src/features/code_actions.zig
+++ b/src/features/code_actions.zig
@@ -304,7 +304,7 @@ fn handleVariableNeverMutated(builder: *Builder, actions: *std.ArrayListUnmanage
 
     try actions.append(builder.arena, .{
         .title = "use 'const'",
-        .kind = .@"source.fixAll",
+        .kind = .quickfix,
         .isPreferred = true,
         .edit = try builder.createWorkspaceEdit(&.{
             builder.createTextEditLoc(var_keyword_loc, "const"),

--- a/tests/lsp_features/code_actions.zig
+++ b/tests/lsp_features/code_actions.zig
@@ -24,7 +24,7 @@ test "code actions - discard value" {
         \\    _ = bar;
         \\}
         \\
-    );
+    , &.{});
 }
 
 test "code actions - discard function parameter" {
@@ -38,7 +38,7 @@ test "code actions - discard function parameter" {
         \\    _ = c;
         \\}
         \\
-    );
+    , &.{});
 }
 
 test "code actions - discard captures" {
@@ -79,7 +79,7 @@ test "code actions - discard captures" {
         \\    };
         \\}
         \\
-    );
+    , &.{});
 }
 
 test "code actions - discard capture with comment" {
@@ -99,7 +99,7 @@ test "code actions - discard capture with comment" {
         \\    }
         \\}
         \\
-    );
+    , &.{});
 }
 
 test "code actions - remove pointless discard" {
@@ -127,7 +127,7 @@ test "code actions - remove pointless discard" {
         \\    return 0;
         \\}
         \\
-    );
+    , &.{});
 }
 
 test "code actions - correct unnecessary uses of var" {
@@ -143,15 +143,20 @@ test "code actions - correct unnecessary uses of var" {
         \\    _ = foo;
         \\}
         \\
-    );
+    , &.{"use 'const'"});
 }
 
-fn testAutofix(before: []const u8, after: []const u8) !void {
-    try testAutofixOptions(before, after, true); // diagnostics come from our AstGen fork
-    try testAutofixOptions(before, after, false); // diagnostics come from calling zig ast-check
+fn testAutofix(before: []const u8, after: []const u8, ignore_messages: []const []const u8) !void {
+    try testAutofixOptions(before, after, true, ignore_messages); // diagnostics come from our AstGen fork
+    try testAutofixOptions(before, after, false, ignore_messages); // diagnostics come from calling zig ast-check
 }
 
-fn testAutofixOptions(before: []const u8, after: []const u8, want_zir: bool) !void {
+fn testAutofixOptions(
+    before: []const u8,
+    after: []const u8,
+    want_zir: bool,
+    ignore_messages: []const []const u8,
+) !void {
     var ctx = try Context.init();
     defer ctx.deinit();
     ctx.server.config.enable_ast_check_diagnostics = true;
@@ -183,6 +188,9 @@ fn testAutofixOptions(before: []const u8, after: []const u8, want_zir: bool) !vo
 
     for (response) |action| {
         const code_action = action.CodeAction;
+        for (ignore_messages) |message| {
+            if (std.mem.eql(u8, code_action.title, message)) return;
+        }
         if (code_action.kind.? != .@"source.fixAll") continue;
         const workspace_edit = code_action.edit.?;
         const changes = workspace_edit.changes.?.map;


### PR DESCRIPTION
the fix is still available as a code action, just manual now