### PR TITLE
highlight symbols that call `@compileError` as deprecated

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -69,6 +69,10 @@ const ClientCapabilities = struct {
     hover_supports_md: bool = false,
     signature_help_supports_md: bool = false,
     completion_doc_supports_md: bool = false,
+    /// deprecated can be marked through the `CompletionItem.deprecated` field
+    supports_completion_deprecated_old: bool = false,
+    /// deprecated can be marked through the `CompletionItem.tags` field
+    supports_completion_deprecated_tag: bool = false,
     label_details_support: bool = false,
     supports_configuration: bool = false,
     supports_workspace_did_change_configuration_dynamic_registration: bool = false,
@@ -434,6 +438,18 @@ fn initializeHandler(server: *Server, _: std.mem.Allocator, request: types.Initi
             if (completion.completionItem) |completionItem| {
                 server.client_capabilities.label_details_support = completionItem.labelDetailsSupport orelse false;
                 server.client_capabilities.supports_snippets = completionItem.snippetSupport orelse false;
+                server.client_capabilities.supports_completion_deprecated_old = completionItem.deprecatedSupport orelse false;
+                if (completionItem.tagSupport) |tagSupport| {
+                    for (tagSupport.valueSet) |tag| {
+                        switch (tag) {
+                            .Deprecated => {
+                                server.client_capabilities.supports_completion_deprecated_tag = true;
+                                break;
+                            },
+                            .placeholder__ => {},
+                        }
+                    }
+                }
                 if (completionItem.documentationFormat) |documentation_format| {
                     for (documentation_format) |format| {
                         if (format == .plaintext) {

--- a/src/features/semantic_tokens.zig
+++ b/src/features/semantic_tokens.zig
@@ -262,7 +262,11 @@ fn colorIdentifierBasedOnType(
         };
         try writeTokenMod(builder, target_tok, if (has_self_param) .method else .function, new_tok_mod);
     } else {
-        try writeTokenMod(builder, target_tok, if (is_parameter) .parameter else .variable, tok_mod);
+        var new_tok_mod = tok_mod;
+        if (type_node.data == .compile_error) {
+            new_tok_mod.deprecated = true;
+        }
+        try writeTokenMod(builder, target_tok, if (is_parameter) .parameter else .variable, new_tok_mod);
     }
 }
 

--- a/tests/lsp_features/hover.zig
+++ b/tests/lsp_features/hover.zig
@@ -742,6 +742,19 @@ test "hover - top-level doc comment" {
     );
 }
 
+test "hover - deprecated" {
+    try testHover(
+        \\const f<cursor>oo = @compileError("some message");
+    ,
+        \\```zig
+        \\const foo = @compileError("some message")
+        \\```
+        \\```zig
+        \\(@compileError("some message"))
+        \\```
+    );
+}
+
 fn testHover(source: []const u8, expected: []const u8) !void {
     try testHoverWithOptions(source, expected, .{ .markup_kind = .markdown });
 }


### PR DESCRIPTION
![Screenshot from 2024-02-12 01-10-32](https://github.com/zigtools/zls/assets/19954306/1b9e4c85-ff72-406a-bbae-f20c9c3789b1)
