### PR TITLE
remove `enable_ast_check_diagnostics`

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ The following options are currently available.
 | --- | --- | --- | --- |
 | `enable_snippets` | `bool` | `true` | Enables snippet completions when the client also supports them |
 | `enable_argument_placeholders` | `bool` | `true` | Whether to enable function argument placeholder completions |
-| `enable_ast_check_diagnostics` | `bool` | `true` | Whether to enable ast-check diagnostics |
 | `enable_build_on_save` | `bool` | `false` | Whether to enable build-on-save diagnostics |
 | `build_on_save_step` | `[]const u8` | `"install"` | Select which step should be executed on build-on-save |
 | `enable_autofix` | `bool` | `false` | Whether to automatically fix errors on save. Currently supports adding and removing discards. |
@@ -74,7 +73,7 @@ The following options are currently available.
 | `highlight_global_var_declarations` | `bool` | `false` | Whether to highlight global var declarations |
 | `dangerous_comptime_experiments_do_not_enable` | `bool` | `false` | Whether to use the comptime interpreter |
 | `skip_std_references` | `bool` | `false` | When true, skips searching for references in std. Improves lookup speed for functions in user's code. Renaming and go-to-definition will continue to work as is |
-| `prefer_ast_check_as_child_process` | `bool` | `true` | Can be used in conjuction with `enable_ast_check_diagnostics` to favor using `zig ast-check` instead of ZLS's fork |
+| `prefer_ast_check_as_child_process` | `bool` | `true` | Favor using `zig ast-check` instead of ZLS's fork |
 | `record_session` | `bool` | `false` | When true, zls will record all request is receives and write in into `record_session_path`, so that they can replayed with `zls replay` |
 | `record_session_path` | `?[]const u8` | `null` | Output file path when `record_session` is set. The recommended file extension *.zlsreplay |
 | `replay_session_path` | `?[]const u8` | `null` | Used when calling `zls replay` for specifying the replay file. If no extra argument is given `record_session_path` is used as the default path. |

--- a/schema.json
+++ b/schema.json
@@ -14,11 +14,6 @@
             "type": "boolean",
             "default": true
         },
-        "enable_ast_check_diagnostics": {
-            "description": "Whether to enable ast-check diagnostics",
-            "type": "boolean",
-            "default": true
-        },
         "enable_build_on_save": {
             "description": "Whether to enable build-on-save diagnostics",
             "type": "boolean",
@@ -100,7 +95,7 @@
             "default": false
         },
         "prefer_ast_check_as_child_process": {
-            "description": "Can be used in conjuction with `enable_ast_check_diagnostics` to favor using `zig ast-check` instead of ZLS's fork",
+            "description": "Favor using `zig ast-check` instead of ZLS's fork",
             "type": "boolean",
             "default": true
         },

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -10,9 +10,6 @@ enable_snippets: bool = true,
 /// Whether to enable function argument placeholder completions
 enable_argument_placeholders: bool = true,
 
-/// Whether to enable ast-check diagnostics
-enable_ast_check_diagnostics: bool = true,
-
 /// Whether to enable build-on-save diagnostics
 enable_build_on_save: bool = false,
 
@@ -62,7 +59,7 @@ dangerous_comptime_experiments_do_not_enable: bool = false,
 /// When true, skips searching for references in std. Improves lookup speed for functions in user's code. Renaming and go-to-definition will continue to work as is
 skip_std_references: bool = false,
 
-/// Can be used in conjuction with `enable_ast_check_diagnostics` to favor using `zig ast-check` instead of ZLS's fork
+/// Favor using `zig ast-check` instead of ZLS's fork
 prefer_ast_check_as_child_process: bool = true,
 
 /// When true, zls will record all request is receives and write in into `record_session_path`, so that they can replayed with `zls replay`

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -327,7 +327,6 @@ fn getAutofixMode(server: *Server) enum {
 
 /// caller owns returned memory.
 fn autofix(server: *Server, arena: std.mem.Allocator, handle: *DocumentStore.Handle) error{OutOfMemory}!std.ArrayListUnmanaged(types.TextEdit) {
-    if (!server.config.enable_ast_check_diagnostics) return .{};
     if (handle.tree.errors.len != 0) return .{};
 
     var diagnostics = std.ArrayListUnmanaged(types.Diagnostic){};
@@ -912,9 +911,7 @@ pub fn updateConfiguration(server: *Server, new_config: configuration.Configurat
         server.showMessage(.Warning, "zig executable could not be found", .{});
     }
 
-    if (server.config.enable_ast_check_diagnostics and
-        server.config.prefer_ast_check_as_child_process)
-    {
+    if (server.config.prefer_ast_check_as_child_process) {
         if (!std.process.can_spawn) {
             log.info("'prefer_ast_check_as_child_process' is ignored because your OS can't spawn a child process", .{});
         } else if (server.status == .initialized and server.config.zig_exe_path == null) {
@@ -1467,7 +1464,7 @@ fn codeActionHandler(server: *Server, arena: std.mem.Allocator, request: types.C
 
     // as of right now, only ast-check errors may get a code action
     var diagnostics = std.ArrayListUnmanaged(types.Diagnostic){};
-    if (server.config.enable_ast_check_diagnostics and handle.tree.errors.len == 0) {
+    if (handle.tree.errors.len == 0) {
         try diagnostics_gen.getAstCheckDiagnostics(server, arena, handle, &diagnostics);
     }
 

--- a/src/config_gen/config.json
+++ b/src/config_gen/config.json
@@ -13,12 +13,6 @@
             "default": true
         },
         {
-            "name": "enable_ast_check_diagnostics",
-            "description": "Whether to enable ast-check diagnostics",
-            "type": "bool",
-            "default": true
-        },
-        {
             "name": "enable_build_on_save",
             "description": "Whether to enable build-on-save diagnostics",
             "type": "bool",
@@ -115,7 +109,7 @@
         },
         {
             "name": "prefer_ast_check_as_child_process",
-            "description": "Can be used in conjuction with `enable_ast_check_diagnostics` to favor using `zig ast-check` instead of ZLS's fork",
+            "description": "Favor using `zig ast-check` instead of ZLS's fork",
             "type": "bool",
             "default": true
         },

--- a/src/features/diagnostics.zig
+++ b/src/features/diagnostics.zig
@@ -41,7 +41,7 @@ pub fn generateDiagnostics(server: *Server, arena: std.mem.Allocator, handle: *D
         });
     }
 
-    if (server.config.enable_ast_check_diagnostics and tree.errors.len == 0) {
+    if (tree.errors.len == 0) {
         try getAstCheckDiagnostics(server, arena, handle, &diagnostics);
     }
 
@@ -368,7 +368,6 @@ pub fn getAstCheckDiagnostics(
     handle: *DocumentStore.Handle,
     diagnostics: *std.ArrayListUnmanaged(types.Diagnostic),
 ) error{OutOfMemory}!void {
-    std.debug.assert(server.config.enable_ast_check_diagnostics);
     std.debug.assert(handle.tree.errors.len == 0);
 
     if (server.config.prefer_ast_check_as_child_process and

--- a/tests/context.zig
+++ b/tests/context.zig
@@ -8,7 +8,6 @@ const Server = zls.Server;
 const types = zls.types;
 
 const default_config: Config = .{
-    .enable_ast_check_diagnostics = false,
     .semantic_tokens = .full,
     .enable_inlay_hints = true,
     .inlay_hints_exclude_single_argument = false,

--- a/tests/lsp_features/code_actions.zig
+++ b/tests/lsp_features/code_actions.zig
@@ -370,7 +370,6 @@ fn testAutofixOptions(before: []const u8, after: []const u8, want_zir: bool) !vo
     var ctx = try Context.init();
     defer ctx.deinit();
     ctx.server.config.enable_autofix = true;
-    ctx.server.config.enable_ast_check_diagnostics = true;
     ctx.server.config.prefer_ast_check_as_child_process = !want_zir;
 
     const uri = try ctx.addDocument(before);


### PR DESCRIPTION
Is there any reason why you wouldn't want to see errors from `zig ast-check`?