### PR TITLE
revert #1773 & update ast-check runner

### DIFF
--- a/src/features/diagnostics.zig
+++ b/src/features/diagnostics.zig
@@ -394,6 +394,9 @@ fn getDiagnosticsFromAstCheck(
     const zig_exe_path = server.config.zig_exe_path.?;
 
     const stderr_bytes = blk: {
+        server.zig_exe_lock.lock();
+        defer server.zig_exe_lock.unlock();
+
         var process = std.process.Child.init(&[_][]const u8{ zig_exe_path, "ast-check", "--color", "off" }, server.allocator);
         process.stdin_behavior = .Pipe;
         process.stderr_behavior = .Pipe;


### PR DESCRIPTION
Spawning multiple ast-check child processes is broken for some reason. Zig just keeps trying to read from stdin and never halts.

The easier reproduction is the following `build.zig`. I have only tested this on Linux.
```zig
const std = @import("std");
pub fn build(b: *std.Build) void {
    for (0..16) |_| {
        const run = std.Build.Step.Run.create(b, "run ast-check");
        run.addArgs(&.{ b.graph.zig_exe, "ast-check" });
        run.setStdIn(.{ .bytes = "test {}" });
        b.getInstallStep().dependOn(&run.step);
    }
}
```