### PR TITLE
Fix type resolution of various primitives

### DIFF
--- a/src/features/semantic_tokens.zig
+++ b/src/features/semantic_tokens.zig
@@ -1000,8 +1000,8 @@ fn writeIdentifier(builder: *Builder, name_token: Ast.Node.Index) error{OutOfMem
 
     if (!is_escaped_identifier) {
         if (std.mem.eql(u8, name, "_")) return;
-        if (Analyser.resolvePrimitiveType(name)) |primitive| {
-            const is_type = builder.analyser.ip.indexToKey(primitive).typeOf() == .type_type;
+        if (builder.analyser.resolvePrimitiveType(handle, name)) |primitive| {
+            const is_type = primitive.type.is_type_val;
             return try writeToken(builder, name_token, if (is_type) .type else .keywordLiteral);
         }
     }

--- a/tests/lsp_features/hover.zig
+++ b/tests/lsp_features/hover.zig
@@ -464,6 +464,59 @@ test "hover - integer overflow on top level container" {
     );
 }
 
+test "hover - primitive" {
+    try testHover(
+        \\const f<cursor>oo = true;
+    ,
+        \\```zig
+        \\const foo = true
+        \\```
+        \\```zig
+        \\(bool)
+        \\```
+    );
+    try testHover(
+        \\const f<cursor>oo = false;
+    ,
+        \\```zig
+        \\const foo = false
+        \\```
+        \\```zig
+        \\(bool)
+        \\```
+    );
+    try testHover(
+        \\const f<cursor>oo = null;
+    ,
+        \\```zig
+        \\const foo = null
+        \\```
+        \\```zig
+        \\(@TypeOf(null))
+        \\```
+    );
+    try testHover(
+        \\const f<cursor>oo = undefined;
+    ,
+        \\```zig
+        \\const foo = undefined
+        \\```
+        \\```zig
+        \\(@TypeOf(undefined))
+        \\```
+    );
+    try testHover(
+        \\const f<cursor>oo: i7 = 42;
+    ,
+        \\```zig
+        \\const foo: i7 = 42
+        \\```
+        \\```zig
+        \\(i7)
+        \\```
+    );
+}
+
 fn testHover(source: []const u8, expected: []const u8) !void {
     const cursor_idx = std.mem.indexOf(u8, source, "<cursor>").?;
     const text = try std.mem.concat(allocator, u8, &.{ source[0..cursor_idx], source[cursor_idx + "<cursor>".len ..] });

--- a/tests/lsp_features/hover.zig
+++ b/tests/lsp_features/hover.zig
@@ -486,6 +486,19 @@ test "hover - primitive" {
         \\```
     );
     try testHover(
+        \\const a = true;
+        \\const b = false;
+        \\const c = true;
+        \\const f<cursor>oo = if (a) b else c;
+    ,
+        \\```zig
+        \\const foo = if (a) b else c
+        \\```
+        \\```zig
+        \\(bool)
+        \\```
+    );
+    try testHover(
         \\const f<cursor>oo = null;
     ,
         \\```zig
@@ -513,6 +526,16 @@ test "hover - primitive" {
         \\```
         \\```zig
         \\(i7)
+        \\```
+    );
+    try testHover(
+        \\const f<cursor>oo: u7 = 42;
+    ,
+        \\```zig
+        \\const foo: u7 = 42
+        \\```
+        \\```zig
+        \\(u7)
         \\```
     );
 }

--- a/tests/lsp_features/semantic_tokens.zig
+++ b/tests/lsp_features/semantic_tokens.zig
@@ -105,12 +105,16 @@ test "semantic tokens - type literals" {
         \\u8,
         \\u15,
         \\anyframe,
+        \\i2,
+        \\u3,
     , &.{
         .{ "bool", .type, .{} },
         .{ "f16", .type, .{} },
         .{ "u8", .type, .{} },
         .{ "u15", .type, .{} },
         .{ "anyframe", .type, .{} },
+        .{ "i2", .type, .{} },
+        .{ "u3", .type, .{} },
     });
 }
 


### PR DESCRIPTION
```zig
const a = false; // bool
const b = true; // bool
const c = null; // @TypeOf(null)
const d = undefined; // @TypeOf(undefined)
const e: i7 = 42; // i7
const f: u7 = 42; // u7
```

- Added `.int` variant to `Type.data` for integer types not covered by `InternPool.Index`
- `primitives.get("true")` returns `.bool_true` but the type of `true` should be `.bool_type`. Let's use the return value of `InternPool.Key.typeOf` if the primitive is a value and not a type. (Closes #1600)

@Techatrix: What are the following lines for? https://github.com/zigtools/zls/blob/a4c568d/src/analysis.zig#L4071-L4079 At first glance, they seem redundant since `addReferencedTypes` already handles `.ip_index`