### PR TITLE
completions: add result type based completions for builtin arguments

### DIFF
--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -1425,6 +1425,13 @@ fn resolveBuiltinFnArg(
             }
         }
 
+        if (std.mem.eql(u8, name, "@branchHint")) {
+            switch (arg_index) {
+                0 => break :name "BranchHint",
+                else => return null,
+            }
+        }
+
         return null;
     };
 

--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -1126,72 +1126,115 @@ fn getSwitchOrStructInitContext(
     find_identifier: while (upper_index > 0) : (upper_index -= 1) {
         switch (token_tags[upper_index]) {
             .r_brace => braces_depth += 1,
-            .l_brace => braces_depth -= 1,
-            .period => if (braces_depth == one_opening and token_tags[upper_index + 1] == .l_brace) { // anon struct init `.{.`
-                // if the preceding token is `=`, then this might be a `var foo: Foo = .{.`
-                if (upper_index > 1 and token_tags[upper_index - 1] == .equal) {
-                    upper_index -= 2; // eat `= .`
-                    break :find_identifier;
-                }
-                // We never return from this branch/condition to the `find_identifier: while ..` loop, so reset and reuse these
-                fn_arg_index = 0;
-                braces_depth = even; // not actually looking for/expecting an uneven number of braces, just making use of the helpful const
-                parens_depth = even;
-                while (upper_index > 0) : (upper_index -= 1) {
-                    switch (token_tags[upper_index]) {
-                        .r_brace => braces_depth += 1,
-                        .l_brace => braces_depth -= 1,
-                        .r_paren => parens_depth += 1,
-                        .l_paren => {
-                            parens_depth -= 1;
-                            if (parens_depth == one_opening and token_tags[upper_index - 1] == .identifier) {
-                                upper_index -= 1;
-                                break :find_identifier;
+            .l_brace => {
+                braces_depth -= 1;
+                if (braces_depth != one_opening) continue;
+                upper_index -= 1;
+                switch (token_tags[upper_index]) {
+                    // `S{.`
+                    .identifier => break :find_identifier,
+                    // anon struct init `.{.`
+                    .period => {
+                        if (upper_index < 3) return null;
+                        upper_index -= 1;
+                        if (token_tags[upper_index] == .ampersand) upper_index -= 1; // `&.{.`
+                        if (token_tags[upper_index] == .equal) { // `= .{.`
+                            upper_index -= 1; // eat the `=`
+                            switch (token_tags[upper_index]) {
+                                .identifier, // `const s: S = .{.`, `S{.name = .`
+                                .period_asterisk, //  `s.* = .{.`
+                                => break :find_identifier,
+                                else => return null,
                             }
-                        },
-                        .comma => if (braces_depth == even and parens_depth == even) { // those only matter when outside of braces and before final '('
-                            fn_arg_index += 1;
-                        },
-                        .semicolon => return null, // generic exit; maybe also .keyword_(var/const)
-                        else => {},
-                    }
+                        }
+                        // We never return from this branch/condition to the `find_identifier: while ..` loop, so reset and reuse these
+                        fn_arg_index = 0;
+                        braces_depth = even; // not actually looking for/expecting an uneven number of braces, just making use of the helpful const
+                        parens_depth = even;
+                        while (upper_index > 0) : (upper_index -= 1) {
+                            switch (token_tags[upper_index]) {
+                                .r_brace => braces_depth += 1,
+                                .l_brace => {
+                                    braces_depth -= 1;
+                                    if (braces_depth == one_opening) return null;
+                                },
+                                .r_paren => parens_depth += 1,
+                                .l_paren => {
+                                    parens_depth -= 1;
+                                    if (parens_depth == one_opening and switch (token_tags[upper_index - 1]) {
+                                        .identifier,
+                                        .builtin,
+                                        => true,
+                                        else => false,
+                                    }) {
+                                        upper_index -= 1;
+                                        break :find_identifier;
+                                    }
+                                },
+                                .comma => if (braces_depth == even and parens_depth == even) { // those only matter when outside of braces and before final '('
+                                    fn_arg_index += 1;
+                                },
+                                .semicolon => return null, // generic exit; maybe also .keyword_(var/const)
+                                else => {},
+                            }
+                        }
+                        return null;
+                    },
+                    // The opening brace is preceded by a r_paren => evaluate
+                    .r_paren => {
+                        need_ret_type = true;
+                        var token_index = upper_index - 1; // if `switch` we need the last token of the condition
+                        parens_depth = even;
+                        // Walk backwards counting parens until one_opening then check the preceding token's tag
+                        while (token_index > 0) : (token_index -= 1) {
+                            switch (token_tags[token_index]) {
+                                .r_paren => parens_depth += 1,
+                                .l_paren => {
+                                    parens_depth -= 1;
+                                    if (parens_depth == one_opening)
+                                        switch (token_tags[token_index - 1]) {
+                                            .keyword_switch => {
+                                                likely = .switch_case;
+                                                upper_index -= 1; // eat the switch's .r_paren
+                                                break :find_identifier;
+                                            },
+                                            .identifier,
+                                            // .builtin, // `@f(){.`
+                                            => {
+                                                upper_index = token_index - 1; // the fn name
+                                                break :find_identifier;
+                                            },
+                                            else => return null,
+                                        };
+                                },
+                                .semicolon => return null,
+                                else => {},
+                            }
+                        }
+                    },
+                    else => return null,
                 }
-                break :find_identifier;
             },
             // We're fishing for a `f(some, other{}, .<cursor>enum)`
-            .r_paren => {
-                parens_depth += 1;
-                if (braces_depth == one_opening) { // The opening brace is preceded by a r_paren => evaluate
-                    need_ret_type = true;
-                    var token_index = upper_index - 1; // if `switch` we need the last token of the condition
-                    parens_depth = even;
-                    // Walk backwards counting parens until one_opening then check the preceding token's tag
-                    while (token_index > 0) : (token_index -= 1) {
-                        switch (token_tags[token_index]) {
-                            .r_paren => parens_depth += 1,
-                            .l_paren => {
-                                parens_depth -= 1;
-                                if (parens_depth == one_opening)
-                                    switch (token_tags[token_index - 1]) {
-                                        .keyword_switch => {
-                                            likely = .switch_case;
-                                            upper_index -= 1; // eat the switch's .r_paren
-                                            break :find_identifier;
-                                        },
-                                        .identifier => {
-                                            upper_index = token_index - 1; // the fn name
-                                            break :find_identifier;
-                                        },
-                                        else => return null,
-                                    };
-                            },
-                            .semicolon => return null,
-                            else => {},
-                        }
-                    }
+            .r_paren => parens_depth += 1,
+            .l_paren => {
+                parens_depth -= 1;
+                if (parens_depth != one_opening) continue;
+                if (braces_depth != even) return null;
+                upper_index -= 1;
+                switch (token_tags[upper_index]) {
+                    // `f(.`
+                    .identifier,
+                    .builtin,
+                    .keyword_addrspace,
+                    .keyword_callconv,
+                    => {
+                        likely = .enum_arg;
+                        break :find_identifier;
+                    },
+                    else => return null,
                 }
             },
-            .l_paren => parens_depth -= 1,
             .comma => if (braces_depth == even and parens_depth == even) { // those only matter when outside of braces and before final '('
                 fn_arg_index += 1;
             },
@@ -1283,9 +1326,126 @@ fn collectContainerNodes(
         .var_access => |loc| try collectVarAccessContainerNodes(builder, handle, loc, dot_context, &types_with_handles),
         .field_access => |loc| try collectFieldAccessContainerNodes(builder, handle, loc, dot_context, &types_with_handles),
         .enum_literal => |loc| try collectEnumLiteralContainerNodes(builder, handle, loc, &types_with_handles),
+        .builtin => |loc| try collectBuiltinContainerNodes(builder, handle, loc, dot_context, &types_with_handles),
+        .keyword => |tag| try collectKeywordFnContainerNodes(builder, tag, dot_context, &types_with_handles),
         else => {},
     }
     return types_with_handles.toOwnedSlice(builder.arena);
+}
+
+fn resolveBuiltinFnArg(
+    analyser: *Analyser,
+    arg_index: usize,
+    /// Includes leading `@`
+    name: []const u8,
+) std.mem.Allocator.Error!?Analyser.Type {
+    const builtin_name: []const u8 = name: {
+        if (std.mem.eql(u8, name, "@Type")) {
+            switch (arg_index) {
+                0 => break :name "Type",
+                else => return null,
+            }
+        }
+
+        if (std.mem.eql(u8, name, "@setFloatMode")) {
+            switch (arg_index) {
+                0 => break :name "FloatMode",
+                else => return null,
+            }
+        }
+
+        if (std.mem.eql(u8, name, "@prefetch")) {
+            switch (arg_index) {
+                1 => break :name "PrefetchOptions",
+                else => return null,
+            }
+        }
+
+        if (std.mem.eql(u8, name, "@reduce")) {
+            switch (arg_index) {
+                0 => break :name "ReduceOp",
+                else => return null,
+            }
+        }
+
+        if (std.mem.eql(u8, name, "@export")) {
+            switch (arg_index) {
+                1 => break :name "ExportOptions",
+                else => return null,
+            }
+        }
+
+        if (std.mem.eql(u8, name, "@extern")) {
+            switch (arg_index) {
+                1 => break :name "ExternOptions",
+                else => return null,
+            }
+        }
+
+        if (std.mem.eql(u8, name, "@fence")) {
+            switch (arg_index) {
+                0 => break :name "AtomicOrder",
+                else => return null,
+            }
+        }
+
+        if (std.mem.eql(u8, name, "@cmpxchgWeak") or std.mem.eql(u8, name, "@cmpxchgStrong")) {
+            switch (arg_index) {
+                4, 5 => break :name "AtomicOrder",
+                else => return null,
+            }
+        }
+
+        if (std.mem.eql(u8, name, "@atomicLoad")) {
+            switch (arg_index) {
+                2 => break :name "AtomicOrder",
+                else => return null,
+            }
+        }
+
+        if (std.mem.eql(u8, name, "@atomicStore")) {
+            switch (arg_index) {
+                3 => break :name "AtomicOrder",
+                else => return null,
+            }
+        }
+
+        if (std.mem.eql(u8, name, "@atomicRmw")) {
+            switch (arg_index) {
+                2 => break :name "AtomicRmwOp",
+                4 => break :name "AtomicOrder",
+                else => return null,
+            }
+        }
+
+        if (std.mem.eql(u8, name, "@call")) {
+            switch (arg_index) {
+                0 => break :name "CallModifier",
+                else => return null,
+            }
+        }
+
+        return null;
+    };
+
+    return analyser.instanceStdBuiltinType(builtin_name);
+}
+
+fn collectBuiltinContainerNodes(
+    builder: *Builder,
+    handle: *DocumentStore.Handle,
+    loc: offsets.Loc,
+    dot_context: EnumLiteralContext,
+    types_with_handles: *std.ArrayListUnmanaged(Analyser.Type),
+) error{OutOfMemory}!void {
+    if (dot_context.need_ret_type) return;
+    if (try resolveBuiltinFnArg(
+        builder.analyser,
+        dot_context.fn_arg_index,
+        handle.tree.source[loc.start..loc.end],
+    )) |ty| {
+        try types_with_handles.append(builder.arena, ty);
+    }
 }
 
 fn collectVarAccessContainerNodes(
@@ -1434,4 +1594,27 @@ fn collectEnumLiteralContainerNodes(
         if (try analyser.resolveOptionalUnwrap(member_type)) |unwrapped| member_type = unwrapped;
         try types_with_handles.append(arena, member_type);
     }
+}
+
+fn collectKeywordFnContainerNodes(
+    builder: *Builder,
+    tag: std.zig.Token.Tag,
+    dot_context: EnumLiteralContext,
+    types_with_handles: *std.ArrayListUnmanaged(Analyser.Type),
+) error{OutOfMemory}!void {
+    const builtin_type_name: []const u8 = name: {
+        switch (tag) {
+            .keyword_addrspace => switch (dot_context.fn_arg_index) {
+                0 => break :name "AddressSpace",
+                else => return,
+            },
+            .keyword_callconv => switch (dot_context.fn_arg_index) {
+                0 => break :name "CallingConvention",
+                else => return,
+            },
+            else => return,
+        }
+    };
+    const ty = try builder.analyser.instanceStdBuiltinType(builtin_type_name) orelse return;
+    try types_with_handles.append(builder.arena, ty);
 }

--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -2478,6 +2478,9 @@ test "builtin fn `field`" {
     , &.{
         .{ .label = "peripherals", .kind = .Struct, .detail = "type" },
     });
+}
+
+test "completion - builtin fns return type" {
     try testCompletion(
         \\pub const chip_mod = struct {
         \\    pub const devices = struct {
@@ -2511,6 +2514,211 @@ test "builtin fn `field`" {
         \\}
     , &.{
         .{ .label = "peripherals", .kind = .Struct, .detail = "type" },
+    });
+    try testCompletion(
+        \\test {
+        \\    const src = @src();
+        \\    src.<cursor>
+        \\}
+    , &.{
+        .{ .label = "module", .kind = .Field, .detail = "[:0]const u8" },
+        .{ .label = "file", .kind = .Field, .detail = "[:0]const u8" },
+        .{ .label = "fn_name", .kind = .Field, .detail = "[:0]const u8" },
+        .{ .label = "line", .kind = .Field, .detail = "u32" },
+        .{ .label = "column", .kind = .Field, .detail = "u32" },
+    });
+    try testCompletion(
+        \\test {
+        \\    const ti = @typeInfo().<cursor>;
+        \\}
+    , &.{
+        .{ .label = "type", .kind = .Field, .detail = "void" },
+        .{ .label = "void", .kind = .Field, .detail = "void" },
+        .{ .label = "bool", .kind = .Field, .detail = "void" },
+        .{ .label = "noreturn", .kind = .Field, .detail = "void" },
+        .{ .label = "int", .kind = .Struct, .detail = "Int" },
+        .{ .label = "float", .kind = .Struct, .detail = "Float" },
+        .{ .label = "pointer", .kind = .Struct, .detail = "Pointer" },
+        .{ .label = "array", .kind = .Struct, .detail = "Array" },
+        .{ .label = "@\"struct\"", .kind = .Struct, .detail = "Struct" },
+        .{ .label = "comptime_float", .kind = .Field, .detail = "void" },
+        .{ .label = "comptime_int", .kind = .Field, .detail = "void" },
+        .{ .label = "undefined", .kind = .Field, .detail = "void" },
+        .{ .label = "null", .kind = .Field, .detail = "void" },
+        .{ .label = "optional", .kind = .Struct, .detail = "Optional" },
+        .{ .label = "error_union", .kind = .Struct, .detail = "ErrorUnion" },
+        .{ .label = "error_set", .kind = .Field, .detail = "?[]const Error" },
+        .{ .label = "@\"enum\"", .kind = .Struct, .detail = "Enum" },
+        .{ .label = "@\"union\"", .kind = .Struct, .detail = "Union" },
+        .{ .label = "@\"fn\"", .kind = .Struct, .detail = "Fn" },
+        .{ .label = "@\"opaque\"", .kind = .Struct, .detail = "Opaque" },
+        .{ .label = "frame", .kind = .Struct, .detail = "Frame" },
+        .{ .label = "@\"anyframe\"", .kind = .Struct, .detail = "AnyFrame" },
+        .{ .label = "vector", .kind = .Struct, .detail = "Vector" },
+        .{ .label = "enum_literal", .kind = .Field, .detail = "void" },
+    });
+}
+
+test "completion - builtin fns taking an enum arg" {
+    try testCompletion(
+        \\test {
+        \\    @Type(.{.<cursor>
+        \\}
+    , &.{
+        .{ .label = "type", .kind = .Field, .detail = "void" },
+        .{ .label = "void", .kind = .Field, .detail = "void" },
+        .{ .label = "bool", .kind = .Field, .detail = "void" },
+        .{ .label = "noreturn", .kind = .Field, .detail = "void" },
+        .{ .label = "int", .kind = .Field, .detail = "Int" },
+        .{ .label = "float", .kind = .Field, .detail = "Float" },
+        .{ .label = "pointer", .kind = .Field, .detail = "Pointer" },
+        .{ .label = "array", .kind = .Field, .detail = "Array" },
+        .{ .label = "@\"struct\"", .kind = .Field, .detail = "Struct" },
+        .{ .label = "comptime_float", .kind = .Field, .detail = "void" },
+        .{ .label = "comptime_int", .kind = .Field, .detail = "void" },
+        .{ .label = "undefined", .kind = .Field, .detail = "void" },
+        .{ .label = "null", .kind = .Field, .detail = "void" },
+        .{ .label = "optional", .kind = .Field, .detail = "Optional" },
+        .{ .label = "error_union", .kind = .Field, .detail = "ErrorUnion" },
+        .{ .label = "error_set", .kind = .Field, .detail = "ErrorSet" },
+        .{ .label = "@\"enum\"", .kind = .Field, .detail = "Enum" },
+        .{ .label = "@\"union\"", .kind = .Field, .detail = "Union" },
+        .{ .label = "@\"fn\"", .kind = .Field, .detail = "Fn" },
+        .{ .label = "@\"opaque\"", .kind = .Field, .detail = "Opaque" },
+        .{ .label = "frame", .kind = .Field, .detail = "Frame" },
+        .{ .label = "@\"anyframe\"", .kind = .Field, .detail = "AnyFrame" },
+        .{ .label = "vector", .kind = .Field, .detail = "Vector" },
+        .{ .label = "enum_literal", .kind = .Field, .detail = "void" },
+    });
+    try testCompletion(
+        \\test {
+        \\    @Type(.{.Struct = .{.<cursor>
+        \\}
+    , &.{
+        .{ .label = "layout", .kind = .Field, .detail = "ContainerLayout" },
+        .{ .label = "backing_integer", .kind = .Field, .detail = "?type = null" },
+        .{ .label = "fields", .kind = .Field, .detail = "[]const StructField" },
+        .{ .label = "decls", .kind = .Field, .detail = "[]const Declaration" },
+        .{ .label = "is_tuple", .kind = .Field, .detail = "bool" },
+    });
+    try testCompletion(
+        \\test {
+        \\    @setFloatMode(.<cursor>)
+        \\}
+    , &.{
+        .{ .label = "strict", .kind = .EnumMember, .detail = "strict" },
+        .{ .label = "optimized", .kind = .EnumMember, .detail = "optimized" },
+    });
+    try testCompletion(
+        \\test {
+        \\    @prefetch(, .{.<cursor>})
+        \\}
+    , &.{
+        .{ .label = "rw", .kind = .Field, .detail = "Rw = .read" },
+        .{ .label = "locality", .kind = .Field, .detail = "u2 = 3" },
+        .{ .label = "cache", .kind = .Field, .detail = "Cache = .data" },
+    });
+    try testCompletion(
+        \\test {
+        \\    @reduce(.<cursor>
+        \\}
+    , &.{
+        .{ .label = "And", .kind = .EnumMember, .detail = "And" },
+        .{ .label = "Or", .kind = .EnumMember, .detail = "Or" },
+        .{ .label = "Xor", .kind = .EnumMember, .detail = "Xor" },
+        .{ .label = "Min", .kind = .EnumMember, .detail = "Min" },
+        .{ .label = "Max", .kind = .EnumMember, .detail = "Max" },
+        .{ .label = "Add", .kind = .EnumMember, .detail = "Add" },
+        .{ .label = "Mul", .kind = .EnumMember, .detail = "Mul" },
+    });
+    try testCompletionTextEdit(.{
+        .source = "comptime { @export(foo ,.<cursor>",
+        .label = "name",
+        .expected_insert_line = "comptime { @export(foo ,.{ .name = ",
+        .expected_replace_line = "comptime { @export(foo ,.{ .name = ",
+        .enable_snippets = false,
+    });
+    try testCompletionTextEdit(.{
+        .source = "test { @extern(T , .<cursor>",
+        .label = "is_thread_local",
+        .expected_insert_line = "test { @extern(T , .{ .is_thread_local = ",
+        .expected_replace_line = "test { @extern(T , .{ .is_thread_local = ",
+        .enable_snippets = false,
+    });
+    try testCompletionTextEdit(.{
+        .source = "test { @fence(.<cursor>",
+        .label = "acq_rel",
+        .expected_insert_line = "test { @fence(.acq_rel",
+        .expected_replace_line = "test { @fence(.acq_rel",
+        .enable_snippets = false,
+    });
+    try testCompletionTextEdit(.{
+        .source = "test { @cmpxchgWeak(1,2,3,4, .<cursor>",
+        .label = "acq_rel",
+        .expected_insert_line = "test { @cmpxchgWeak(1,2,3,4, .acq_rel",
+        .expected_replace_line = "test { @cmpxchgWeak(1,2,3,4, .acq_rel",
+        .enable_snippets = false,
+    });
+    try testCompletionTextEdit(.{
+        .source = "test { @cmpxchgStrong(1,2,3,4,5,.<cursor>",
+        .label = "acq_rel",
+        .expected_insert_line = "test { @cmpxchgStrong(1,2,3,4,5,.acq_rel",
+        .expected_replace_line = "test { @cmpxchgStrong(1,2,3,4,5,.acq_rel",
+        .enable_snippets = false,
+    });
+    try testCompletionTextEdit(.{
+        .source = "test { @atomicLoad(1,2,.<cursor>",
+        .label = "acq_rel",
+        .expected_insert_line = "test { @atomicLoad(1,2,.acq_rel",
+        .expected_replace_line = "test { @atomicLoad(1,2,.acq_rel",
+        .enable_snippets = false,
+    });
+    try testCompletionTextEdit(.{
+        .source = "test { @atomicStore(1,2,3,.<cursor>",
+        .label = "acq_rel",
+        .expected_insert_line = "test { @atomicStore(1,2,3,.acq_rel",
+        .expected_replace_line = "test { @atomicStore(1,2,3,.acq_rel",
+        .enable_snippets = false,
+    });
+    try testCompletionTextEdit(.{
+        .source = "test { @atomicRmw(1,2,.<cursor>",
+        .label = "Add",
+        .expected_insert_line = "test { @atomicRmw(1,2,.Add",
+        .expected_replace_line = "test { @atomicRmw(1,2,.Add",
+        .enable_snippets = false,
+    });
+    try testCompletionTextEdit(.{
+        .source = "test { @atomicRmw(1,2,3,4,.<cursor>",
+        .label = "acq_rel",
+        .expected_insert_line = "test { @atomicRmw(1,2,3,4,.acq_rel",
+        .expected_replace_line = "test { @atomicRmw(1,2,3,4,.acq_rel",
+        .enable_snippets = false,
+    });
+    try testCompletion(
+        \\test {
+        \\    @call(.<cursor>
+        \\}
+    , &.{
+        .{ .label = "auto", .kind = .EnumMember, .detail = "auto" },
+        .{ .label = "async_kw", .kind = .EnumMember, .detail = "async_kw" },
+        .{ .label = "never_tail", .kind = .EnumMember, .detail = "never_tail" },
+        .{ .label = "never_inline", .kind = .EnumMember, .detail = "never_inline" },
+        .{ .label = "no_async", .kind = .EnumMember, .detail = "no_async" },
+        .{ .label = "always_tail", .kind = .EnumMember, .detail = "always_tail" },
+        .{ .label = "always_inline", .kind = .EnumMember, .detail = "always_inline" },
+        .{ .label = "compile_time", .kind = .EnumMember, .detail = "compile_time" },
+    });
+    try testCompletionTextEdit(.{
+        .source = "var a: u16 addrspace(.<cursor>",
+        .label = "constant",
+        .expected_insert_line = "var a: u16 addrspace(.constant",
+        .expected_replace_line = "var a: u16 addrspace(.constant",
+    });
+    try testCompletionTextEdit(.{
+        .source = "fn foo() callconv(.<cursor>",
+        .label = "AAPCS",
+        .expected_insert_line = "fn foo() callconv(.AAPCS",
+        .expected_replace_line = "fn foo() callconv(.AAPCS",
     });
 }
 


### PR DESCRIPTION
When writing arguments to builtins like `@Type`, even when using inferred initialization syntax (i.e. `@Type(.{ .`), completions are now provided. This case is detected in exactly the same way as the corresponding case for a normal function argument.

This logic has been implemented for the following builtins, since they use a non-trivial type from `std.builtin`:
* `@Type`
* `@typeInfo`
* `@src`
* `@setFloatMode`
* `@prefetch`
* `@reduce`
* `@export`
* `@extern`
* `@fence`
* `@cmpxchg*`
* `@atomic*`