### PR TITLE
add autofix comments + diagnostic on discards

### DIFF
--- a/src/features/code_actions.zig
+++ b/src/features/code_actions.zig
@@ -166,15 +166,15 @@ fn handleUnusedFunctionParameter(builder: *Builder, actions: *std.ArrayListUnman
     // ) void { ... }
     // We have to be able to detect both cases.
     const fn_proto_param = payload.get(tree).?;
-    const param_end = offsets.tokenToLoc(tree, ast.paramLastToken(tree, fn_proto_param)).end;
+    const last_param_token = ast.paramLastToken(tree, fn_proto_param);
 
-    const found_comma = std.mem.startsWith(
-        u8,
-        std.mem.trimLeft(u8, tree.source[param_end..], " \n"),
-        ",",
-    );
+    const potential_comma_token = last_param_token + 1;
+    const found_comma = potential_comma_token < tree.tokens.len and tree.tokens.items(.tag)[potential_comma_token] == .comma;
 
-    const new_text = try createDiscardText(builder, identifier_name, token_starts[node_tokens[payload.func]], true, !found_comma);
+    const potential_r_paren_token = last_param_token + @intFromBool(found_comma) + 1;
+    const is_last_param = potential_r_paren_token < tree.tokens.len and tree.tokens.items(.tag)[potential_r_paren_token] == .r_paren;
+
+    const new_text = try createDiscardText(builder, identifier_name, token_starts[node_tokens[payload.func]], true, is_last_param);
 
     const index = token_starts[node_tokens[block]] + 1;
 

--- a/src/features/diagnostics.zig
+++ b/src/features/diagnostics.zig
@@ -11,6 +11,7 @@ const Analyser = @import("../analysis.zig");
 const ast = @import("../ast.zig");
 const offsets = @import("../offsets.zig");
 const URI = @import("../uri.zig");
+const code_actions = @import("code_actions.zig");
 const tracy = @import("../tracy.zig");
 
 const Module = @import("../stage2/Module.zig");
@@ -42,6 +43,10 @@ pub fn generateDiagnostics(server: *Server, arena: std.mem.Allocator, handle: *D
 
     if (server.config.enable_ast_check_diagnostics and tree.errors.len == 0) {
         try getAstCheckDiagnostics(server, arena, handle, &diagnostics);
+    }
+
+    if (server.config.enable_autofix) {
+        try code_actions.collectAutoDiscardDiagnostics(tree, arena, &diagnostics, server.offset_encoding);
     }
 
     if (server.config.warn_style) {

--- a/tests/lsp_features/code_actions.zig
+++ b/tests/lsp_features/code_actions.zig
@@ -39,6 +39,17 @@ test "code actions - discard function parameter" {
         \\}
         \\
     );
+    try testAutofix(
+        \\fn foo(a: void, b: void, c: void,) void {}
+        \\
+    ,
+        \\fn foo(a: void, b: void, c: void,) void {
+        \\    _ = a; // autofix
+        \\    _ = b; // autofix
+        \\    _ = c; // autofix
+        \\}
+        \\
+    );
 }
 
 test "code actions - discard captures" {

--- a/tests/lsp_features/code_actions.zig
+++ b/tests/lsp_features/code_actions.zig
@@ -18,10 +18,10 @@ test "code actions - discard value" {
     ,
         \\test {
         \\    var foo = {};
-        \\    _ = foo;
+        \\    _ = foo; // autofix
         \\    const bar, var baz = .{ 1, 2 };
-        \\    _ = baz;
-        \\    _ = bar;
+        \\    _ = baz; // autofix
+        \\    _ = bar; // autofix
         \\}
         \\
     );
@@ -33,9 +33,9 @@ test "code actions - discard function parameter" {
         \\
     ,
         \\fn foo(a: void, b: void, c: void) void {
-        \\    _ = a;
-        \\    _ = b;
-        \\    _ = c;
+        \\    _ = a; // autofix
+        \\    _ = b; // autofix
+        \\    _ = c; // autofix
         \\}
         \\
     );
@@ -56,26 +56,26 @@ test "code actions - discard captures" {
     ,
         \\test {
         \\    for (0..10, 0..10, 0..10) |i, j, k| {
-        \\        _ = i;
-        \\        _ = j;
-        \\        _ = k;
+        \\        _ = i; // autofix
+        \\        _ = j; // autofix
+        \\        _ = k; // autofix
         \\    }
         \\    switch (union(enum) {}{}) {
         \\        inline .a => |cap, tag| {
-        \\            _ = cap;
-        \\            _ = tag;
+        \\            _ = cap; // autofix
+        \\            _ = tag; // autofix
         \\        },
         \\    }
         \\    if (null) |x| {
-        \\        _ = x;
+        \\        _ = x; // autofix
         \\    }
         \\    if (null) |v| {
-        \\        _ = v;
+        \\        _ = v; // autofix
         \\    } else |e| {
-        \\        _ = e;
+        \\        _ = e; // autofix
         \\    }
         \\    _ = null catch |e| {
-        \\        _ = e;
+        \\        _ = e; // autofix
         \\    };
         \\}
         \\
@@ -95,7 +95,7 @@ test "code actions - discard capture with comment" {
         \\    if (1 == 1) |a|
         \\    //a
         \\    {
-        \\        _ = a;
+        \\        _ = a; // autofix
         \\    }
         \\}
         \\
@@ -115,7 +115,7 @@ test "code actions - discard capture - while loop with continue" {
         \\    var lines: ?[]const u8 = "";
         \\    var linei: usize = 0;
         \\    while (lines.next()) |line| : (linei += 1) {
-        \\        _ = line;
+        \\        _ = line; // autofix
         \\    }
         \\}
         \\
@@ -133,7 +133,7 @@ test "code actions - discard capture - while loop with continue" {
         \\    var lines: ?[]const u8 = "";
         \\    var linei: usize = 0;
         \\    while (lines.next()) |line| : (linei += (1 * (2 + 1))) {
-        \\        _ = line;
+        \\        _ = line; // autofix
         \\    }
         \\}
         \\
@@ -150,7 +150,7 @@ test "code actions - discard capture - while loop with continue" {
         \\    var lines: ?[]const u8 = "";
         \\    var linei: usize = 0;
         \\    while (lines.next()) |line| : (linei += ")))".len) {
-        \\        _ = line;
+        \\        _ = line; // autofix
         \\    }
         \\}
         \\
@@ -160,13 +160,13 @@ test "code actions - discard capture - while loop with continue" {
 test "code actions - remove pointless discard" {
     try testAutofix(
         \\fn foo(a: u32) u32 {
-        \\    _ = a;
+        \\    _ = a; // autofix
         \\    const b: ?u32 = a;
-        \\    _ = b;
+        \\    _ = b; // autofix
         \\    const c = b;
-        \\    _ = c;
+        \\    _ = c; // autofix
         \\    if (c) |d| {
-        \\        _ = d;
+        \\        _ = d; // autofix
         \\        return d;
         \\    }
         \\    return 0;
@@ -180,6 +180,62 @@ test "code actions - remove pointless discard" {
         \\        return d;
         \\    }
         \\    return 0;
+        \\}
+        \\
+    );
+}
+
+test "code actions - remove discard of unknown identifier" {
+    try testAutofix(
+        \\fn foo() void {
+        \\    _ = a; // autofix
+        \\}
+        \\
+    ,
+        \\fn foo() void {
+        \\}
+        \\
+    );
+}
+
+test "code actions - ignore autofix comment whitespace" {
+    try testAutofix(
+        \\fn foo() void {
+        \\    _ = a; // autofix
+        \\}
+        \\
+    ,
+        \\fn foo() void {
+        \\}
+        \\
+    );
+    try testAutofix(
+        \\fn foo() void {
+        \\    _ = a;// autofix
+        \\}
+        \\
+    ,
+        \\fn foo() void {
+        \\}
+        \\
+    );
+    try testAutofix(
+        \\fn foo() void {
+        \\    _ = a;//autofix
+        \\}
+        \\
+    ,
+        \\fn foo() void {
+        \\}
+        \\
+    );
+    try testAutofix(
+        \\fn foo() void {
+        \\    _ = a;   //   autofix  
+        \\}
+        \\
+    ,
+        \\fn foo() void {
         \\}
         \\
     );


### PR DESCRIPTION
This idea has been brought up in #1623. 

Here is what I've changed:
- add a `// autofix` comment after every discard that is added by autofix
- only removed unnecessary discard if they have the autofix comment
- show a diagnostic on every discard that has the autofix comment

Suggestions on a better better diagnostic message or autofix comment are welcome.

Here is what I get shown when autofix adds a discard to my code:
![Screenshot from 2023-12-11 20-25-30](https://github.com/zigtools/zls/assets/19954306/01fb85b2-3ae6-49bc-a07b-e892616da57e)
Note that I am using the `usernamehw.errorlens` extension that shows diagnostics messages inside the document.
