### PR TITLE
disable codecov github annotations

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,3 +6,5 @@ coverage:
     patch:
       default:
         informational: true
+github_checks:
+  annotations: false


### PR DESCRIPTION
We know that coverage is not perfect. Don't need the daily reminder...