### PR TITLE
move global error/enum completions to `completions.zig`

### DIFF
--- a/src/DocumentScope.zig
+++ b/src/DocumentScope.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
 const ast = @import("ast.zig");
 const Ast = std.zig.Ast;
-const types = @import("lsp.zig");
 const tracy = @import("tracy.zig");
 const offsets = @import("offsets.zig");
 const Analyser = @import("analysis.zig");
@@ -14,31 +13,36 @@ declarations: std.MultiArrayList(Declaration) = .{},
 /// used for looking up a child declaration in a given scope
 declaration_lookup_map: DeclarationLookupMap = .{},
 extra: std.ArrayListUnmanaged(u32) = .{},
-// TODO: make this lighter;
-// error completions: just store the name, the logic has no other moving parts
-// enum completions: same, but determine whether to store docs somewhere or fetch them on-demand (on-demand likely better)
-error_completions: CompletionSet = .{},
-enum_completions: CompletionSet = .{},
+/// All identifier token that are in error sets.
+/// When there are multiple error sets that contain the same error, only one of them is stored.
+/// A token that has a doc comment takes priority.
+/// This means that if there a multiple error sets with the same name, only one of them is included.
+global_error_set: IdentifierSet = .{},
+/// All identifier token that are in enums.
+/// When there are multiple enums that contain the field name, only one of them is stored.
+/// A token that has a doc comment takes priority.
+/// This means that if there a multiple enums with the same name, only one of them is included.
+global_enum_set: IdentifierSet = .{},
 
-const CompletionContext = struct {
-    pub fn hash(self: @This(), item: types.CompletionItem) u32 {
-        _ = self;
-        return @truncate(std.hash.Wyhash.hash(0, item.label));
+/// Stores a set of identifier tokens with unique names
+pub const IdentifierSet = std.ArrayHashMapUnmanaged(Ast.TokenIndex, void, IdentifierTokenContext, true);
+
+pub const IdentifierTokenContext = struct {
+    tree: Ast,
+
+    pub fn eql(self: @This(), a: Ast.TokenIndex, b: Ast.TokenIndex, b_index: usize) bool {
+        _ = b_index;
+        if (a == b) return true;
+        const a_name = offsets.identifierTokenToNameSlice(self.tree, a);
+        const b_name = offsets.identifierTokenToNameSlice(self.tree, b);
+        return std.mem.eql(u8, a_name, b_name);
     }
 
-    pub fn eql(self: @This(), a: types.CompletionItem, b: types.CompletionItem, b_index: usize) bool {
-        _ = self;
-        _ = b_index;
-        return std.mem.eql(u8, a.label, b.label);
+    pub fn hash(self: @This(), token: Ast.TokenIndex) u32 {
+        const name = offsets.identifierTokenToNameSlice(self.tree, token);
+        return std.array_hash_map.hashString(name);
     }
 };
-
-pub const CompletionSet = std.ArrayHashMapUnmanaged(
-    types.CompletionItem,
-    void,
-    CompletionContext,
-    false,
-);
 
 /// Every `index` inside this `ArrayhashMap` is equivalent to a `Declaration.Index`
 /// This means that every declaration is only the child of a single scope
@@ -351,23 +355,8 @@ pub fn deinit(scope: *DocumentScope, allocator: std.mem.Allocator) void {
     scope.declaration_lookup_map.deinit(allocator);
     scope.extra.deinit(allocator);
 
-    for (scope.enum_completions.keys()) |item| {
-        if (item.detail) |detail| allocator.free(detail);
-        switch (item.documentation orelse continue) {
-            .string => |str| allocator.free(str),
-            .MarkupContent => |content| allocator.free(content.value),
-        }
-    }
-    scope.enum_completions.deinit(allocator);
-
-    for (scope.error_completions.keys()) |item| {
-        if (item.detail) |detail| allocator.free(detail);
-        switch (item.documentation orelse continue) {
-            .string => |str| allocator.free(str),
-            .MarkupContent => |content| allocator.free(content.value),
-        }
-    }
-    scope.error_completions.deinit(allocator);
+    scope.global_enum_set.deinit(allocator);
+    scope.global_error_set.deinit(allocator);
 }
 
 fn locToSmallLoc(loc: offsets.Loc) Scope.SmallLoc {
@@ -665,28 +654,27 @@ noinline fn walkContainerDecl(
                     continue;
                 }
 
-                if (token_tags[main_tokens[decl]] != .identifier) {
+                const main_token = main_tokens[decl];
+                if (token_tags[main_token] != .identifier) {
                     // TODO this code path should not be reachable
                     continue;
                 }
-                const name = offsets.identifierTokenToNameSlice(tree, main_tokens[decl]);
+                const name = offsets.identifierTokenToNameSlice(tree, main_token);
                 try scope.pushDeclaration(name, .{ .ast_node = decl }, .field);
 
                 if (is_enum_or_tagged_union) {
                     if (std.mem.eql(u8, name, "_")) continue;
 
-                    const doc = try Analyser.getDocComments(allocator, tree, decl);
-                    errdefer if (doc) |d| allocator.free(d);
-                    // TODO: Fix allocation; just store indices
-                    const gop_res = try context.doc_scope.enum_completions.getOrPut(allocator, .{
-                        .label = name,
-                        .kind = .EnumMember,
-                        .insertText = name,
-                        .insertTextFormat = .PlainText,
-                        .documentation = if (doc) |d| .{ .MarkupContent = types.MarkupContent{ .kind = .markdown, .value = d } } else null,
-                    });
-                    if (gop_res.found_existing) {
-                        if (doc) |d| allocator.free(d);
+                    const gop = try context.doc_scope.global_enum_set.getOrPutContext(
+                        context.allocator,
+                        main_token,
+                        IdentifierTokenContext{ .tree = tree },
+                    );
+                    if (!gop.found_existing) {
+                        gop.key_ptr.* = main_token;
+                    } else if (gop.found_existing and token_tags[main_token - 1] == .doc_comment) {
+                        // a token with a doc comment takes priority.
+                        gop.key_ptr.* = main_token;
                     }
                 }
             },
@@ -754,16 +742,16 @@ noinline fn walkErrorSetNode(
             .identifier => {
                 const name = offsets.identifierTokenToNameSlice(tree, tok_i);
                 try scope.pushDeclaration(name, .{ .error_token = tok_i }, .other);
-                const gop = try context.doc_scope.error_completions.getOrPut(context.allocator, .{
-                    .label = name,
-                    .kind = .Constant,
-                    //.detail =
-                    .insertText = name,
-                    .insertTextFormat = .PlainText,
-                });
-                // TODO: use arena
+                const gop = try context.doc_scope.global_error_set.getOrPutContext(
+                    context.allocator,
+                    tok_i,
+                    IdentifierTokenContext{ .tree = tree },
+                );
                 if (!gop.found_existing) {
-                    gop.key_ptr.detail = try std.fmt.allocPrint(context.allocator, "error.{s}", .{name});
+                    gop.key_ptr.* = tok_i;
+                } else if (gop.found_existing and token_tags[tok_i - 1] == .doc_comment) {
+                    // a token with a doc comment takes priority.
+                    gop.key_ptr.* = tok_i;
                 }
             },
             else => {},

--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -934,6 +934,44 @@ test "completion - enum" {
     });
 }
 
+test "completion - global enum set" {
+    try testCompletion(
+        \\const SomeError = error{ e };
+        \\const E1 = enum {
+        \\    foo,
+        \\    bar,
+        \\};
+        \\const E2 = enum {
+        \\    baz,
+        \\    ///hello
+        \\    qux,
+        \\};
+        \\const baz = .<cursor>
+    , &.{
+        .{ .label = "foo", .kind = .EnumMember },
+        .{ .label = "bar", .kind = .EnumMember },
+        .{ .label = "baz", .kind = .EnumMember },
+        .{ .label = "qux", .kind = .EnumMember, .documentation = "hello" },
+    });
+    try testCompletion(
+        \\const SomeError = error{ e };
+        \\const Enum1 = enum {
+        \\    ///hello world
+        \\    foo,
+        \\    bar,
+        \\};
+        \\const Enum2 = enum {
+        \\    foo,
+        \\    ///hallo welt
+        \\    bar,
+        \\};
+        \\const baz = .<cursor>
+    , &.{
+        .{ .label = "foo", .kind = .EnumMember, .documentation = "hello world" },
+        .{ .label = "bar", .kind = .EnumMember, .documentation = "hallo welt" },
+    });
+}
+
 test "completion - switch cases" {
     // Because current logic is to list all enums if all else fails,
     // the following tests include an extra enum to ensure that we're not just 'getting lucky'
@@ -1059,17 +1097,6 @@ test "completion - switch cases" {
 test "completion - error set" {
     try testCompletion(
         \\const E = error {
-        \\    Foo,
-        \\    Bar,
-        \\};
-        \\const baz = error.<cursor>
-    , &.{
-        .{ .label = "Foo", .kind = .Constant, .detail = "error.Foo" },
-        .{ .label = "Bar", .kind = .Constant, .detail = "error.Bar" },
-    });
-
-    try testCompletion(
-        \\const E = error {
         \\    foo,
         \\    bar,
         \\};
@@ -1077,6 +1104,68 @@ test "completion - error set" {
     , &.{
         .{ .label = "foo", .kind = .Constant, .detail = "error.foo" },
         .{ .label = "bar", .kind = .Constant, .detail = "error.bar" },
+    });
+    try testCompletion(
+        \\const E1 = error {
+        \\    foo,
+        \\    bar,
+        \\};
+        \\const E2 = error {
+        \\    baz,
+        \\    ///hello
+        \\    qux,
+        \\};
+        \\const baz = E2.<cursor>
+    , &.{
+        .{ .label = "baz", .kind = .Constant, .detail = "error.baz" },
+        .{ .label = "qux", .kind = .Constant, .detail = "error.qux", .documentation = "hello" },
+    });
+}
+
+test "completion - global error set" {
+    try testCompletion(
+        \\const SomeEnum = enum { e };
+        \\const Error1 = error {
+        \\    foo,
+        \\    bar,
+        \\};
+        \\const Error2 = error {
+        \\    baz,
+        \\    ///hello
+        \\    qux,
+        \\};
+        \\const baz = error.<cursor>
+    , &.{
+        .{ .label = "foo", .kind = .Constant, .detail = "error.foo" },
+        .{ .label = "bar", .kind = .Constant, .detail = "error.bar" },
+        .{ .label = "baz", .kind = .Constant, .detail = "error.baz" },
+        .{ .label = "qux", .kind = .Constant, .detail = "error.qux", .documentation = "hello" },
+    });
+    try testCompletion(
+        \\const SomeEnum = enum { e };
+        \\const Error1 = error {
+        \\    ///hello world
+        \\    foo,
+        \\    bar,
+        \\};
+        \\const Error2 = error {
+        \\    foo,
+        \\    ///hallo welt
+        \\    bar,
+        \\};
+        \\const baz = error.<cursor>
+    , &.{
+        .{ .label = "foo", .kind = .Constant, .detail = "error.foo", .documentation = "hello world" },
+        .{ .label = "bar", .kind = .Constant, .detail = "error.bar", .documentation = "hallo welt" },
+    });
+    try testCompletion(
+        \\const Error = error {
+        \\    ///hello world
+        \\    @"some name",
+        \\};
+        \\const baz = error.<cursor>
+    , &.{
+        .{ .label = "some name", .kind = .Constant, .detail = "error.@\"some name\"", .documentation = "hello world" },
     });
 }
 


### PR DESCRIPTION
This removes dependency on any LSP types from the DocumentScope and DocumentStore.
Behavior is unchanged except that global error set completions were not showing doc comments.