### PR TITLE
fix signature help when cursor is after the lparen of the function call

### DIFF
--- a/src/features/signature_help.zig
+++ b/src/features/signature_help.zig
@@ -69,7 +69,13 @@ pub fn getSignatureInfo(analyser: *Analyser, arena: std.mem.Allocator, handle: *
     //   to scan up to find a function or builtin call
     const first_token = tree.firstToken(innermost_block);
     // We start by finding the token that includes the current cursor position
-    const last_token = offsets.sourceIndexToTokenIndex(tree, absolute_index);
+    const last_token = blk: {
+        const last_token = offsets.sourceIndexToTokenIndex(tree, absolute_index);
+        switch (token_tags[last_token]) {
+            .l_brace, .l_paren, .l_bracket => break :blk last_token,
+            else => break :blk last_token - 1,
+        }
+    };
 
     // We scan the tokens from last to first, adding and removing open and close
     //   delimiter tokens to a stack, while keeping track of commas corresponding

--- a/tests/lsp_features/signature_help.zig
+++ b/tests/lsp_features/signature_help.zig
@@ -24,7 +24,27 @@ test "signature help - simple" {
     , "fn foo(a: u32, b: u32) void", 0);
     try testSignatureHelp(
         \\fn foo(a: u32, b: u32) void {
+        \\    foo(<cursor>,0)
+        \\}
+    , "fn foo(a: u32, b: u32) void", 0);
+    try testSignatureHelp(
+        \\fn foo(a: u32, b: u32) void {
         \\    foo(0,<cursor>)
+        \\}
+    , "fn foo(a: u32, b: u32) void", 1);
+    try testSignatureHelp(
+        \\fn foo(a: u32, b: u32) void {
+        \\    foo(0,<cursor>55)
+        \\}
+    , "fn foo(a: u32, b: u32) void", 1);
+    try testSignatureHelp(
+        \\fn foo(a: u32, b: u32) void {
+        \\    foo(0,5<cursor>5)
+        \\}
+    , "fn foo(a: u32, b: u32) void", 1);
+    try testSignatureHelp(
+        \\fn foo(a: u32, b: u32) void {
+        \\    foo(0,55<cursor>)
         \\}
     , "fn foo(a: u32, b: u32) void", 1);
 }
@@ -37,12 +57,32 @@ test "signature help - syntax error resistance" {
     , "fn foo(a: u32, b: u32) void", 0);
     try testSignatureHelp(
         \\fn foo(a: u32, b: u32) void {
+        \\    foo(5<cursor>
+        \\}
+    , "fn foo(a: u32, b: u32) void", 0);
+    try testSignatureHelp(
+        \\fn foo(a: u32, b: u32) void {
+        \\    foo(5<cursor>5
+        \\}
+    , "fn foo(a: u32, b: u32) void", 0);
+    try testSignatureHelp(
+        \\fn foo(a: u32, b: u32) void {
+        \\    foo(<cursor>55
+        \\}
+    , "fn foo(a: u32, b: u32) void", 0);
+    try testSignatureHelp(
+        \\fn foo(a: u32, b: u32) void {
         \\    foo(<cursor>;
         \\}
     , "fn foo(a: u32, b: u32) void", 0);
     try testSignatureHelp(
         \\fn foo(a: u32, b: u32) void {
-        \\    foo(<cursor>);
+        \\    foo(<cursor>,
+        \\}
+    , "fn foo(a: u32, b: u32) void", 0);
+    try testSignatureHelp(
+        \\fn foo(a: u32, b: u32) void {
+        \\    foo(<cursor>,;
         \\}
     , "fn foo(a: u32, b: u32) void", 0);
 }
@@ -204,7 +244,7 @@ fn testSignatureHelp(source: []const u8, expected_label: []const u8, expected_ac
     var ctx = try Context.init();
     defer ctx.deinit();
 
-    const test_uri = try ctx.addDocument(source);
+    const test_uri = try ctx.addDocument(text);
 
     const params = types.SignatureHelpParams{
         .textDocument = .{ .uri = test_uri },


### PR DESCRIPTION
This fixes a bug that was introduced in 756492b1d3ae8e3cec808bc34eb95c10b2589cef and went undetected because the signature help tests were testing on the wrong source code.

fixes #1717