### PR TITLE
regenerate diagnostics when zig executable has changed

### DIFF
--- a/src/DocumentStore.zig
+++ b/src/DocumentStore.zig
@@ -359,6 +359,10 @@ pub const Handle = struct {
         return @bitCast(self.impl.status.load(.Acquire));
     }
 
+    pub fn isOpen(self: Handle) bool {
+        return self.getStatus().open;
+    }
+
     /// returns the previous value
     fn setOpen(self: *Handle, open: bool) bool {
         if (open) {

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -895,6 +895,13 @@ pub fn updateConfiguration(server: *Server, new_config: configuration.Configurat
     }
 
     if (server.status == .initialized) {
+        if (new_zig_exe_path and server.client_capabilities.supports_publish_diagnostics) {
+            for (server.document_store.handles.values()) |handle| {
+                if (!handle.isOpen()) continue;
+                try server.pushJob(.{ .generate_diagnostics = try server.allocator.dupe(u8, handle.uri) });
+            }
+        }
+
         const json_message = try server.sendToClientRequest(
             .{ .string = "semantic_tokens_refresh" },
             "workspace/semanticTokens/refresh",


### PR DESCRIPTION
The new zig may generate different diagnostics than the previous