### PR TITLE
DocumentScope: Provide an explicit backing int for `Scope.Tag`

### DIFF
--- a/src/DocumentScope.zig
+++ b/src/DocumentScope.zig
@@ -78,7 +78,7 @@ pub const DeclarationLookupContext = struct {
 };
 
 pub const Scope = struct {
-    pub const Tag = enum {
+    pub const Tag = enum(u3) {
         /// `node_tags[ast_node]` is ContainerDecl or Root or ErrorSetDecl
         container,
         /// index into `DocumentScope.extra`


### PR DESCRIPTION
Zig `0.12.0-dev.3673+1fb238131` requires an explicit backing integer for types within a packed struct:
```
src/DocumentScope.zig:129:14: error: packed structs cannot contain fields of type 'DocumentScope.Scope.Tag'
        tag: Tag,
             ^~~
src/DocumentScope.zig:81:21: note: enum declared here
    pub const Tag = enum {
```