### PR TITLE
completions for re-exported functions

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -232,6 +232,28 @@ pub fn isInstanceCall(
 }
 
 pub fn hasSelfParam(analyser: *Analyser, handle: *DocumentStore.Handle, func: Ast.full.FnProto) error{OutOfMemory}!bool {
+    const token_starts = handle.tree.tokens.items(.start);
+    const in_container = try innermostContainer(handle, token_starts[func.ast.fn_token]);
+    return analyser.firstParamIs(handle, func, in_container);
+}
+
+pub fn isSelfFunction(analyser: *Analyser, func_type: TypeWithHandle, container: TypeWithHandle) error{OutOfMemory}!bool {
+    if (!func_type.isFunc()) return false;
+    const func_decl = try analyser.resolveFuncProtoOfCallable(func_type) orelse return false;
+    if (func_decl.type.is_type_val) return false;
+
+    var buf: [1]Ast.Node.Index = undefined;
+    const func = func_decl.handle.tree.fullFnProto(&buf, func_decl.type.data.other) orelse return false;
+
+    return analyser.firstParamIs(func_decl.handle, func, container);
+}
+
+pub fn firstParamIs(
+    analyser: *Analyser,
+    handle: *DocumentStore.Handle,
+    func: Ast.full.FnProto,
+    expected: TypeWithHandle,
+) error{OutOfMemory}!bool {
     // Non-decl prototypes cannot have a self parameter.
     if (func.name_token == null) return false;
     if (func.ast.params.len == 0) return false;
@@ -241,14 +263,11 @@ pub fn hasSelfParam(analyser: *Analyser, handle: *DocumentStore.Handle, func: As
     const param = ast.nextFnParam(&it).?;
     if (param.type_expr == 0) return false;
 
-    const token_starts = tree.tokens.items(.start);
-    const in_container = try innermostContainer(handle, token_starts[func.ast.fn_token]);
-
     if (try analyser.resolveTypeOfNodeInternal(.{
         .node = param.type_expr,
         .handle = handle,
     })) |resolved_type| {
-        if (std.meta.eql(in_container, resolved_type))
+        if (resolved_type.eql(expected))
             return true;
     }
 
@@ -257,7 +276,7 @@ pub fn hasSelfParam(analyser: *Analyser, handle: *DocumentStore.Handle, func: As
             .node = ptr_type.ast.child_type,
             .handle = handle,
         })) |resolved_prefix_op| {
-            if (std.meta.eql(in_container, resolved_prefix_op))
+            if (resolved_prefix_op.eql(expected))
                 return true;
         }
     }
@@ -3217,6 +3236,7 @@ fn iterateSymbolsContainerInternal(
 
     for (scope_decls) |decl_index| {
         const decl = document_scope.declarations.get(@intFromEnum(decl_index));
+
         switch (decl) {
             .ast_node => |node| switch (node_tags[node]) {
                 .container_field_init,
@@ -3236,7 +3256,18 @@ fn iterateSymbolsContainerInternal(
                 .simple_var_decl,
                 .aligned_var_decl,
                 => {
-                    if (instance_access) continue;
+                    if (instance_access) {
+                        // allow declarations which evaluate to functions where
+                        // the first parameter has the type of the container:
+                        const alias = try analyser.resolveVarDeclAlias(
+                            NodeWithHandle{ .node = node, .handle = handle },
+                        ) orelse continue;
+
+                        const alias_type = try alias.resolveType(analyser) orelse continue;
+
+                        const container_type = TypeWithHandle.typeVal(container_handle);
+                        if (!try analyser.isSelfFunction(alias_type, container_type)) continue;
+                    }
                 },
                 else => {},
             },

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -3262,11 +3262,9 @@ fn iterateSymbolsContainerInternal(
                     if (instance_access) {
                         // allow declarations which evaluate to functions where
                         // the first parameter has the type of the container:
-                        const alias = try analyser.resolveVarDeclAlias(
+                        const alias_type = try analyser.resolveTypeOfNode(
                             NodeWithHandle{ .node = node, .handle = handle },
                         ) orelse continue;
-
-                        const alias_type = try alias.resolveType(analyser) orelse continue;
 
                         const container_type = TypeWithHandle.typeVal(container_handle);
                         if (!try analyser.isSelfFunction(alias_type, container_type)) continue;

--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -1672,6 +1672,24 @@ test "completion - enum completion on out of bound parameter index" {
     , &.{});
 }
 
+test "completion - delegated declaration" {
+    try testCompletion(
+        \\fn fooImpl(_: Foo) void {}
+        \\fn barImpl(_: *const Foo) void {}
+        \\fn bazImpl(_: u32) void {}
+        \\const Foo = struct {
+        \\    pub const foo = fooImpl;
+        \\    pub const bar = barImpl;
+        \\    pub const baz = bazImpl;
+        \\};
+        \\const foo = Foo{};
+        \\const baz = foo.<cursor>;
+    , &.{
+        .{ .label = "foo", .kind = .Function, .detail = "fn fooImpl(_: Foo) void" },
+        .{ .label = "bar", .kind = .Function, .detail = "fn barImpl(_: *const Foo) void" },
+    });
+}
+
 fn testCompletion(source: []const u8, expected_completions: []const Completion) !void {
     const cursor_idx = std.mem.indexOf(u8, source, "<cursor>").?;
     const text = try std.mem.concat(allocator, u8, &.{ source[0..cursor_idx], source[cursor_idx + "<cursor>".len ..] });

--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -673,6 +673,22 @@ test "completion - struct" {
         .{ .label = "S", .kind = .Constant, .detail = "const S = struct" },
         .{ .label = "Mode", .kind = .Constant, .detail = "const Mode = enum" },
     });
+
+    try testCompletion(
+        \\fn fooImpl(_: Foo) void {}
+        \\fn barImpl(_: *const Foo) void {}
+        \\fn bazImpl(_: u32) void {}
+        \\const Foo = struct {
+        \\    pub const foo = fooImpl;
+        \\    pub const bar = barImpl;
+        \\    pub const baz = bazImpl;
+        \\};
+        \\const foo = Foo{};
+        \\const baz = foo.<cursor>;
+    , &.{
+        .{ .label = "foo", .kind = .Function, .detail = "fn fooImpl(_: Foo) void" },
+        .{ .label = "bar", .kind = .Function, .detail = "fn barImpl(_: *const Foo) void" },
+    });
 }
 
 test "completion - union" {
@@ -1670,24 +1686,6 @@ test "completion - enum completion on out of bound parameter index" {
         \\fn foo() void {}
         \\const foo = foo(,.<cursor>);
     , &.{});
-}
-
-test "completion - delegated declaration" {
-    try testCompletion(
-        \\fn fooImpl(_: Foo) void {}
-        \\fn barImpl(_: *const Foo) void {}
-        \\fn bazImpl(_: u32) void {}
-        \\const Foo = struct {
-        \\    pub const foo = fooImpl;
-        \\    pub const bar = barImpl;
-        \\    pub const baz = bazImpl;
-        \\};
-        \\const foo = Foo{};
-        \\const baz = foo.<cursor>;
-    , &.{
-        .{ .label = "foo", .kind = .Function, .detail = "fn fooImpl(_: Foo) void" },
-        .{ .label = "bar", .kind = .Function, .detail = "fn barImpl(_: *const Foo) void" },
-    });
 }
 
 fn testCompletion(source: []const u8, expected_completions: []const Completion) !void {


### PR DESCRIPTION
closes #423

I encountered this bug while using https://github.com/ziglibs/zgl, which has many types that look like the following:

```zig
pub const VertexArray = enum(UInt) {
    invalid = 0,
    _,

    pub const create = gl.createVertexArray;
    pub const delete = gl.deleteVertexArray;
    pub const gen = gl.genVertexArray;
    pub const bind = gl.bindVertexArray;
    pub const enableVertexAttribute = gl.enableVertexArrayAttrib;
    pub const disableVertexAttribute = gl.disableVertexArrayAttrib;

    pub const attribFormat = gl.vertexArrayAttribFormat;
    pub const attribIFormat = gl.vertexArrayAttribIFormat;
    pub const attribLFormat = gl.vertexArrayAttribLFormat;

    pub const attribBinding = gl.vertexArrayAttribBinding;

    pub const vertexBuffer = gl.vertexArrayVertexBuffer;
    pub const elementBuffer = gl.vertexArrayElementBuffer;
};
```

Previously, there were no completions for any of the re-exported functions. But with this patch we yield completions for all re-exported functions which accept the container (`VertexArray` in the case above) as their first argument.