### PR TITLE
Added option to truncate completion label details to improve visibilty in some editors.

### DIFF
--- a/src/Config.zig
+++ b/src/Config.zig
@@ -95,4 +95,7 @@ build_runner_global_cache_path: ?[]const u8 = null,
 /// Completions confirm behavior. If 'true', replace the text after the cursor
 completions_with_replace: bool = true,
 
+/// When false, function signature in completion results will be truncated. Sublime Text default is false to prevent obstruction of the return type.
+completion_label_details: bool = true,
+
 // DO NOT EDIT

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -376,6 +376,7 @@ fn initializeHandler(server: *Server, _: std.mem.Allocator, request: types.Initi
         log.info("client is '{s}-{s}'", .{ clientInfo.name, clientInfo.version orelse "<no version>" });
 
         if (std.mem.eql(u8, clientInfo.name, "Sublime Text LSP")) blk: {
+            server.config.completion_label_details = false;
             server.client_capabilities.max_detail_length = 256;
             // TODO investigate why fixall doesn't work in sublime text
             server.client_capabilities.supports_code_action_fixall = false;


### PR DESCRIPTION
`self` check isn't ideal but it will work for most methods and fallback to `(...)` which is still true.

![image](https://github.com/zigtools/zls/assets/14058796/c0e032d9-5175-4c3a-bd6d-a83506774d56)
