### PR TITLE
fix completions on function alias declaration

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -167,6 +167,7 @@ pub const FormatFunctionOptions = struct {
     include_fn_keyword: bool,
     /// only included if available
     include_name: bool,
+    override_name: ?[]const u8 = null,
     skip_first_param: bool = false,
     parameters: union(enum) {
         collapse,
@@ -197,7 +198,9 @@ pub fn formatFunction(
     }
 
     if (data.include_name) {
-        if (data.fn_proto.name_token) |name_token| {
+        if (data.override_name) |name| {
+            try writer.writeAll(name);
+        } else if (data.fn_proto.name_token) |name_token| {
             try writer.writeAll(tree.tokenSlice(name_token));
         }
     }

--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -264,6 +264,7 @@ fn nodeToCompletion(
 
                             .include_fn_keyword = false,
                             .include_name = true,
+                            .override_name = func_name,
                             .skip_first_param = skip_self_param,
                             .parameters = .{ .show = .{
                                 .include_modifiers = true,

--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -2830,6 +2830,31 @@ test "insert replace behaviour - function with partial argument placeholders" {
     });
 }
 
+test "insert replace behaviour - function alias" {
+    try testCompletionTextEdit(.{
+        .source =
+        \\fn func() void {}
+        \\const alias = func;
+        \\const foo = <cursor>();
+        ,
+        .label = "alias",
+        .expected_insert_line = "const foo = alias();",
+        .expected_replace_line = "const foo = alias();",
+    });
+    try testCompletionTextEdit(.{
+        .source =
+        \\fn func() void {}
+        \\const alias = func;
+        \\const foo = <cursor>();
+        ,
+        .label = "alias",
+        .expected_insert_line = "const foo = alias();",
+        .expected_replace_line = "const foo = alias();",
+        .enable_snippets = true,
+        .enable_argument_placeholders = true,
+    });
+}
+
 test "insert replace behaviour - struct literal" {
     try testCompletionTextEdit(.{
         .source =


### PR DESCRIPTION
Fixes a bug that I introduced in #1763.

```zig
fn func() void {}
const alias = func;
const foo = <cursor>; // selecting `alias` would previously complete to `func()` instead of `alias()`
```