### PR TITLE
inlay hints for destructured variables

### DIFF
--- a/src/features/inlay_hints.zig
+++ b/src/features/inlay_hints.zig
@@ -354,6 +354,18 @@ fn writeNodeInlayHint(
                 try typeStrOfNode(builder, node) orelse return,
             );
         },
+        .assign_destructure => {
+            if (!builder.config.inlay_hints_show_variable_type_hints) return;
+            const dat = tree.nodes.items(.data);
+            const lhs_count = tree.extra_data[dat[node].lhs];
+            const lhs_exprs = tree.extra_data[dat[node].lhs + 1 ..][0..lhs_count];
+
+            for (lhs_exprs) |lhs_node| {
+                const var_decl = tree.fullVarDecl(lhs_node) orelse continue;
+                if (var_decl.ast.type_node != 0) continue;
+                try inferAppendTypeStr(builder, var_decl.ast.mut_token + 1);
+            }
+        },
         .if_simple,
         .@"if",
         => {

--- a/tests/lsp_features/inlay_hints.zig
+++ b/tests/lsp_features/inlay_hints.zig
@@ -190,7 +190,18 @@ test "hide redundant parameter names" {
         .hide_redundant_param_names_last_token = true,
     });
 }
-
+test "inlay destructuring" {
+    try testInlayHints(
+        \\fn func() void {
+        \\    const foo<comptime_int>, const bar<comptime_int> = .{1, 2};
+        \\}
+    , .{ .kind = .Type });
+    try testInlayHints(
+        \\fn func() void {
+        \\    const foo: comptime_int, const bar<comptime_int> = .{1, 2};
+        \\}
+    , .{ .kind = .Type });
+}
 test "var decl" {
     try testInlayHints(
         \\const foo<comptime_int> = 5;


### PR DESCRIPTION
hacked on this tonight should be good to go, one thing I have noticed is:
```zig
const a = .{1, @as(u32, 2)};
```
does not give a tuple type(it just gives an array of the first element type) and therefore doesn't destructure properly in inlay hints or hover, but that seems like it was an issue before this so I'll make a seperate issue for tracking it.