### PR TITLE
resolve string literal and error value types using InternPool

### DIFF
--- a/src/analyser/completions.zig
+++ b/src/analyser/completions.zig
@@ -38,7 +38,7 @@ pub fn dotCompletions(
                         try completions.ensureUnusedCapacity(arena, names.len);
                         for (names) |name| {
                             completions.appendAssumeCapacity(.{
-                                .label = try std.fmt.allocPrint(arena, "{}", .{name.fmt(&ip.string_pool)}),
+                                .label = try std.fmt.allocPrint(arena, "{}", .{ip.fmtId(name)}),
                                 .kind = .Constant,
                                 .detail = try std.fmt.allocPrint(arena, "error.{}", .{ip.fmtId(name)}),
                             });

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -1749,10 +1749,68 @@ fn resolveTypeOfNodeUncached(analyser: *Analyser, node_handle: NodeWithHandle) e
         .negation,
         => return try Type.typeValFromIP(analyser, .bool_type),
 
-        .multiline_string_literal,
-        .string_literal,
-        .error_value, // TODO
-        => return Type{ .data = .{ .other = .{ .node = node, .handle = handle } }, .is_type_val = false },
+        .multiline_string_literal => {
+            const start = datas[node].lhs;
+            const end = datas[node].rhs;
+
+            var length: u64 = 0;
+
+            for (start..end + 1, 0..) |token_index, i| {
+                const slice = tree.tokenSlice(@intCast(token_index));
+                const carriage_return_ending: usize = if (slice[slice.len - 2] == '\r') 2 else 1;
+                length += slice.len - carriage_return_ending - 2 + @intFromBool(i != 0);
+            }
+
+            const string_literal_type = try analyser.ip.get(analyser.gpa, .{ .pointer_type = .{
+                .elem_type = try analyser.ip.get(analyser.gpa, .{ .array_type = .{
+                    .child = .u8_type,
+                    .len = length,
+                    .sentinel = .zero_u8,
+                } }),
+                .flags = .{
+                    .size = .One,
+                    .is_const = true,
+                },
+            } });
+            return try Type.typeValFromIP(analyser, string_literal_type);
+        },
+        .string_literal => {
+            const token_bytes = tree.tokenSlice(main_tokens[node]);
+
+            var counting_writer = std.io.countingWriter(std.io.null_writer);
+            const result = try std.zig.string_literal.parseWrite(counting_writer.writer(), token_bytes);
+            switch (result) {
+                .success => {},
+                .failure => return null,
+            }
+
+            const string_literal_type = try analyser.ip.get(analyser.gpa, .{ .pointer_type = .{
+                .elem_type = try analyser.ip.get(analyser.gpa, .{ .array_type = .{
+                    .child = .u8_type,
+                    .len = counting_writer.bytes_written,
+                    .sentinel = .zero_u8,
+                } }),
+                .flags = .{
+                    .size = .One,
+                    .is_const = true,
+                },
+            } });
+            return try Type.typeValFromIP(analyser, string_literal_type);
+        },
+        .error_value => {
+            const name = offsets.identifierTokenToNameSlice(tree, datas[node].rhs);
+            const name_index = try analyser.ip.string_pool.getOrPutString(analyser.gpa, name);
+
+            const error_set_type = try analyser.ip.get(analyser.gpa, .{ .error_set_type = .{
+                .owner_decl = .none,
+                .names = try analyser.ip.getStringSlice(analyser.gpa, &.{name_index}),
+            } });
+            const error_value = try analyser.ip.get(analyser.gpa, .{ .error_value = .{
+                .ty = error_set_type,
+                .error_tag_name = name_index,
+            } });
+            return Type{ .data = .{ .ip_index = .{ .index = error_value } }, .is_type_val = false };
+        },
 
         .char_literal => return try Type.typeValFromIP(analyser, .comptime_int_type),
 
@@ -4422,48 +4480,15 @@ fn addReferencedTypes(
                 });
             },
 
-            .multiline_string_literal => {
-                const node = node_handle.node;
-                const handle = node_handle.handle;
-                const tree = handle.tree;
+            .multiline_string_literal => unreachable,
 
-                const start = tree.nodes.items(.data)[node].lhs;
-                const end = tree.nodes.items(.data)[node].rhs;
-                var len: usize = end - start;
-                var tok_i = start;
-                while (tok_i <= end) : (tok_i += 1) {
-                    const slice = tree.tokenSlice(tok_i);
-                    len += slice.len - 3;
-                    if (slice[slice.len - 2] == '\r') len -= 1;
-                }
-                return try std.fmt.allocPrint(allocator, "*const [{d}:0]u8", .{len});
-            },
+            .string_literal => unreachable,
 
-            .string_literal => {
-                const node = node_handle.node;
-                const handle = node_handle.handle;
-                const tree = handle.tree;
+            .number_literal, .char_literal => unreachable,
 
-                const token = tree.tokenSlice(tree.nodes.items(.main_token)[node]);
-                var counter = std.io.countingWriter(std.io.null_writer);
-                return switch (try std.zig.string_literal.parseWrite(counter.writer(), token)) {
-                    .success => try std.fmt.allocPrint(allocator, "*const [{d}:0]u8", .{counter.bytes_written}),
-                    .failure => null,
-                };
-            },
+            .enum_literal => unreachable,
 
-            .number_literal, .char_literal => return "comptime_int",
-
-            .enum_literal => return "@TypeOf(.enum_literal)",
-
-            .error_value => {
-                const node = node_handle.node;
-                const handle = node_handle.handle;
-                const tree = handle.tree;
-
-                const identifier = offsets.identifierTokenToNameSlice(tree, tree.nodes.items(.data)[node].rhs);
-                return try std.fmt.allocPrint(allocator, "error{{{}}}", .{std.zig.fmtId(identifier)});
-            },
+            .error_value => unreachable,
 
             .identifier => {
                 const node = node_handle.node;

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -776,6 +776,16 @@ pub fn resolveDerefType(analyser: *Analyser, pointer: Type) error{OutOfMemory}!?
             .One, .C => return try info.elem_ty.instanceTypeVal(analyser),
             .Many, .Slice => return null,
         },
+        .ip_index => |payload| {
+            const ty = analyser.ip.typeOf(payload.index);
+            switch (analyser.ip.indexToKey(ty)) {
+                .pointer_type => |pointer_info| switch (pointer_info.flags.size) {
+                    .One, .C => return try Type.typeValFromIP(analyser, pointer_info.elem_type),
+                    .Many, .Slice => return null,
+                },
+                else => return null,
+            }
+        },
         else => return null,
     }
 }

--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -327,15 +327,7 @@ fn nodeToCompletion(
         .optional_type => unreachable,
         .multiline_string_literal,
         .string_literal,
-        => {
-            try list.append(arena, .{
-                .label = "len",
-                .detail = "const len: usize",
-                .kind = .Field,
-                .insertText = "len",
-                .insertTextFormat = .PlainText,
-            });
-        },
+        => unreachable,
         else => if (Analyser.nodeToString(tree, node)) |string| {
             try list.append(arena, .{
                 .label = string,

--- a/tests/lsp_features/hover.zig
+++ b/tests/lsp_features/hover.zig
@@ -81,10 +81,37 @@ test "hover - literal" {
         \\```
     );
     try testHover(
+        \\const f<cursor>oo = {};
+    ,
+        \\```zig
+        \\const foo = {}
+        \\```
+        \\```zig
+        \\(void)
+        \\```
+    );
+}
+
+test "hover - string literal" {
+    try testHover(
         \\const f<cursor>oo = "ipsum lorem";
     ,
         \\```zig
         \\const foo = "ipsum lorem"
+        \\```
+        \\```zig
+        \\(*const [11:0]u8)
+        \\```
+    );
+    try testHover(
+        \\const f<cursor>oo =
+        \\    \\ipsum lorem
+        \\;
+    ,
+        \\```zig
+        \\const foo =
+        \\    \\ipsum lorem
+        \\
         \\```
         \\```zig
         \\(*const [11:0]u8)
@@ -104,16 +131,6 @@ test "hover - literal" {
         \\```
         \\```zig
         \\(*const [26:0]u8)
-        \\```
-    );
-    try testHover(
-        \\const f<cursor>oo = {};
-    ,
-        \\```zig
-        \\const foo = {}
-        \\```
-        \\```zig
-        \\(void)
         \\```
     );
 }

--- a/tests/lsp_features/hover.zig
+++ b/tests/lsp_features/hover.zig
@@ -133,6 +133,16 @@ test "hover - string literal" {
         \\(*const [26:0]u8)
         \\```
     );
+    try testHover(
+        \\const f<cursor>oo = "hello".*;
+    ,
+        \\```zig
+        \\const foo = "hello".*
+        \\```
+        \\```zig
+        \\([5:0]u8)
+        \\```
+    );
 }
 
 test "hover - builtin" {


### PR DESCRIPTION
string literals and error values could previously be "stringified" but weren't fully resolved into ZLS's type representation. This change will resolve them into the InternPool which enables further analysis to be performed on these values.