### PR TITLE
make tracy a lazy dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "src/tracy"]
-	path = src/tracy
-	url = https://github.com/wolfpld/tracy

--- a/build.zig
+++ b/build.zig
@@ -310,6 +310,8 @@ fn getTracyModule(
     });
     tracy_module.addImport("options", tracy_options.createModule());
     if (!options.enable) return tracy_module;
+    const tracy_dependency = b.lazyDependency("tracy", .{}) orelse return tracy_module;
+
     tracy_module.link_libc = true;
     tracy_module.link_libcpp = true;
 
@@ -319,9 +321,9 @@ fn getTracyModule(
     else
         &[_][]const u8{ "-DTRACY_ENABLE=1", "-fno-sanitize=undefined" };
 
-    tracy_module.addIncludePath(b.path("src/tracy"));
+    tracy_module.addIncludePath(tracy_dependency.path(""));
     tracy_module.addCSourceFile(.{
-        .file = b.path("src/tracy/public/TracyClient.cpp"),
+        .file = tracy_dependency.path("public/TracyClient.cpp"),
         .flags = tracy_c_flags,
     });
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -23,6 +23,11 @@
             .url = "https://github.com/zigtools/zig-lsp-codegen/archive/6b34887189def7c859307f4a9fc436bc5f2f04c9.tar.gz",
             .hash = "122054fe123b819c1cca154f0f89dd799832a639d432287a2371499bcaf7b9dcb7a0",
         },
+        .tracy = .{
+            .url = "https://github.com/wolfpld/tracy/archive/refs/tags/v0.11.1.tar.gz",
+            .hash = "122022a478dccaed1309fb5d022f4041eec45d40c93a855ed24fad970774c2426d91",
+            .lazy = true,
+        },
     },
     .paths = .{""},
 }

--- a/deps.nix
+++ b/deps.nix
@@ -67,4 +67,12 @@ in linkFarm name [
       hash = "sha256-Q1Lm0YornfymWeryFdKe0AXsOJxhxHH72U1IcMxiVtA=";
     };
   }
+  {
+    name = "122022a478dccaed1309fb5d022f4041eec45d40c93a855ed24fad970774c2426d91";
+    path = fetchZigArtifact {
+      name = "tracy";
+      url = "https://github.com/wolfpld/tracy/archive/refs/tags/v0.11.1.tar.gz";
+      hash = "sha256-LBHKgW8rdWvicw+GsAkpIEGfPavHpxc4Kf/Yl9kYiKE=";
+    };
+  }
 ]


### PR DESCRIPTION
This allows us to completely get rid of git submodules.

There is just one unfortunate issue which is why I made this a separate Draft from #1741.
When using an old zig version like 0.11.0 you will get this unhelpful error when compiling ZLS.
```
warning: FileNotFound: /home/techatrix/.cache/zig/p/12202aac930cebaf2b57f443cacc2483478580a72f1316b4f0a720ddd91246fce69d/build.zig
error: FileNotFound
```
This is because 0.11.0 has no support for dependencies that do not have a `build.zig` like the tracy repo.
So we either lose our minimum build version check (and gain new issues reports because of it) or we use a tracy wrapper library that provides a `build.zig`. It would also be possible to wait for the Zig 0.12.0 release since it will become more unlikely that someones tries to compile ZLS with 0.11.0 after that.