### PR TITLE
consider `anytype` as a possible self parameter

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -344,11 +344,12 @@ pub fn firstParamIs(
     func: Ast.full.FnProto,
     expected: Type,
 ) error{OutOfMemory}!bool {
-    if (func.ast.params.len == 0) return false;
-
     const tree = handle.tree;
     var it = func.iterate(&tree);
-    const param = ast.nextFnParam(&it).?;
+    const param = ast.nextFnParam(&it) orelse return false;
+    if (param.anytype_ellipsis3) |token| {
+        if (tree.tokens.items(.tag)[token] == .keyword_anytype) return true;
+    }
     if (param.type_expr == 0) return false;
 
     const resolved_type = try analyser.resolveTypeOfNodeInternal(.{

--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -2091,7 +2091,7 @@ test "completion - anytype resolution based on callsite-references" {
     });
 }
 
-test "builtin fn `field`" {
+test "completion - builtin fn `field`" {
     try testCompletion(
         \\pub const chip_mod = struct {
         \\    pub const devices = struct {
@@ -2248,7 +2248,7 @@ test "completion - combine doc comments of declaration and definition" {
     });
 }
 
-test "hover - top-level doc comment" {
+test "completion - top-level doc comment" {
     try testCompletion(
         \\//! B
         \\
@@ -2267,6 +2267,36 @@ test "hover - top-level doc comment" {
             \\ B
             ,
         },
+    });
+}
+
+test "completion - function `self` parameter detection" {
+    try testCompletion(
+        \\const S = struct {
+        \\    fn f(self: S) void {}
+        \\};
+        \\const s = S{};
+        \\s.<cursor>
+    , &.{
+        .{ .label = "f", .kind = .Method, .detail = "fn (self: S) void", .insert_text = "f()" },
+    });
+    try testCompletion(
+        \\const S = struct {
+        \\    fn f(self: @This()) void {}
+        \\};
+        \\const s = S{};
+        \\s.<cursor>
+    , &.{
+        .{ .label = "f", .kind = .Method, .detail = "fn (self: @This()) void", .insert_text = "f()" },
+    });
+    try testCompletion(
+        \\const S = struct {
+        \\    fn f(self: anytype) void {}
+        \\};
+        \\const s = S{};
+        \\s.<cursor>
+    , &.{
+        .{ .label = "f", .kind = .Method, .detail = "fn (self: anytype) void", .insert_text = "f()" },
     });
 }
 

--- a/tests/lsp_features/semantic_tokens.zig
+++ b/tests/lsp_features/semantic_tokens.zig
@@ -419,7 +419,7 @@ test "semantic tokens - call" {
         \\const alpha = foo(0);
     , &.{
         .{ "fn", .keyword, .{} },
-        .{ "foo", .function, .{ .declaration = true, .generic = true } },
+        .{ "foo", .method, .{ .declaration = true, .generic = true } },
         .{ "a", .parameter, .{ .declaration = true } },
         .{ "anytype", .type, .{} },
         .{ "void", .type, .{} },
@@ -430,7 +430,7 @@ test "semantic tokens - call" {
         .{ "const", .keyword, .{} },
         .{ "alpha", .variable, .{ .declaration = true } },
         .{ "=", .operator, .{} },
-        .{ "foo", .function, .{ .generic = true } },
+        .{ "foo", .method, .{ .generic = true } },
         .{ "0", .number, .{} },
     });
 }

--- a/tests/lsp_features/signature_help.zig
+++ b/tests/lsp_features/signature_help.zig
@@ -201,6 +201,16 @@ test "signature help - self parameter" {
     , "fn foo(self: *@This(), a: u32, b: void) bool", 2);
 }
 
+test "signature help - self parameter is anytype" {
+    try testSignatureHelp(
+        \\const S = struct {
+        \\    fn foo(self: anytype, a: u32, b: void) bool {}
+        \\};
+        \\const s: S = undefined;
+        \\const foo = s.foo(3,<cursor>);
+    , "fn foo(self: anytype, a: u32, b: void) bool", 2);
+}
+
 test "signature help - anytype" {
     try testSignatureHelp(
         \\fn foo(a: u32, b: anytype, c: u32) void {


### PR DESCRIPTION
```zig
const S = struct {
    fn method(self: anytype) void {}
};

test {
    var foo = S{};
    foo.<cursor>; // ask for completions as select "method"

    foo.method(${self: anytype}); // old behavior
    foo.method(); // new behavior
}
```