### PR TITLE
refactor self parameter detection

### DIFF
--- a/src/ComptimeInterpreter.zig
+++ b/src/ComptimeInterpreter.zig
@@ -1103,7 +1103,7 @@ pub fn interpret(
         .async_call_one_comma,
         => {
             var params: [1]Ast.Node.Index = undefined;
-            const call_full = tree.fullCall(&params, node_idx) orelse unreachable;
+            const call_full = tree.fullCall(&params, node_idx).?;
 
             var args = try std.ArrayListUnmanaged(Value).initCapacity(interpreter.allocator, call_full.ast.params.len);
             defer args.deinit(interpreter.allocator);

--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -255,7 +255,12 @@ fn nodeToCompletion(
             const use_placeholders = server.config.enable_argument_placeholders;
             const use_label_details = server.client_capabilities.label_details_support;
 
-            const skip_self_param = !(parent_is_type_val orelse true) and try analyser.hasSelfParam(handle, func);
+            const func_ty = Analyser.Type{
+                .data = .{ .other = .{ .node = node, .handle = handle } }, // this assumes that function types can only be Ast nodes
+                .is_type_val = true,
+            };
+
+            const skip_self_param = !(parent_is_type_val orelse true) and try analyser.hasSelfParam(func_ty);
 
             const insert_text = blk: {
                 if (use_snippets and use_placeholders) {
@@ -1405,7 +1410,7 @@ fn collectFieldAccessContainerNodes(
                 const symbol_decl = try analyser.lookupSymbolGlobal(handle, first_symbol, loc.start) orelse continue;
                 const symbol_type = try symbol_decl.resolveType(analyser) orelse continue;
                 if (!symbol_type.is_type_val) { // then => instance_of_T
-                    if (try analyser.hasSelfParam(fn_proto_handle, full_fn_proto)) break :blk 2;
+                    if (try analyser.hasSelfParam(node_type)) break :blk 2;
                 }
                 break :blk 1; // is `T`, no SelfParam
             };

--- a/src/features/signature_help.zig
+++ b/src/features/signature_help.zig
@@ -29,7 +29,7 @@ fn fnProtoToSignatureInfo(
     const proto_comments = try Analyser.getDocComments(arena, tree, fn_node);
 
     const arg_idx = if (skip_self_param) blk: {
-        const has_self_param = try analyser.hasSelfParam(fn_handle, proto);
+        const has_self_param = try analyser.hasSelfParam(func_type);
         break :blk commas + @intFromBool(has_self_param);
     } else commas;
 


### PR DESCRIPTION
I was working on resolving some missing 'self paramter' detection cases like the following:
```zig
const S = struct {
    const Self = @This();
    usingnamespace struct {
        fn foo(self: Self, number: u32) u32 {
            _ = self;
            _ = number;
        }
    };
};

test {
    var instance: S = undefined;
    const result = instance.foo; // completes to `(self: Self, number: u32)` but should be `(number: u32)`
    //                         ^ cursor here
    _ = result;
}
```
This PR doesn't fix this but at least it makes the code easier to deal with.