### PR TITLE
Added config setting to toggle display of function definition in label details

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The following options are currently available.
 | `global_cache_path` | `?[]const u8` | `null` | Path to a directory that will be used as zig's cache. null is equivalent to `${KnownFolders.Cache}/zls` |
 | `build_runner_global_cache_path` | `?[]const u8` | `null` | Path to a directory that will be used as the global cache path when executing a projects build.zig. null is equivalent to the path shown by `zig env` |
 | `completions_with_replace` | `bool` | `true` | Completions confirm behavior. If 'true', replace the text after the cursor |
+| `completion_label_details` | `bool` | `true` | When false, the function signature of completion results is hidden. Improves readability in some editors |
 <!-- DO NOT EDIT -->
 
 ### Per-build Configuration Options

--- a/schema.json
+++ b/schema.json
@@ -148,6 +148,11 @@
             "description": "Completions confirm behavior. If 'true', replace the text after the cursor",
             "type": "boolean",
             "default": true
+        },
+        "completion_label_details": {
+            "description": "When false, the function signature of completion results is hidden. Improves readability in some editors",
+            "type": "boolean",
+            "default": true
         }
     }
 }

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -92,4 +92,7 @@ build_runner_global_cache_path: ?[]const u8 = null,
 /// Completions confirm behavior. If 'true', replace the text after the cursor
 completions_with_replace: bool = true,
 
+/// When false, the function signature of completion results is hidden. Improves readability in some editors
+completion_label_details: bool = true,
+
 // DO NOT EDIT

--- a/src/config_gen/config.json
+++ b/src/config_gen/config.json
@@ -172,6 +172,12 @@
             "description": "Completions confirm behavior. If 'true', replace the text after the cursor",
             "type": "bool",
             "default": true
+        },
+        {
+            "name": "completion_label_details",
+            "description": "When false, the function signature of completion results is hidden. Improves readability in some editors",
+            "type": "bool",
+            "default": true
         }
     ]
 }

--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -2367,7 +2367,7 @@ fn testCompletionWithOptions(source: []const u8, expected_completions: []const C
             return error.InvalidCompletionDetail;
         }
 
-        if (expected_completion.labelDetails) |expected_label_details| blk: {
+        if (expected_completion.labelDetails) |expected_label_details| {
             const actual_label_details = actual_completion.labelDetails orelse {
                 try error_builder.msgAtIndex("expected label details on completion item '{s}'!", test_uri, cursor_idx, .err, .{label});
                 return error.InvalidCompletionLabelDetails;
@@ -2375,17 +2375,26 @@ fn testCompletionWithOptions(source: []const u8, expected_completions: []const C
             const detail_ok = (expected_label_details.detail == null and actual_label_details.detail == null) or
                 (expected_label_details.detail != null and actual_label_details.detail != null and std.mem.eql(u8, expected_label_details.detail.?, actual_label_details.detail.?));
 
+            if (!detail_ok) {
+                try error_builder.msgAtIndex("completion item '{s}' should have label detail '{?s}' but was '{?s}'!", test_uri, cursor_idx, .err, .{
+                    label,
+                    expected_label_details.detail,
+                    actual_label_details.detail,
+                });
+                return error.InvalidCompletionLabelDetails;
+            }
+
             const description_ok = (expected_label_details.description == null and actual_label_details.description == null) or
                 (expected_label_details.description != null and actual_label_details.description != null and std.mem.eql(u8, expected_label_details.description.?, actual_label_details.description.?));
 
-            if (detail_ok and description_ok) break :blk;
-
-            try error_builder.msgAtIndex("completion item '{s}' should have label detail '{}' but was '{}'!", test_uri, cursor_idx, .err, .{
-                label,
-                expected_label_details,
-                actual_label_details,
-            });
-            return error.InvalidCompletionLabelDetails;
+            if (!description_ok) {
+                try error_builder.msgAtIndex("completion item '{s}' should have label detail description '{?s}' but was '{?s}'!", test_uri, cursor_idx, .err, .{
+                    label,
+                    expected_label_details.description,
+                    actual_label_details.description,
+                });
+                return error.InvalidCompletionLabelDetails;
+            }
         }
 
         blk: {


### PR DESCRIPTION
Helps with visibility of return types in some editors (sublime, vscode). `self` check is not ideal but it will work for the vast majority of methods and fallback to `(...)`.

![image](https://github.com/zigtools/zls/assets/14058796/0d8a2a46-4b45-42d3-a58f-32f2e5bfe53a)
