### PR TITLE
CI: ensure that tags are fetched so that `zls --version` works

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-tags: "true"
 
       - uses: goto-bus-stop/setup-zig@v2
         with:

--- a/.github/workflows/build_runner.yml
+++ b/.github/workflows/build_runner.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-tags: "true"
 
       - name: Grab zig
         uses: goto-bus-stop/setup-zig@v2

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -64,12 +64,14 @@ jobs:
         if: github.event_name != 'pull_request_target'
         uses: actions/checkout@v4
         with:
+          fetch-tags: "true"
           path: zls
 
       - name: Checkout zls (PR)
         if: github.event_name == 'pull_request_target'
         uses: actions/checkout@v4
         with:
+          fetch-tags: "true"
           path: zls
           ref: "refs/pull/${{ github.event.number }}/merge"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-tags: "true"
 
       - uses: goto-bus-stop/setup-zig@v2
         with:


### PR DESCRIPTION
The previous deployment just published ZLS 0.12.0