### PR TITLE
Artifacts deployment: Disable the `x86-windows` target

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -118,7 +118,8 @@ pub fn build(b: *Build) !void {
         .{ .cpu_arch = .x86_64, .os_tag = .windows },
         .{ .cpu_arch = .x86_64, .os_tag = .linux },
         .{ .cpu_arch = .x86_64, .os_tag = .macos },
-        .{ .cpu_arch = .x86, .os_tag = .windows },
+        // See: https://github.com/ziglang/zig/issues/19619
+        // .{ .cpu_arch = .x86, .os_tag = .windows },
         .{ .cpu_arch = .x86, .os_tag = .linux },
         .{ .cpu_arch = .aarch64, .os_tag = .linux },
         .{ .cpu_arch = .aarch64, .os_tag = .macos },


### PR DESCRIPTION
See: https://github.com/ziglang/zig/issues/19619