### PR TITLE
Improved `positionLessThan()`, `rangeLessThan()` and `extractString()`

### DIFF
--- a/src/offsets.zig
+++ b/src/offsets.zig
@@ -834,21 +834,10 @@ fn testGetNCodeUnitByteCount(text: []const u8, n: [3]usize) !void {
     try std.testing.expectEqual(n[0], getNCodeUnitByteCount(text, n[2], .@"utf-32"));
 }
 
-pub fn rangeLessThan(a: types.Range, b: types.Range) bool {
+pub inline fn rangeLessThan(a: types.Range, b: types.Range) bool {
     return positionLessThan(a.start, b.start) or positionLessThan(a.end, b.end);
 }
 
-pub fn positionLessThan(a: types.Position, b: types.Position) bool {
-    if (a.line < b.line) {
-        return true;
-    }
-    if (a.line > b.line) {
-        return false;
-    }
-
-    if (a.character < b.character) {
-        return true;
-    }
-
-    return false;
+pub inline fn positionLessThan(a: types.Position, b: types.Position) bool {
+    return (a.line < b.line or a.character < b.character);
 }

--- a/src/offsets.zig
+++ b/src/offsets.zig
@@ -839,5 +839,5 @@ pub inline fn rangeLessThan(a: types.Range, b: types.Range) bool {
 }
 
 pub inline fn positionLessThan(a: types.Position, b: types.Position) bool {
-    return (a.line < b.line or a.character < b.character);
+    return (a.line < b.line or (a.line == b.line and a.character < b.character));
 }

--- a/src/translate_c.zig
+++ b/src/translate_c.zig
@@ -257,9 +257,10 @@ pub fn translate(
 }
 
 fn extractString(str: []const u8) []const u8 {
-    if (std.mem.startsWith(u8, str, "\"") and std.mem.endsWith(u8, str, "\"")) {
-        return str[1 .. str.len - 1];
-    } else {
-        return str;
+    if (str.len >= 2) {
+        if (str[0] == '"' and str[str.len - 1] == '"') {
+            return str[1..(str.len - 1)];
+        }
     }
+    return str;
 }


### PR DESCRIPTION
I looked at the source code and when I saw these functions I really wanted to change them.

I changed the `extractString()` function because multiple underlying functions are called for a single character which are not necessary and reduce performance.

I found a lot of things that can be changed to make the source code more readable and increase performance. Maybe it would be appropriate to focus on that.

> [!NOTE]
> These small changes also reduced the size of the compiled file from `3.198 KB` to `3.197 KB`.