### PR TITLE
improve type stringification logic

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
 const DocumentStore = @import("DocumentStore.zig");
 const Ast = std.zig.Ast;
-const types = @import("lsp.zig");
 const offsets = @import("offsets.zig");
 const URI = @import("uri.zig");
 const log = std.log.scoped(.zls_analysis);

--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -37,6 +37,7 @@ fn typeToCompletion(
                 try list.append(arena, .{
                     .label = "*",
                     .kind = .Operator,
+                    .detail = try std.fmt.allocPrint(arena, "{}", .{info.elem_ty.fmtTypeVal(analyser)}),
                     .insertText = "*",
                     .insertTextFormat = .PlainText,
                 });
@@ -55,9 +56,14 @@ fn typeToCompletion(
                     .insertText = "len",
                     .insertTextFormat = .PlainText,
                 });
+
+                var many_ptr_ty = ty;
+                many_ptr_ty.is_type_val = true;
+                many_ptr_ty.data.pointer.size = .Many;
                 try list.append(arena, .{
                     .label = "ptr",
                     .kind = .Field,
+                    .detail = try std.fmt.allocPrint(arena, "{}", .{many_ptr_ty.fmtTypeVal(analyser)}),
                     .insertText = "ptr",
                     .insertTextFormat = .PlainText,
                 });
@@ -77,11 +83,12 @@ fn typeToCompletion(
                 .insertTextFormat = .PlainText,
             });
         },
-        .optional => |_| {
+        .optional => |child_ty| {
             if (ty.is_type_val) return;
             try list.append(arena, .{
                 .label = "?",
                 .kind = .Operator,
+                .detail = try std.fmt.allocPrint(arena, "{}", .{child_ty.fmtTypeVal(analyser)}),
                 .insertText = "?",
                 .insertTextFormat = .PlainText,
             });

--- a/src/features/hover.zig
+++ b/src/features/hover.zig
@@ -114,9 +114,9 @@ fn hoverSymbolRecursive(
             try doc_strings.append(arena, doc);
         try analyser.referencedTypes(
             resolved_type,
-            &resolved_type_str,
             &reference_collector,
         );
+        resolved_type_str = try std.fmt.allocPrint(arena, "{}", .{resolved_type.fmt(analyser)});
     }
     const referenced_types: []const Analyser.ReferencedType = type_references.keys();
 

--- a/src/features/inlay_hints.zig
+++ b/src/features/inlay_hints.zig
@@ -236,20 +236,10 @@ fn reduceTypeWhitespace(str: []const u8, arena: std.mem.Allocator) ![]const u8 {
 fn typeStrOfNode(builder: *Builder, node: Ast.Node.Index) !?[]const u8 {
     const resolved_type = try builder.analyser.resolveTypeOfNode(.{ .handle = builder.handle, .node = node }) orelse return null;
 
-    var type_references = Analyser.ReferencedType.Set.init(builder.arena);
-    var reference_collector = Analyser.ReferencedType.Collector.init(&type_references);
-
-    var type_str: []const u8 = "";
-    try builder.analyser.referencedTypes(
-        resolved_type,
-        &type_str,
-        &reference_collector,
-    );
+    const type_str: []const u8 = try std.fmt.allocPrint(builder.arena, "{}", .{resolved_type.fmt(builder.analyser)});
     if (type_str.len == 0) return null;
 
-    type_str = try reduceTypeWhitespace(type_str, builder.arena);
-
-    return type_str;
+    return try reduceTypeWhitespace(type_str, builder.arena);
 }
 
 fn typeStrOfToken(builder: *Builder, token: Ast.TokenIndex) !?[]const u8 {
@@ -260,15 +250,7 @@ fn typeStrOfToken(builder: *Builder, token: Ast.TokenIndex) !?[]const u8 {
     ) orelse return null;
     const resolved_type = try things.resolveType(builder.analyser) orelse return null;
 
-    var type_references = Analyser.ReferencedType.Set.init(builder.arena);
-    var reference_collector = Analyser.ReferencedType.Collector.init(&type_references);
-
-    var type_str: []const u8 = "";
-    try builder.analyser.referencedTypes(
-        resolved_type,
-        &type_str,
-        &reference_collector,
-    );
+    const type_str: []const u8 = try std.fmt.allocPrint(builder.arena, "{}", .{resolved_type.fmt(builder.analyser)});
     if (type_str.len == 0) return null;
 
     return try reduceTypeWhitespace(type_str, builder.arena);

--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -273,8 +273,7 @@ test "completion - std.ArrayHashMap" {
         \\const foo = key.?.<cursor>
     , &.{
         .{ .label = "len", .kind = .Field, .detail = "usize" },
-        // TODO detail should be 'const ptr: [*]const u8'
-        .{ .label = "ptr", .kind = .Field },
+        .{ .label = "ptr", .kind = .Field, .detail = "[*]const u8" },
     });
     try testCompletion(
         \\const std = @import("std");
@@ -292,8 +291,7 @@ test "completion - std.ArrayHashMap" {
         \\const gop = try map.getOrPut(0);
         \\const foo = gop.value_ptr.<cursor>
     , &.{
-        // TODO detail should be 'u32'
-        .{ .label = "*", .kind = .Operator },
+        .{ .label = "*", .kind = .Operator, .detail = "S" },
         .{ .label = "alpha", .kind = .Field, .detail = "u32" },
     });
 }
@@ -307,8 +305,7 @@ test "completion - std.HashMap" {
         \\const foo = key.?.<cursor>
     , &.{
         .{ .label = "len", .kind = .Field, .detail = "usize" },
-        // TODO detail should be 'const ptr: [*]const u8'
-        .{ .label = "ptr", .kind = .Field },
+        .{ .label = "ptr", .kind = .Field, .detail = "[*]const u8" },
     });
     try testCompletion(
         \\const std = @import("std");
@@ -326,8 +323,7 @@ test "completion - std.HashMap" {
         \\const gop = try map.getOrPut(0);
         \\const foo = gop.value_ptr.<cursor>
     , &.{
-        // TODO detail should be 'u32'
-        .{ .label = "*", .kind = .Operator },
+        .{ .label = "*", .kind = .Operator, .detail = "S" },
         .{ .label = "alpha", .kind = .Field, .detail = "u32" },
     });
 }
@@ -387,8 +383,7 @@ test "completion - optional" {
         \\const foo: ?u32 = undefined;
         \\const bar = foo.<cursor>
     , &.{
-        // TODO detail should be 'u32'
-        .{ .label = "?", .kind = .Operator },
+        .{ .label = "?", .kind = .Operator, .detail = "u32" },
     });
 
     try testCompletion(
@@ -412,8 +407,7 @@ test "completion - pointer" {
         \\const foo: *u32 = undefined;
         \\const bar = foo.<cursor>
     , &.{
-        // TODO detail should be 'u32'
-        .{ .label = "*", .kind = .Operator },
+        .{ .label = "*", .kind = .Operator, .detail = "u32" },
     });
 
     try testCompletion(
@@ -429,8 +423,7 @@ test "completion - pointer" {
         \\const bar = foo.<cursor>
     , &.{
         .{ .label = "len", .kind = .Field, .detail = "usize" },
-        // TODO detail should be '[*]const u8'
-        .{ .label = "ptr", .kind = .Field },
+        .{ .label = "ptr", .kind = .Field, .detail = "[*]const u8" },
     });
 
     try testCompletion(
@@ -446,8 +439,7 @@ test "completion - pointer" {
         \\const foo: *S = undefined;
         \\const bar = foo.<cursor>
     , &.{
-        // TODO detail should be 'S'
-        .{ .label = "*", .kind = .Operator },
+        .{ .label = "*", .kind = .Operator, .detail = "S" },
         .{ .label = "alpha", .kind = .Field, .detail = "u32" },
     });
 
@@ -553,8 +545,7 @@ test "completion - single pointer to array" {
         \\const foo: *[3]u32 = undefined;
         \\const bar = foo.<cursor>
     , &.{
-        // TODO detail should be '[3]u32'
-        .{ .label = "*", .kind = .Operator },
+        .{ .label = "*", .kind = .Operator, .detail = "[3]u32" },
         .{ .label = "len", .kind = .Field, .detail = "usize = 3" },
     });
     try testCompletion(


### PR DESCRIPTION
I've moved the code that stringifies a type into a separate function. It was previously embedded into the `addReferencedTypes` function.

The following completions should now show the result type:
- `.ptr`
- `.?`
- `.*`