### PR TITLE
rework error union representation

### DIFF
--- a/src/DocumentScope.zig
+++ b/src/DocumentScope.zig
@@ -928,7 +928,7 @@ noinline fn walkCatchNode(
     try walkNode(context, tree, data[node_idx].lhs);
 
     const catch_token = main_tokens[node_idx] + 2;
-    if (token_tags.len > catch_token and
+    if (catch_token < tree.tokens.len and
         token_tags[catch_token - 1] == .pipe and
         token_tags[catch_token] == .identifier)
     {

--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -1329,7 +1329,7 @@ fn collectVarAccessContainerNodes(
             const has_body = fn_proto_handle.tree.nodes.items(.tag)[fn_proto_node] == .fn_decl;
             const body = fn_proto_handle.tree.nodes.items(.data)[fn_proto_node].rhs;
             var node_type = try analyser.resolveReturnType(full_fn_proto, fn_proto_handle, if (has_body) body else null) orelse return;
-            if (try analyser.resolveUnwrapErrorUnionType(node_type, .right)) |unwrapped| node_type = unwrapped;
+            if (try analyser.resolveUnwrapErrorUnionType(node_type, .payload)) |unwrapped| node_type = unwrapped;
             try node_type.getAllTypesWithHandlesArrayList(arena, types_with_handles);
             return;
         }
@@ -1360,7 +1360,7 @@ fn collectFieldAccessContainerNodes(
     const name_loc = Analyser.identifierLocFromPosition(loc.end, handle) orelse {
         const result = try analyser.getFieldAccessType(handle, loc.end, loc) orelse return;
         const container = try analyser.resolveDerefType(result) orelse result;
-        if (try analyser.resolveUnwrapErrorUnionType(container, .right)) |unwrapped| {
+        if (try analyser.resolveUnwrapErrorUnionType(container, .payload)) |unwrapped| {
             if (unwrapped.isEnumType() or unwrapped.isUnionType()) {
                 try types_with_handles.append(arena, unwrapped);
                 return;
@@ -1388,7 +1388,7 @@ fn collectFieldAccessContainerNodes(
                 const has_body = fn_proto_handle.tree.nodes.items(.tag)[fn_proto_node] == .fn_decl;
                 const body = fn_proto_handle.tree.nodes.items(.data)[fn_proto_node].rhs;
                 node_type = try analyser.resolveReturnType(full_fn_proto, fn_proto_handle, if (has_body) body else null) orelse continue;
-                if (try analyser.resolveUnwrapErrorUnionType(node_type, .right)) |unwrapped| node_type = unwrapped;
+                if (try analyser.resolveUnwrapErrorUnionType(node_type, .payload)) |unwrapped| node_type = unwrapped;
                 try node_type.getAllTypesWithHandlesArrayList(arena, types_with_handles);
                 continue;
             }

--- a/src/features/inlay_hints.zig
+++ b/src/features/inlay_hints.zig
@@ -360,6 +360,7 @@ fn writeNodeInlayHint(
 ) error{OutOfMemory}!void {
     const node_tags = tree.nodes.items(.tag);
     const main_tokens = tree.nodes.items(.main_token);
+    const token_tags = tree.tokens.items(.tag);
 
     const tag = node_tags[node];
 
@@ -425,6 +426,17 @@ fn writeNodeInlayHint(
             if (!builder.config.inlay_hints_show_variable_type_hints) return;
             const full_case = builder.handle.tree.fullSwitchCase(node).?;
             if (full_case.payload_token) |token| try inferAppendTypeStr(builder, token);
+        },
+        .@"catch" => {
+            if (!builder.config.inlay_hints_show_variable_type_hints) return;
+
+            const catch_token = main_tokens[node] + 2;
+            if (catch_token < tree.tokens.len and
+                token_tags[catch_token - 1] == .pipe and
+                token_tags[catch_token] == .identifier)
+            {
+                try inferAppendTypeStr(builder, catch_token);
+            }
         },
         .builtin_call_two,
         .builtin_call_two_comma,

--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -1560,6 +1560,17 @@ test "completion - error union" {
         .{ .label = "alpha", .kind = .Field, .detail = "u32" },
     });
 
+    try testCompletion(
+        \\const S = struct { alpha: u32 };
+        \\fn foo() !S {}
+        \\fn bar() !void {
+        \\    const baz = try foo();
+        \\    baz.<cursor>
+        \\}
+    , &.{
+        .{ .label = "alpha", .kind = .Field, .detail = "u32" },
+    });
+
     // try testCompletion(
     //     \\const S = struct { alpha: u32 };
     //     \\fn foo() error{Foo}!S {}

--- a/tests/lsp_features/inlay_hints.zig
+++ b/tests/lsp_features/inlay_hints.zig
@@ -275,6 +275,28 @@ test "inlayhints - capture values" {
     , .Type);
 }
 
+test "inlayhints - capture value with catch" {
+    try testInlayHints(
+        \\fn foo() !u32 {}
+        \\test {
+        \\    foo() catch |err| {}
+        \\}
+    , .Type);
+    try testInlayHints(
+        \\const Error<type> = error{OutOfMemory};
+        \\fn foo() Error!u32 {}
+        \\test {
+        \\    foo() catch |err<Error>| {}
+        \\}
+    , .Type);
+    try testInlayHints(
+        \\fn foo() error{OutOfMemory}!u32 {}
+        \\test {
+        \\    foo() catch |err<error{OutOfMemory}>| {}
+        \\}
+    , .Type);
+}
+
 fn testInlayHints(source: []const u8, kind: types.InlayHintKind) !void {
     var phr = try helper.collectClearPlaceholders(allocator, source);
     defer phr.deinit(allocator);

--- a/tests/lsp_features/inlay_hints.zig
+++ b/tests/lsp_features/inlay_hints.zig
@@ -160,6 +160,49 @@ test "inlayhints - var decl" {
     , .Type);
 }
 
+test "inlayhints - function with error union" {
+    try testInlayHints(
+        \\fn foo() !u32 {}
+        \\test {
+        \\    const val<!u32> = foo();
+        \\}
+    , .Type);
+    try testInlayHints(
+        \\const Error<type> = error{OutOfMemory};
+        \\fn foo() Error!u32 {}
+        \\test {
+        \\    const val<Error!u32> = foo();
+        \\}
+    , .Type);
+    try testInlayHints(
+        \\fn foo() error{OutOfMemory}!u32 {}
+        \\test {
+        \\    const val<error{OutOfMemory}!u32> = foo();
+        \\}
+    , .Type);
+
+    // same but with `try`
+    try testInlayHints(
+        \\fn foo() !u32 {}
+        \\test {
+        \\    const val<u32> = try foo();
+        \\}
+    , .Type);
+    try testInlayHints(
+        \\const Error<type> = error{OutOfMemory};
+        \\fn foo() Error!u32 {}
+        \\test {
+        \\    const val<u32> = try foo();
+        \\}
+    , .Type);
+    try testInlayHints(
+        \\fn foo() error{OutOfMemory}!u32 {}
+        \\test {
+        \\    const val<u32> = try foo();
+        \\}
+    , .Type);
+}
+
 test "inlayhints - generic function parameter" {
     // TODO there should be an inlay hint that shows `T`
     try testInlayHints(


### PR DESCRIPTION
I've also added inlay hint when capturing the error value with `catch`.

fixes #1777