### PR TITLE
set minimum build version to `0.12.0-dev.2679+54bbc73f8`

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -5,7 +5,7 @@ const zls_version = std.SemanticVersion{ .major = 0, .minor = 12, .patch = 0 };
 
 /// document the latest breaking change that caused a change to the string below:
 /// std: make options a struct instance instead of a namespace
-const min_zig_string = "0.12.0-dev.2701+d18f52197";
+const min_zig_string = "0.12.0-dev.2679+54bbc73f8";
 
 const Build = blk: {
     const current_zig = builtin.zig_version;


### PR DESCRIPTION
the minimum zig version in cb423ebb22b33758bbff95038228e67e8d72d3f3 was incorrect.