### PR TITLE
handle `offsets.positionToIndex` on more characters than line length

### DIFF
--- a/src/offsets.zig
+++ b/src/offsets.zig
@@ -480,9 +480,11 @@ pub fn countCodeUnits(text: []const u8, encoding: Encoding) usize {
 }
 
 /// returns the number of (utf-8 code units / bytes) that represent `n` code units in `text`
+/// if `text` has less than `n` code units then the number of code units in
+/// `text` are returned, i.e. the result is being clamped.
 pub fn getNCodeUnitByteCount(text: []const u8, n: usize, encoding: Encoding) usize {
     switch (encoding) {
-        .@"utf-8" => return n,
+        .@"utf-8" => return @min(text.len, n),
         .@"utf-16" => {
             if (n == 0) return 0;
             var iter: std.unicode.Utf8Iterator = .{ .bytes = text, .i = 0 };
@@ -502,6 +504,7 @@ pub fn getNCodeUnitByteCount(text: []const u8, n: usize, encoding: Encoding) usi
             var i: usize = 0;
             var count: usize = 0;
             while (count != n) : (count += 1) {
+                if (i >= text.len) break;
                 i += std.unicode.utf8ByteSequenceLength(text[i]) catch unreachable;
             }
             return i;

--- a/tests/utility/offsets.zig
+++ b/tests/utility/offsets.zig
@@ -31,6 +31,24 @@ test "offsets - index <-> Position" {
     try testIndexPosition("a¶↉🠁\n", 11, 1, .{ 0, 0, 0 });
 }
 
+test "offsets - positionToIndex where character value is greater than the line length" {
+    try testPositionToIndex("", 0, 0, .{ 1, 1, 1 });
+
+    try testPositionToIndex("\n", 0, 0, .{ 1, 1, 1 });
+    try testPositionToIndex("\n", 0, 0, .{ 2, 2, 2 });
+    try testPositionToIndex("\n", 0, 0, .{ 3, 3, 3 });
+
+    try testPositionToIndex("\n", 1, 1, .{ 1, 1, 1 });
+    try testPositionToIndex("\n", 1, 1, .{ 2, 2, 2 });
+    try testPositionToIndex("\n", 1, 1, .{ 3, 3, 3 });
+
+    try testPositionToIndex("hello\nfrom\nzig\n", 5, 0, .{ 6, 6, 6 });
+    try testPositionToIndex("hello\nfrom\nzig\n", 10, 1, .{ 5, 5, 5 });
+
+    try testPositionToIndex("a¶↉🠁\na¶↉🠁", 21, 1, .{ 11, 6, 5 });
+    try testPositionToIndex("a¶↉🠁\na¶↉🠁\n", 21, 1, .{ 11, 6, 5 });
+}
+
 test "offsets - tokenToLoc" {
     try testTokenToLoc("foo", 0, 0, 3);
     try testTokenToLoc("foo\n", 0, 0, 3);
@@ -155,6 +173,16 @@ fn testIndexPosition(text: []const u8, index: usize, line: u32, characters: [3]u
     try std.testing.expectEqual(position8, offsets.indexToPosition(text, index, .@"utf-8"));
     try std.testing.expectEqual(position16, offsets.indexToPosition(text, index, .@"utf-16"));
     try std.testing.expectEqual(position32, offsets.indexToPosition(text, index, .@"utf-32"));
+
+    try std.testing.expectEqual(index, offsets.positionToIndex(text, position8, .@"utf-8"));
+    try std.testing.expectEqual(index, offsets.positionToIndex(text, position16, .@"utf-16"));
+    try std.testing.expectEqual(index, offsets.positionToIndex(text, position32, .@"utf-32"));
+}
+
+fn testPositionToIndex(text: []const u8, index: usize, line: u32, characters: [3]u32) !void {
+    const position8: types.Position = .{ .line = line, .character = characters[0] };
+    const position16: types.Position = .{ .line = line, .character = characters[1] };
+    const position32: types.Position = .{ .line = line, .character = characters[2] };
 
     try std.testing.expectEqual(index, offsets.positionToIndex(text, position8, .@"utf-8"));
     try std.testing.expectEqual(index, offsets.positionToIndex(text, position16, .@"utf-16"));


### PR DESCRIPTION
The LSP specification says the following about the `character` field of `Position`:
> If the character value is greater than the line length it defaults back to the line length.