### PR TITLE
code_actions: autofix unused capture in while loop with continue stat…

### DIFF
--- a/src/features/code_actions.zig
+++ b/src/features/code_actions.zig
@@ -240,7 +240,8 @@ fn handleUnusedCapture(
                 } else if (c == '(') {
                     depth += 1;
                 } else if (source[block_start] == ')') {
-                    depth = std.math.sub(usize, depth, 1) catch return;
+                    // don't need to worry about overflow cause depth is always > 0 here
+                    depth -= 1;
                 },
                 .ws2 => if (!std.ascii.isWhitespace(c)) break,
             }
@@ -495,6 +496,7 @@ const DiagnosticKind = union(enum) {
 
     fn parse(diagnostic_message: []const u8) ?DiagnosticKind {
         const msg = diagnostic_message;
+
         if (std.mem.startsWith(u8, msg, "unused ")) {
             return DiagnosticKind{
                 .unused = parseEnum(IdCat, msg["unused ".len..]) orelse return null,

--- a/tests/lsp_features/code_actions.zig
+++ b/tests/lsp_features/code_actions.zig
@@ -102,6 +102,28 @@ test "code actions - discard capture with comment" {
     );
 }
 
+test "code actions - discard capture - while loop with continue" {
+    try testAutofix(
+        \\const std = @import("std");
+        \\test {
+        \\    var lines = std.mem.tokenizeSequence(u8, "", "\n");
+        \\    var linei: usize = 0;
+        \\    while (lines.next()) |line| : (linei += 1) {}
+        \\}
+        \\
+    ,
+        \\const std = @import("std");
+        \\test {
+        \\    var lines = std.mem.tokenizeSequence(u8, "", "\n");
+        \\    var linei: usize = 0;
+        \\    while (lines.next()) |line| : (linei += 1) {
+        \\        _ = line;
+        \\    }
+        \\}
+        \\
+    );
+}
+
 test "code actions - remove pointless discard" {
     try testAutofix(
         \\fn foo(a: u32) u32 {

--- a/tests/lsp_features/code_actions.zig
+++ b/tests/lsp_features/code_actions.zig
@@ -122,6 +122,26 @@ test "code actions - discard capture - while loop with continue" {
         \\}
         \\
     );
+
+    try testAutofix(
+        \\const std = @import("std");
+        \\test {
+        \\    var lines = std.mem.tokenizeSequence(u8, "", "\n");
+        \\    var linei: usize = 0;
+        \\    while (lines.next()) |line| : (linei += (1 * (2 + 1))) {}
+        \\}
+        \\
+    ,
+        \\const std = @import("std");
+        \\test {
+        \\    var lines = std.mem.tokenizeSequence(u8, "", "\n");
+        \\    var linei: usize = 0;
+        \\    while (lines.next()) |line| : (linei += (1 * (2 + 1))) {
+        \\        _ = line;
+        \\    }
+        \\}
+        \\
+    );
 }
 
 test "code actions - remove pointless discard" {

--- a/tests/lsp_features/code_actions.zig
+++ b/tests/lsp_features/code_actions.zig
@@ -104,17 +104,15 @@ test "code actions - discard capture with comment" {
 
 test "code actions - discard capture - while loop with continue" {
     try testAutofix(
-        \\const std = @import("std");
         \\test {
-        \\    var lines = std.mem.tokenizeSequence(u8, "", "\n");
+        \\    var lines: ?[]const u8 = "";
         \\    var linei: usize = 0;
         \\    while (lines.next()) |line| : (linei += 1) {}
         \\}
         \\
     ,
-        \\const std = @import("std");
         \\test {
-        \\    var lines = std.mem.tokenizeSequence(u8, "", "\n");
+        \\    var lines: ?[]const u8 = "";
         \\    var linei: usize = 0;
         \\    while (lines.next()) |line| : (linei += 1) {
         \\        _ = line;
@@ -124,19 +122,34 @@ test "code actions - discard capture - while loop with continue" {
     );
 
     try testAutofix(
-        \\const std = @import("std");
         \\test {
-        \\    var lines = std.mem.tokenizeSequence(u8, "", "\n");
+        \\    var lines: ?[]const u8 = "";
         \\    var linei: usize = 0;
         \\    while (lines.next()) |line| : (linei += (1 * (2 + 1))) {}
         \\}
         \\
     ,
-        \\const std = @import("std");
         \\test {
-        \\    var lines = std.mem.tokenizeSequence(u8, "", "\n");
+        \\    var lines: ?[]const u8 = "";
         \\    var linei: usize = 0;
         \\    while (lines.next()) |line| : (linei += (1 * (2 + 1))) {
+        \\        _ = line;
+        \\    }
+        \\}
+        \\
+    );
+    try testAutofix(
+        \\test {
+        \\    var lines: ?[]const u8 = "";
+        \\    var linei: usize = 0;
+        \\    while (lines.next()) |line| : (linei += ")))".len) {}
+        \\}
+        \\
+    ,
+        \\test {
+        \\    var lines: ?[]const u8 = "";
+        \\    var linei: usize = 0;
+        \\    while (lines.next()) |line| : (linei += ")))".len) {
         \\        _ = line;
         \\    }
         \\}


### PR DESCRIPTION
previously this statement wasn't autofixed
```zig
...
while (lines.next()) |line| : (linei += 1) {}
```
and and now it becomes
```zig
...
while (lines.next()) |line| : (linei += 1) {
    _ = line;
}
```