### PR TITLE
Fix zig std api breaking (std.os.iovec_const -> std.posix.iovec_const)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -6,8 +6,8 @@ const zls_version = std.SemanticVersion{ .major = 0, .minor = 12, .patch = 0 };
 const zls_version_is_tagged: bool = false;
 
 /// document the latest breaking change that caused a change to the string below:
-/// std.builtin: make enum fields lowercase
-const min_zig_string = "0.12.0-dev.3245+4f782d1e8";
+/// extract std.posix from std.os
+const min_zig_string = "0.12.0-dev.3381+982eff7985";
 
 pub fn build(b: *Build) !void {
     const target = b.standardTargetOptions(.{});

--- a/src/ZigCompileServer.zig
+++ b/src/ZigCompileServer.zig
@@ -97,7 +97,7 @@ pub fn serveMessage(
     header: OutMessage.Header,
     bufs: []const []const u8,
 ) !void {
-    var iovecs: [10]std.os.iovec_const = undefined;
+    var iovecs: [10]std.posix.iovec_const = undefined;
     const header_le = bswap(header);
     iovecs[0] = .{
         .iov_base = @as([*]const u8, @ptrCast(&header_le)),


### PR DESCRIPTION
Detail:
extract std.posix from std.os
https://github.com/ziglang/zig/pull/19354