### PR TITLE
Fix fallback logic in `analysis.getPositionContext`

### DIFF
--- a/tests/utility/position_context.zig
+++ b/tests/utility/position_context.zig
@@ -11,366 +11,369 @@ test "position context - var access" {
     try testContext(
         \\const a_var =<cursor> identifier;
     ,
-        .empty,
-        null,
+        .{ .tag = .empty },
     );
     try testContext(
         \\const a_var = <cursor>identifier;
-    ,
-        .var_access,
-        "i",
-    );
+    , .{
+        .tag = .var_access,
+        .slice = "i",
+    });
     try testContext(
         \\const a_var = iden<cursor>tifier;
-    ,
-        .var_access,
-        "ident",
-    );
+    , .{
+        .tag = .var_access,
+        .slice = "ident",
+    });
     try testContext(
         \\const a_var = identifier<cursor>;
-    ,
-        .var_access,
-        "identifier",
-    );
+    , .{
+        .tag = .var_access,
+        .slice = "identifier",
+    });
     try testContext(
         \\const a_var = identifier;<cursor>
-    ,
-        .empty,
-        null,
-    );
+    , .{
+        .tag = .empty,
+    });
 
     try testContext(
         \\    fn foo() !<cursor>Str {
-    ,
-        .var_access,
-        "S",
-    );
+    , .{
+        .tag = .var_access,
+        .slice = "S",
+    });
     try testContext(
         \\    fn foo() !St<cursor>r {
-    ,
-        .var_access,
-        "Str",
-    );
+    , .{
+        .tag = .var_access,
+        .slice = "Str",
+    });
     try testContext(
         \\    fn foo() !Str<cursor> {
-    ,
-        .var_access,
-        "Str",
-    );
+    , .{
+        .tag = .var_access,
+        .slice = "Str",
+    });
     try testContext(
         \\    fn foo() !Str <cursor>{
-    ,
-        .var_access,
-        "Str",
-    );
+    , .{
+        .tag = .var_access,
+        .slice = "Str",
+    });
 
     try testContext(
         \\    fn foo() <cursor>Err!void {
-    ,
-        .var_access,
-        "E",
-    );
+    , .{
+        .tag = .var_access,
+        .slice = "E",
+    });
     try testContext(
         \\    fn foo() Er<cursor>r!void {
-    ,
-        .var_access,
-        "Err",
-    );
+    , .{
+        .tag = .var_access,
+        .slice = "Err",
+    });
     try testContext(
         \\    fn foo() Err<cursor>!void {
-    ,
-        .var_access,
-        "Err",
-    );
+    , .{
+        .tag = .var_access,
+        .slice = "Err",
+    });
     try testContext(
         \\    fn foo() Err!<cursor>void {
-    ,
-        .var_access,
-        "v",
-    );
+    , .{
+        .tag = .var_access,
+        .slice = "v",
+    });
 
     try testContext(
         \\if (<cursor>bar.field == foo) {
-    ,
-        .var_access,
-        "b",
-    );
+    , .{
+        .tag = .var_access,
+        .slice = "b",
+    });
     try testContext(
         \\if (ba<cursor>r.field == foo) {
-    ,
-        .var_access,
-        "bar",
-    );
+    , .{
+        .tag = .var_access,
+        .slice = "bar",
+    });
     try testContext(
         \\if (bar<cursor>.field == foo) {
-    ,
-        .var_access,
-        "bar",
-    );
+    , .{
+        .tag = .var_access,
+        .slice = "bar",
+    });
 
     try testContext(
         \\if (bar[0]<cursor>.field == foo) {
-    ,
-        .var_access,
-        "bar",
-    );
+    , .{
+        .tag = .var_access,
+        .slice = "bar",
+    });
 }
 
 test "position context - field access" {
     try testContext(
         \\if (bar.<cursor>field == foo) {
-    ,
-        .field_access,
-        "bar.f",
-    );
+    , .{
+        .tag = .field_access,
+        .slice = "bar.f",
+    });
     try testContext(
         \\if (bar.fie<cursor>ld == foo) {
-    ,
-        .field_access,
-        "bar.fiel",
-    );
+    , .{
+        .tag = .field_access,
+        .slice = "bar.fiel",
+    });
     try testContext(
         \\if (bar.field<cursor> == foo) {
-    ,
-        .field_access,
-        "bar.field",
-    );
+    , .{
+        .tag = .field_access,
+        .slice = "bar.field",
+    });
 
     try testContext(
         \\if (bar.member<cursor>.field == foo) {
-    ,
-        .field_access,
-        "bar.member",
-    );
+    , .{
+        .tag = .field_access,
+        .slice = "bar.member",
+    });
     try testContext(
         \\if (bar.member.<cursor>field == foo) {
-    ,
-        .field_access,
-        "bar.member.f",
-    );
+    , .{
+        .tag = .field_access,
+        .slice = "bar.member.f",
+    });
     try testContext(
         \\if (bar.member.fie<cursor>ld == foo) {
-    ,
-        .field_access,
-        "bar.member.fiel",
-    );
+    , .{
+        .tag = .field_access,
+        .slice = "bar.member.fiel",
+    });
     try testContext(
         \\if (bar.member.field<cursor> == foo) {
-    ,
-        .field_access,
-        "bar.member.field",
-    );
+    , .{
+        .tag = .field_access,
+        .slice = "bar.member.field",
+    });
 
     try testContext(
         \\if (bar.*.?<cursor>.field == foo) {
-    ,
-        .field_access,
-        "bar.*.?",
-    );
+    , .{
+        .tag = .field_access,
+        .slice = "bar.*.?",
+    });
     try testContext(
         \\if (bar.*.?.<cursor>field == foo) {
-    ,
-        .field_access,
-        "bar.*.?.f",
-    );
+    , .{
+        .tag = .field_access,
+        .slice = "bar.*.?.f",
+    });
 
     try testContext(
         \\if (bar[0].<cursor>field == foo) {
-    ,
-        .field_access,
-        "bar[0].f",
-    );
+    , .{
+        .tag = .field_access,
+        .slice = "bar[0].f",
+    });
 
     try testContext(
         \\if (bar.<cursor>@"field" == foo) {
-    ,
-        .field_access,
-        "bar.@\"",
-    );
+    , .{
+        .tag = .field_access,
+        .slice = "bar.@\"",
+    });
     try testContext(
         \\if (bar.@"fie<cursor>ld" == foo) {
-    ,
-        .field_access,
-        "bar.@\"fiel",
-    );
+    , .{
+        .tag = .field_access,
+        .slice = "bar.@\"fiel",
+    });
     try testContext(
         \\if (bar.@"field"<cursor> == foo) {
-    ,
-        .field_access,
-        "bar.@\"field\"",
-    );
+    , .{
+        .tag = .field_access,
+        .slice = "bar.@\"field\"",
+    });
 
     try testContext(
         \\const arr = std.ArrayList(SomeStruct(a, b, c, d)).<cursor>init(allocator);
-    ,
-        .field_access,
-        "std.ArrayList(SomeStruct(a, b, c, d)).i",
-    );
+    , .{
+        .tag = .field_access,
+        .slice = "std.ArrayList(SomeStruct(a, b, c, d)).i",
+    });
     try testContext(
         \\const arr = std.ArrayList(SomeStruct(a, b, c, d)).in<cursor>it(allocator);
-    ,
-        .field_access,
-        "std.ArrayList(SomeStruct(a, b, c, d)).ini",
-    );
+    , .{
+        .tag = .field_access,
+        .slice = "std.ArrayList(SomeStruct(a, b, c, d)).ini",
+    });
     try testContext(
         \\const arr = std.ArrayList(SomeStruct(a, b, c, d)).init<cursor>(allocator);
-    ,
-        .field_access,
-        "std.ArrayList(SomeStruct(a, b, c, d)).init",
-    );
+    , .{
+        .tag = .field_access,
+        .slice = "std.ArrayList(SomeStruct(a, b, c, d)).init",
+    });
 
     try testContext(
         \\fn foo() !Foo.<cursor>bar {
-    ,
-        .field_access,
-        "Foo.b",
-    );
+    , .{
+        .tag = .field_access,
+        .slice = "Foo.b",
+    });
     try testContext(
         \\fn foo() !Foo.ba<cursor>r {
-    ,
-        .field_access,
-        "Foo.bar",
-    );
+    , .{
+        .tag = .field_access,
+        .slice = "Foo.bar",
+    });
     try testContext(
         \\fn foo() !Foo.bar<cursor> {
-    ,
-        .field_access,
-        "Foo.bar",
-    );
+    , .{
+        .tag = .field_access,
+        .slice = "Foo.bar",
+    });
 
     try testContext(
         \\fn foo() Foo.<cursor>bar!void {
-    ,
-        .field_access,
-        "Foo.b",
-    );
+    , .{
+        .tag = .field_access,
+        .slice = "Foo.b",
+    });
     try testContext(
         \\fn foo() Foo.ba<cursor>r!void {
-    ,
-        .field_access,
-        "Foo.bar",
-    );
+    , .{
+        .tag = .field_access,
+        .slice = "Foo.bar",
+    });
     try testContext(
         \\fn foo() Foo.bar<cursor>!void {
-    ,
-        .field_access,
-        "Foo.bar",
-    );
+    , .{
+        .tag = .field_access,
+        .slice = "Foo.bar",
+    });
 }
 
 test "position context - builtin" {
     try testContext(
         \\var foo = <cursor>@
-    ,
-        .empty,
-        null,
-    );
+    , .{
+        .tag = .empty,
+    });
+    try testContext(
+        \\var foo = @<cursor>
+    , .{
+        .tag = .builtin,
+        .slice = "@",
+    });
     try testContext(
         \\var foo = <cursor>@intC(u32, 5);
-    ,
-        .builtin,
-        "@i",
-    );
+    , .{
+        .tag = .builtin,
+        .slice = "@i",
+    });
     try testContext(
         \\var foo = @<cursor>intC(u32, 5);
-    ,
-        .builtin,
-        "@i",
-    );
+    , .{
+        .tag = .builtin,
+        .slice = "@i",
+    });
     try testContext(
         \\var foo = @int<cursor>C(u32, 5);
-    ,
-        .builtin,
-        "@intC",
-    );
+    , .{
+        .tag = .builtin,
+        .slice = "@intC",
+    });
     try testContext(
         \\var foo = @intC<cursor>(u32, 5);
-    ,
-        .builtin,
-        "@intC",
-    );
+    , .{
+        .tag = .builtin,
+        .slice = "@intC",
+    });
 
     try testContext(
         \\fn foo() void { <cursor>@setRuntime(false); };
-    ,
-        .builtin,
-        "@s",
-    );
+    , .{
+        .tag = .builtin,
+        .slice = "@s",
+    });
     try testContext(
         \\fn foo() void { @<cursor>setRuntime(false); };
-    ,
-        .builtin,
-        "@s",
-    );
+    , .{
+        .tag = .builtin,
+        .slice = "@s",
+    });
     try testContext(
         \\fn foo() void { @set<cursor>Runtime(false); };
-    ,
-        .builtin,
-        "@setR",
-    );
+    , .{
+        .tag = .builtin,
+        .slice = "@setR",
+    });
     try testContext(
         \\fn foo() void { @setRuntime<cursor>(false); };
-    ,
-        .builtin,
-        "@setRuntime",
-    );
+    , .{
+        .tag = .builtin,
+        .slice = "@setRuntime",
+    });
 }
 
 test "position context - comment" {
     try testContext(
         \\// i am<cursor> a test
-    ,
-        .comment,
-        null, // report "// i am a test"
-    );
+    , .{
+        .tag = .comment,
+        .slice = null, // report "// i am a test"
+    });
     try testContext(
         \\/// i am<cursor> a test
-    ,
-        .comment,
-        null, // report /// i am a test
-    );
+    , .{
+        .tag = .comment,
+        .slice = null, // report /// i am a test
+    });
 }
 
 test "position context - import/embedfile string literal" {
     try testContext(
         \\const std = @import("s<cursor>t");
-    ,
-        .import_string_literal,
-        "\"st", // maybe report just "st"
-    );
+    , .{
+        .tag = .import_string_literal,
+        .slice = "\"st", // maybe report just "st"
+    });
     try testContext(
         \\const std = @import("st<cursor>");
-    ,
-        .import_string_literal,
-        "\"st", // maybe report just "st"
-    );
+    , .{
+        .tag = .import_string_literal,
+        .slice = "\"st", // maybe report just "st"
+    });
     try testContext(
         \\const std = @embedFile("file.<cursor>");
-    ,
-        .embedfile_string_literal,
-        "\"file.", // maybe report just "file."
-    );
+    , .{
+        .tag = .embedfile_string_literal,
+        .slice = "\"file.", // maybe report just "file."
+    });
     try testContext(
         \\const std = @embedFile("file<cursor>.");
-    ,
-        .embedfile_string_literal,
-        "\"file", // maybe report just "file."
-    );
+    , .{
+        .tag = .embedfile_string_literal,
+        .slice = "\"file", // maybe report just "file."
+    });
 }
 
 test "position context - string literal" {
     try testContext(
         \\var foo = "he<cursor>llo world!";
-    ,
-        .string_literal,
-        "\"hel", // maybe report just "he"
-    );
+    , .{
+        .tag = .string_literal,
+        .slice = "\"hel", // maybe report just "he"
+    });
     try testContext(
         \\var foo = \\hell<cursor>o;
-    ,
-        .string_literal,
-        "\\\\hello", // maybe report just "hello;"
-    );
+    , .{
+        .tag = .string_literal,
+        .slice = "\\\\hello", // maybe report just "hello;"
+    });
 }
 
 test "position context - global error set" {
@@ -383,28 +386,24 @@ test "position context - global error set" {
     // );
     try testContext(
         \\fn foo() erro<cursor>r!void {
-    ,
-        .global_error_set,
-        null,
-    );
+    , .{
+        .tag = .global_error_set,
+    });
     try testContext(
         \\fn foo() error<cursor>!void {
-    ,
-        .global_error_set,
-        null,
-    );
+    , .{
+        .tag = .global_error_set,
+    });
     try testContext(
         \\fn foo() error<cursor>.!void {
-    ,
-        .global_error_set,
-        null,
-    );
+    , .{
+        .tag = .global_error_set,
+    });
     try testContext(
         \\fn foo() error.<cursor>!void {
-    ,
-        .global_error_set,
-        null,
-    );
+    , .{
+        .tag = .global_error_set,
+    });
 
     // TODO this should probably also be .global_error_set
     // try testContext(
@@ -424,110 +423,120 @@ test "position context - global error set" {
 test "position context - enum literal" {
     try testContext(
         \\var foo = .<cursor>tag;
-    ,
-        .enum_literal,
-        ".t",
-    );
+    , .{
+        .tag = .enum_literal,
+        .slice = ".t",
+    });
     try testContext(
         \\var foo = .ta<cursor>g;
-    ,
-        .enum_literal,
-        ".tag",
-    );
+    , .{
+        .tag = .enum_literal,
+        .slice = ".tag",
+    });
     try testContext(
         \\var foo = .tag<cursor>;
-    ,
-        .enum_literal,
-        ".tag",
-    );
+    , .{
+        .tag = .enum_literal,
+        .slice = ".tag",
+    });
     try testContext(
         \\var foo = <cursor>.;
-    ,
-        .empty,
-        null,
-    );
+    , .{
+        .tag = .empty,
+    });
     try testContext(
         \\var foo = .<cursor>;
-    ,
-        .enum_literal,
-        ".",
-    );
+    , .{
+        .tag = .enum_literal,
+        .slice = ".",
+    });
 }
 
 test "position context - label" {
     try testContext(
         \\var foo = blk: { break <cursor>:blk null };
-    ,
-        .pre_label,
-        null,
-    );
+    , .{
+        .tag = .pre_label,
+    });
     try testContext(
         \\var foo = blk: { break :<cursor>blk null };
-    ,
-        .label,
-        null,
-    );
+    , .{
+        .tag = .label,
+    });
     try testContext(
         \\var foo = blk: { break :bl<cursor>k null };
-    ,
-        .label,
-        null,
-    );
+    , .{
+        .tag = .label,
+    });
     try testContext(
         \\var foo = blk: { break :blk<cursor> null };
-    ,
-        .label,
-        null,
-    );
+    , .{
+        .tag = .label,
+    });
 }
 
 test "position context - empty" {
     try testContext(
         \\<cursor>
-    ,
-        .empty,
-        null,
-    );
+    , .{
+        .tag = .empty,
+    });
     try testContext(
         \\try foo(arg, slice[<cursor>]);
-    ,
-        .empty,
-        null,
-    );
+    , .{
+        .tag = .empty,
+    });
     try testContext(
         \\try foo(arg, slice[<cursor>..3]);
-    ,
-        .empty,
-        null,
-    );
+    , .{
+        .tag = .empty,
+    });
     try testContext(
         \\try foo(arg, slice[0..<cursor>]);
-    ,
-        .empty,
-        null,
-    );
+    , .{
+        .tag = .empty,
+    });
 }
 
-fn testContext(line: []const u8, tag: std.meta.Tag(Analyser.PositionContext), maybe_range: ?[]const u8) !void {
+test "position context - last resort/fallback" {
+    try testContext(
+        \\    <cursor>@Type(.{.Struct = .{.}})
+    , .{
+        .look_ahead = false,
+        .tag = .builtin,
+        .slice = "@Type",
+    });
+}
+
+const Expected = struct {
+    look_ahead: bool = true,
+    tag: std.meta.Tag(Analyser.PositionContext),
+    slice: ?[]const u8 = null,
+};
+
+fn testContext(
+    line: []const u8,
+    expected: Expected,
+) !void {
     const cursor_idx = std.mem.indexOf(u8, line, "<cursor>").?;
     const final_line = try std.mem.concat(allocator, u8, &.{ line[0..cursor_idx], line[cursor_idx + "<cursor>".len ..] });
     defer allocator.free(final_line);
 
-    const ctx = try Analyser.getPositionContext(allocator, final_line, cursor_idx, true);
+    const ctx = try Analyser.getPositionContext(allocator, final_line, cursor_idx, expected.look_ahead);
 
-    if (std.meta.activeTag(ctx) != tag) {
-        std.debug.print("Expected tag `{s}`, got `{s}`\n", .{ @tagName(tag), @tagName(std.meta.activeTag(ctx)) });
+    if (std.meta.activeTag(ctx) != expected.tag) {
+        std.debug.print("Expected tag `{s}`, got `{s}`\n", .{ @tagName(expected.tag), @tagName(std.meta.activeTag(ctx)) });
         return error.DifferentTag;
     }
 
-    const actual_loc = ctx.loc() orelse if (maybe_range) |expected_range| {
+    const actual_loc = ctx.loc() orelse if (expected.slice) |expected_range| {
         std.debug.print("Expected `{s}`, got null range\n", .{
             expected_range,
         });
         return error.DifferentRange;
     } else return;
 
-    const expected_range = maybe_range orelse {
+    const expected_range = expected.slice orelse {
         std.debug.print("Expected null range, got `{s}`\n", .{
             final_line[actual_loc.start..actual_loc.end],
         });


### PR DESCRIPTION
Most lines are indented, ie `line[0] == ' '`(a space).

Tokenizing `line` as the sole buffer returns location offsets relative/within to that line, but are expected to be indexes within `handle.tree.source` .