### PR TITLE
Pass tests with `std.posix` refactor

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -6,8 +6,8 @@ const zls_version = std.SemanticVersion{ .major = 0, .minor = 12, .patch = 0 };
 const zls_version_is_tagged: bool = false;
 
 /// document the latest breaking change that caused a change to the string below:
-/// std.builtin: make enum fields lowercase
-const min_zig_string = "0.12.0-dev.3245+4f782d1e8";
+/// std.os: extract and separate std.posix
+const min_zig_string = "0.12.0-dev.3385+3a836b480";
 
 pub fn build(b: *Build) !void {
     const target = b.standardTargetOptions(.{});

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
 
     .dependencies = .{
         .known_folders = .{
-            .url = "https://github.com/ziglibs/known-folders/archive/055c95a717c5b54a0fc52ff5f370439c28eb2e73.tar.gz",
-            .hash = "12204a8a7e9184a77f70795b1fc8a9f94dff5cce208c20c5c6452967dddc498e0b64",
+            .url = "https://github.com/ziglibs/known-folders/archive/bf79988adcfce166f848e4b11e718c1966365329.tar.gz",
+            .hash = "12201314cffeb40c5e4e3da166217d2c74628c74486414aaf97422bcd2279915b9fd",
         },
         .diffz = .{
             .url = "https://github.com/ziglibs/diffz/archive/e10bf15962e45affb3fcd7d9a950977a69c901b3.tar.gz",

--- a/deps.nix
+++ b/deps.nix
@@ -11,10 +11,10 @@ linkFarm "zig-packages" [
     };
   }
   {
-    name = "12204a8a7e9184a77f70795b1fc8a9f94dff5cce208c20c5c6452967dddc498e0b64";
+    name = "12201314cffeb40c5e4e3da166217d2c74628c74486414aaf97422bcd2279915b9fd";
     path = fetchzip {
-      url = "https://github.com/ziglibs/known-folders/archive/055c95a717c5b54a0fc52ff5f370439c28eb2e73.tar.gz";
-      hash = "sha256-ApLxRxoo5iQ7L5TrONiojIqLYs/QtPTPriVJv6mvf6w=";
+      url = "https://github.com/ziglibs/known-folders/archive/bf79988adcfce166f848e4b11e718c1966365329.tar.gz";
+      hash = "sha256-Q7eMdyScqj8qEiAHg1BnGRTsWSQOKWWTc6hUYHNlgGg=";
     };
   }
 ]

--- a/src/ZigCompileServer.zig
+++ b/src/ZigCompileServer.zig
@@ -97,7 +97,7 @@ pub fn serveMessage(
     header: OutMessage.Header,
     bufs: []const []const u8,
 ) !void {
-    var iovecs: [10]std.os.iovec_const = undefined;
+    var iovecs: [10]std.posix.iovec_const = undefined;
     const header_le = bswap(header);
     iovecs[0] = .{
         .iov_base = @as([*]const u8, @ptrCast(&header_le)),

--- a/src/debug.zig
+++ b/src/debug.zig
@@ -84,7 +84,7 @@ pub const FailingAllocator = struct {
     /// `likelihood == std.math.intMax(u32)` means that no allocation will be forced to fail
     pub fn init(internal_allocator: std.mem.Allocator, likelihood: u32) FailingAllocator {
         var seed = std.mem.zeroes([8]u8);
-        std.os.getrandom(&seed) catch {};
+        std.posix.getrandom(&seed) catch {};
 
         return FailingAllocator{
             .internal_allocator = internal_allocator,


### PR DESCRIPTION
`std.posix` was extracted from `std.os` in ziglang/zig@3a836b480