### PR TITLE
Function argument removed

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -6,7 +6,7 @@ const zls_version = std.SemanticVersion{ .major = 0, .minor = 12, .patch = 0 };
 const zls_version_is_tagged: bool = false;
 
 /// document the latest breaking change that caused a change to the string below:
-/// std.http.Client.Request: `options: SendOptions` has been removed from the `send()` function.
+/// Uri: propagate per-component encoding
 const min_zig_string = "0.12.0-dev.3631+c4587dc9f";
 
 pub fn build(b: *Build) !void {

--- a/build.zig
+++ b/build.zig
@@ -6,8 +6,8 @@ const zls_version = std.SemanticVersion{ .major = 0, .minor = 12, .patch = 0 };
 const zls_version_is_tagged: bool = false;
 
 /// document the latest breaking change that caused a change to the string below:
-/// compiler: implement analysis-local comptime-mutable memory
-const min_zig_string = "0.12.0-dev.3451+405502286";
+/// std.http.Client.Request: `options: SendOptions` has been removed from the `send()` function.
+const min_zig_string = "0.12.0-dev.3631+c4587dc9f";
 
 pub fn build(b: *Build) !void {
     const target = b.standardTargetOptions(.{});

--- a/flake.lock
+++ b/flake.lock
@@ -83,11 +83,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1711593151,
-        "narHash": "sha256-/9NCoPI7fqJIN8viONsY9X0fAeq8jc3GslFCO0ky6TQ=",
+        "lastModified": 1712757991,
+        "narHash": "sha256-kR7C7Fqt3JP40h0mzmSZeWI5pk1iwqj4CSeGjnUbVHc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bb2b73df7bcfbd2dd55ff39b944d70547d53c267",
+        "rev": "d6b3ddd253c578a7ab98f8011e59990f21dc3932",
         "type": "github"
       },
       "original": {
@@ -130,11 +130,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1711627798,
-        "narHash": "sha256-4BUZmgUFrrD5dRZbOUYRRQEDwLX/r7/ErLi+vHfB/+8=",
+        "lastModified": 1712794997,
+        "narHash": "sha256-H1sVVagnlL6xmvSVELGMEAhvJHv4auAY3B97Oi2I8uo=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "b01e0b81d1fa489e54362ea0a74f182eaa9a35bb",
+        "rev": "9687044a467176bea9e3f0a972143bcbad5dae90",
         "type": "github"
       },
       "original": {

--- a/src/config_gen/config_gen.zig
+++ b/src/config_gen/config_gen.zig
@@ -987,7 +987,7 @@ fn httpGET(allocator: std.mem.Allocator, uri: std.Uri) !Response {
         );
         defer request.deinit();
 
-        try request.send(.{});
+        try request.send();
         try request.finish();
         try request.wait();
 


### PR DESCRIPTION
This function no longer contains any arguments.

```
install
└─ install zls
   └─ zig build-exe zls ReleaseSafe native
      └─ run zls_gen (version_data_master_19824.zig)
         └─ zig build-exe zls_gen Debug native 1 errors
src\config_gen\config_gen.zig:990:20: error: member function expected 0 argument(s), found 1
        try request.send(.{});
```

https://github.com/ziglang/zig/pull/19598/files#diff-ab7384310a623b1845d2013b68374070ab590b1cc82d786e188fadc3f70ccda5L805