### PR TITLE
update tracy to 0.10.0

### DIFF
--- a/src/tracy.zig
+++ b/src/tracy.zig
@@ -88,15 +88,12 @@ pub const Ctx = if (enable) ___tracy_c_zone_context else struct {
 pub inline fn trace(comptime src: std.builtin.SourceLocation) Ctx {
     if (!enable) return .{};
 
-    // TODO: the below `.line = 1,` should be `.line = src.line`, this is blocked by
-    //       https://github.com/ziglang/zig/issues/13315
-
     if (enable_callstack) {
         return ___tracy_emit_zone_begin_callstack(&.{
             .name = null,
             .function = src.fn_name.ptr,
             .file = src.file.ptr,
-            .line = 1,
+            .line = src.line,
             .color = 0,
         }, callstack_depth, 1);
     } else {
@@ -104,7 +101,7 @@ pub inline fn trace(comptime src: std.builtin.SourceLocation) Ctx {
             .name = null,
             .function = src.fn_name.ptr,
             .file = src.file.ptr,
-            .line = 1,
+            .line = src.line,
             .color = 0,
         }, 1);
     }
@@ -113,15 +110,12 @@ pub inline fn trace(comptime src: std.builtin.SourceLocation) Ctx {
 pub inline fn traceNamed(comptime src: std.builtin.SourceLocation, comptime name: [:0]const u8) Ctx {
     if (!enable) return .{};
 
-    // TODO: the below `.line = 1,` should be `.line = src.line`, this is blocked by
-    //       https://github.com/ziglang/zig/issues/13315
-
     if (enable_callstack) {
         return ___tracy_emit_zone_begin_callstack(&.{
             .name = name.ptr,
             .function = src.fn_name.ptr,
             .file = src.file.ptr,
-            .line = 1,
+            .line = src.line,
             .color = 0,
         }, callstack_depth, 1);
     } else {
@@ -129,7 +123,7 @@ pub inline fn traceNamed(comptime src: std.builtin.SourceLocation, comptime name
             .name = name.ptr,
             .function = src.fn_name.ptr,
             .file = src.file.ptr,
-            .line = 1,
+            .line = src.line,
             .color = 0,
         }, 1);
     }


### PR DESCRIPTION
985e7069a24dd84200a9c65bd43eff7809e06519 is no longer necessary.