### PR TITLE
completions: `.field_access`: Unwrap optional types if assigning, eg …

### DIFF
--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -1271,7 +1271,7 @@ fn collectFieldAccessContainerNodes(
         var node_type = try decl.resolveType(analyser) orelse continue;
         // Unwrap `identifier.opt_enum_field = .` or `identifier.opt_cont_field = .{.`
         if (dot_context.likely == .enum_assignment or dot_context.likely == .struct_field) {
-            if (try analyser.resolveOptionalChildType(node_type)) |unwrapped| node_type = unwrapped;
+            if (try analyser.resolveOptionalUnwrap(node_type)) |unwrapped| node_type = unwrapped;
         }
         if (node_type.isFunc()) {
             const fn_proto_node_handle = node_type.data.other; // this assumes that function types can only be Ast nodes

--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -1135,6 +1135,25 @@ test "completion - enum" {
         .{ .label = "sef1", .kind = .EnumMember },
         .{ .label = "sef2", .kind = .EnumMember },
     });
+    try testCompletion(
+        \\const Birdie = enum {
+        \\    canary,
+        \\};
+        \\const SomeEnum = enum {
+        \\    sef1,
+        \\    sef2,
+        \\};
+        \\const S = struct {
+        \\    se: ?SomeEnum = null,
+        \\};
+        \\test {
+        \\    const s = S{};
+        \\    s.se = .<cursor>
+        \\}
+    , &.{
+        .{ .label = "sef1", .kind = .EnumMember },
+        .{ .label = "sef2", .kind = .EnumMember },
+    });
 }
 
 test "completion - global enum set" {
@@ -1518,6 +1537,21 @@ test "completion - struct init" {
         \\const foo = S{ .gamma = .{.<cursor>};
     , &.{
         .{ .label = "gamma", .kind = .Field, .detail = "?S" },
+        .{ .label = "beta", .kind = .Field, .detail = "u32" },
+        .{ .label = "alpha", .kind = .Field, .detail = "*const S" },
+    });
+    try testCompletion(
+        \\const S = struct {
+        \\    alpha: *const S,
+        \\    beta: u32,
+        \\    gamma: ?S = null,
+        \\};
+        \\test {
+        \\    const foo: S = undefined;
+        \\    foo.gamma = .{.<cursor>}
+        \\}
+    , &.{
+        .{ .label = "gamma", .kind = .Field, .detail = "?S = null" },
         .{ .label = "beta", .kind = .Field, .detail = "u32" },
         .{ .label = "alpha", .kind = .Field, .detail = "*const S" },
     });


### PR DESCRIPTION
…`s.field_with_opt_type = .`