### PR TITLE
Fix build for latest Zig master

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -6,8 +6,8 @@ const zls_version = std.SemanticVersion{ .major = 0, .minor = 12, .patch = 0 };
 const zls_version_is_tagged: bool = false;
 
 /// document the latest breaking change that caused a change to the string below:
-/// std.os: extract and separate std.posix
-const min_zig_string = "0.12.0-dev.3385+3a836b480";
+/// compiler: implement analysis-local comptime-mutable memory
+const min_zig_string = "0.12.0-dev.3451+405502286";
 
 pub fn build(b: *Build) !void {
     const target = b.standardTargetOptions(.{});

--- a/flake.lock
+++ b/flake.lock
@@ -83,11 +83,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1710889954,
-        "narHash": "sha256-Pr6F5Pmd7JnNEMHHmspZ0qVqIBVxyZ13ik1pJtm2QXk=",
+        "lastModified": 1711593151,
+        "narHash": "sha256-/9NCoPI7fqJIN8viONsY9X0fAeq8jc3GslFCO0ky6TQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7872526e9c5332274ea5932a0c3270d6e4724f3b",
+        "rev": "bb2b73df7bcfbd2dd55ff39b944d70547d53c267",
         "type": "github"
       },
       "original": {
@@ -130,11 +130,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1711109355,
-        "narHash": "sha256-VZPO5mq2di5yjHkkY9ZGEIZaX7EtdusSkxICBAtHAec=",
+        "lastModified": 1711627798,
+        "narHash": "sha256-4BUZmgUFrrD5dRZbOUYRRQEDwLX/r7/ErLi+vHfB/+8=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "5fe52bdf2c213e47712d93c9ce12dfed4c4cef86",
+        "rev": "b01e0b81d1fa489e54362ea0a74f182eaa9a35bb",
         "type": "github"
       },
       "original": {

--- a/src/lsp.zig
+++ b/src/lsp.zig
@@ -107,7 +107,7 @@ pub fn EnumCustomStringValues(comptime T: type, comptime contains_empty_enum: bo
             for (fields[0 .. fields.len - 1], 0..) |field, i| {
                 kvs_array[i] = .{ field.name, @field(T, field.name) };
             }
-            break :build_kvs kvs_array[0..];
+            break :build_kvs kvs_array;
         };
         /// NOTE: this maps 'empty' to .empty when T contains an empty enum
         /// this shouldn't happen but this doesn't do any harm

--- a/src/uri.zig
+++ b/src/uri.zig
@@ -15,7 +15,7 @@ const reserved_escapes = blk: {
         escapes[i][0] = '%';
         _ = std.fmt.bufPrint(escapes[i][1..], "{X}", .{c}) catch unreachable;
     }
-    break :blk &escapes;
+    break :blk escapes;
 };
 
 /// Returns a URI from a path, caller owns the memory allocated with `allocator`


### PR DESCRIPTION
As of https://github.com/ziglang/zig/pull/19414, a small workaround is necessary to avoid global variables containing references to comptime vars.