### PR TITLE
Workspace Symbols

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -68,6 +68,7 @@ pub fn build(b: *Build) !void {
 
     const known_folders_module = b.dependency("known_folders", .{}).module("known-folders");
     const diffz_module = b.dependency("diffz", .{}).module("diffz");
+    const fastfilter_module = b.dependency("fastfilter", .{}).module("fastfilter");
     const tracy_module = getTracyModule(b, .{
         .target = target,
         .optimize = optimize,
@@ -124,6 +125,7 @@ pub fn build(b: *Build) !void {
         .imports = &.{
             .{ .name = "known-folders", .module = known_folders_module },
             .{ .name = "diffz", .module = diffz_module },
+            .{ .name = "fastfilter", .module = fastfilter_module },
             .{ .name = "tracy", .module = tracy_module },
             .{ .name = "build_options", .module = build_options_module },
             .{ .name = "version_data", .module = version_data_module },

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -15,8 +15,8 @@
             .hash = "1220102cb2c669d82184fb1dc5380193d37d68b54e8d75b76b2d155b9af7d7e2e76d",
         },
         .fastfilter = .{
-            .url = "https://github.com/hexops/fastfilter/archive/b504ba1e636fb4847a7978c10ea32c64d457aaeb.tar.gz",
-            .hash = "1220e672d4980c183c6b29cf9b1200c3db23a7987968b0de7e6357f49b6b174c3276",
+            .url = "https://github.com/hexops/fastfilter/archive/b6e46f6d4811da0d8a0f8675ab85407172a207ba.tar.gz",
+            .hash = "1220c2275142456c3eb8152f626092237a7795e93518896581a9358ce857b3ca550e",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -14,6 +14,10 @@
             .url = "https://github.com/ziglibs/diffz/archive/ef45c00d655e5e40faf35afbbde81a1fa5ed7ffb.tar.gz",
             .hash = "1220102cb2c669d82184fb1dc5380193d37d68b54e8d75b76b2d155b9af7d7e2e76d",
         },
+        .fastfilter = .{
+            .url = "https://github.com/hexops/fastfilter/archive/b504ba1e636fb4847a7978c10ea32c64d457aaeb.tar.gz",
+            .hash = "1220e672d4980c183c6b29cf9b1200c3db23a7987968b0de7e6357f49b6b174c3276",
+        },
     },
     .paths = .{""},
 }

--- a/src/DocumentScope.zig
+++ b/src/DocumentScope.zig
@@ -230,7 +230,7 @@ const ScopeContext = struct {
                     const next_idx = iterator.i;
                     const codepoint_1 = iterator.nextCodepoint() orelse break;
                     const codepoint_2 = iterator.nextCodepoint() orelse break;
-                    try doc_scope.appendTrigram(allocator, Trigram{
+                    try doc_scope.appendTrigram(allocator, .{
                         .codepoint_0 = codepoint_0,
                         .codepoint_1 = codepoint_1,
                         .codepoint_2 = codepoint_2,
@@ -1335,9 +1335,9 @@ pub const TrigramIterator = struct {
 
     pub fn next(iterator: *TrigramIterator) Declaration.OptionalIndex {
         if (iterator.extra_index == null) return .none;
-        const prev, const decl = iterator.extra[iterator.extra_index..][0..2];
+        const prev, const decl = iterator.extra[iterator.extra_index.?..][0..2].*;
         iterator.extra_index = if (prev == std.math.maxInt(u32)) null else prev;
-        return decl;
+        return @as(Declaration.Index, @enumFromInt(decl)).toOptional();
     }
 };
 

--- a/src/DocumentScope.zig
+++ b/src/DocumentScope.zig
@@ -4,13 +4,13 @@ const Ast = std.zig.Ast;
 const tracy = @import("tracy");
 const offsets = @import("offsets.zig");
 const Analyser = @import("analysis.zig");
-const fastfilter = @import("fastfilter");
 const Declaration = Analyser.Declaration;
 
 const DocumentScope = @This();
 
 scopes: std.MultiArrayList(Scope) = .{},
 declarations: std.MultiArrayList(Declaration) = .{},
+declarations_that_should_be_trigram_indexed: std.ArrayListUnmanaged(Declaration.Index) = .{},
 /// Used for looking up a child declaration in a given scope
 declaration_lookup_map: DeclarationLookupMap = .{},
 extra: std.ArrayListUnmanaged(u32) = .{},
@@ -24,23 +24,6 @@ global_error_set: IdentifierSet = .{},
 /// A token that has a doc comment takes priority.
 /// This means that if there a multiple enums with the same name, only one of them is included.
 global_enum_set: IdentifierSet = .{},
-
-// Workspace symbol lookup.
-
-/// Fast lookup with false positives.
-trigram_filter: fastfilter.BinaryFuse8,
-/// Index into `extra`.
-/// Body:
-///     prev: u32 or none = maxInt(u32)
-///     decl: Declaration.Index
-trigram_lookup_map: std.AutoArrayHashMapUnmanaged(Trigram, u32) = .{},
-
-pub const Trigram = packed struct(u64) {
-    codepoint_0: u21,
-    codepoint_1: u21,
-    codepoint_2: u21,
-    padding: u1 = 0,
-};
 
 /// Stores a set of identifier tokens with unique names
 pub const IdentifierSet = std.ArrayHashMapUnmanaged(Ast.TokenIndex, void, IdentifierTokenContext, true);
@@ -199,7 +182,7 @@ const ScopeContext = struct {
 
         scopes_start: u32,
         declarations_start: u32,
-        should_trigrams_be_index: bool,
+        should_trigrams_be_indexed: bool,
 
         fn pushDeclaration(
             pushed: PushedScope,
@@ -225,24 +208,8 @@ const ScopeContext = struct {
             try doc_scope.declarations.append(allocator, declaration);
             const declaration_index: Declaration.Index = @enumFromInt(doc_scope.declarations.len - 1);
 
-            if (pushed.should_trigrams_be_index) {
-                if (std.unicode.Utf8View.init(name)) |view| {
-                    var iterator = view.iterator();
-                    while (iterator.nextCodepoint()) |codepoint_0| {
-                        const next_idx = iterator.i;
-                        const codepoint_1 = iterator.nextCodepoint() orelse break;
-                        const codepoint_2 = iterator.nextCodepoint() orelse break;
-                        try doc_scope.appendTrigram(allocator, .{
-                            .codepoint_0 = codepoint_0,
-                            .codepoint_1 = codepoint_1,
-                            .codepoint_2 = codepoint_2,
-                        }, declaration_index);
-                        iterator.i = next_idx;
-                    }
-                } else |_| {
-                    // NOTE(SuperAuguste): We ignore this error and simply
-                    // skip indexing this name; is this as good idea?
-                }
+            if (pushed.should_trigrams_be_indexed and name.len >= 3) {
+                try doc_scope.declarations_that_should_be_trigram_indexed.append(allocator, declaration_index);
             }
 
             const data = &doc_scope.scopes.items(.data)[@intFromEnum(pushed.scope)];
@@ -337,7 +304,7 @@ const ScopeContext = struct {
             .scope = context.current_scope.unwrap().?,
             .scopes_start = @intCast(context.child_scopes_scratch.items.len),
             .declarations_start = @intCast(context.child_declarations_scratch.items.len),
-            .should_trigrams_be_index = switch (tag) {
+            .should_trigrams_be_indexed = switch (tag) {
                 .container, .container_usingnamespace => true,
                 else => false,
             },
@@ -379,9 +346,7 @@ pub fn init(allocator: std.mem.Allocator, tree: Ast) error{OutOfMemory}!Document
     const tracy_zone = tracy.trace(@src());
     defer tracy_zone.end();
 
-    var document_scope = DocumentScope{
-        .trigram_filter = undefined,
-    };
+    var document_scope = DocumentScope{};
     errdefer document_scope.deinit(allocator);
 
     var context = ScopeContext{
@@ -392,31 +357,18 @@ pub fn init(allocator: std.mem.Allocator, tree: Ast) error{OutOfMemory}!Document
     defer context.deinit();
     try walkContainerDecl(&context, tree, 0);
 
-    document_scope.trigram_filter = try fastfilter.BinaryFuse8.init(allocator, document_scope.trigram_lookup_map.count());
-    document_scope.trigram_filter.populate(allocator, @ptrCast(document_scope.trigram_lookup_map.keys())) catch |err| switch (err) {
-        error.KeysLikelyNotUnique => {
-            // NOTE(SuperAuguste): Ignore this? It shouldn't happen ever
-            // and should, at worst, break lookups for one document, unless
-            // the filter state is all messed up (might crash at lookup time?).
-            // TODO: Look into this more.
-        },
-        else => |e| return e,
-    };
-
     return document_scope;
 }
 
 pub fn deinit(scope: *DocumentScope, allocator: std.mem.Allocator) void {
     scope.scopes.deinit(allocator);
     scope.declarations.deinit(allocator);
+    scope.declarations_that_should_be_trigram_indexed.deinit(allocator);
     scope.declaration_lookup_map.deinit(allocator);
     scope.extra.deinit(allocator);
 
     scope.global_enum_set.deinit(allocator);
     scope.global_error_set.deinit(allocator);
-
-    scope.trigram_filter.deinit(allocator);
-    scope.trigram_lookup_map.deinit(allocator);
 }
 
 fn locToSmallLoc(loc: offsets.Loc) Scope.SmallLoc {
@@ -1221,21 +1173,6 @@ noinline fn walkOtherNode(
     try ast.iterateChildren(tree, node_idx, context, error{OutOfMemory}, walkNode);
 }
 
-fn appendTrigram(
-    doc_scope: *DocumentScope,
-    allocator: std.mem.Allocator,
-    trigram: Trigram,
-    declaration: Declaration.Index,
-) error{OutOfMemory}!void {
-    const gop = try doc_scope.trigram_lookup_map.getOrPut(allocator, trigram);
-
-    const prev_or_none = if (gop.found_existing) gop.value_ptr.* else std.math.maxInt(u32);
-    const new_last = doc_scope.extra.items.len;
-    try doc_scope.extra.appendSlice(allocator, &.{ prev_or_none, @intFromEnum(declaration) });
-
-    gop.value_ptr.* = @intCast(new_last);
-}
-
 // Lookup
 
 pub fn getScopeTag(
@@ -1334,23 +1271,4 @@ pub fn getScopeChildScopesConst(
         const other = slice.items(.child_scopes)[@intFromEnum(scope)].other;
         return @ptrCast(doc_scope.extra.items[other.start..other.end]);
     }
-}
-
-pub const TrigramIterator = struct {
-    extra: []const u32,
-    extra_index: ?u32,
-
-    pub fn next(iterator: *TrigramIterator) Declaration.OptionalIndex {
-        if (iterator.extra_index == null) return .none;
-        const prev, const decl = iterator.extra[iterator.extra_index.?..][0..2].*;
-        iterator.extra_index = if (prev == std.math.maxInt(u32)) null else prev;
-        return @as(Declaration.Index, @enumFromInt(decl)).toOptional();
-    }
-};
-
-pub fn declarationsWithTrigramIterator(doc_scope: DocumentScope, trigram: Trigram) TrigramIterator {
-    return .{
-        .extra = doc_scope.extra.items,
-        .extra_index = doc_scope.trigram_lookup_map.get(trigram),
-    };
 }

--- a/src/DocumentScope.zig
+++ b/src/DocumentScope.zig
@@ -10,6 +10,7 @@ const DocumentScope = @This();
 
 scopes: std.MultiArrayList(Scope) = .{},
 declarations: std.MultiArrayList(Declaration) = .{},
+trigram_decls_mapping_capacity: u32 = 0,
 declarations_that_should_be_trigram_indexed: std.ArrayListUnmanaged(Declaration.Index) = .{},
 /// Used for looking up a child declaration in a given scope
 declaration_lookup_map: DeclarationLookupMap = .{},
@@ -209,6 +210,7 @@ const ScopeContext = struct {
             const declaration_index: Declaration.Index = @enumFromInt(doc_scope.declarations.len - 1);
 
             if (pushed.should_trigrams_be_indexed and name.len >= 3) {
+                doc_scope.trigram_decls_mapping_capacity += @intCast(name.len - 2);
                 try doc_scope.declarations_that_should_be_trigram_indexed.append(allocator, declaration_index);
             }
 

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -32,7 +32,7 @@ const goto = @import("features/goto.zig");
 const hover_handler = @import("features/hover.zig");
 const selection_range = @import("features/selection_range.zig");
 const diagnostics_gen = @import("features/diagnostics.zig");
-
+const URI = @import("uri.zig");
 const log = std.log.scoped(.zls_server);
 
 // public fields
@@ -519,6 +519,8 @@ fn initializeHandler(server: *Server, _: std.mem.Allocator, request: types.Initi
         for (server.client_capabilities.workspace_folders, workspace_folders) |*dest, src| {
             dest.* = try server.allocator.dupe(u8, src.uri);
         }
+        server.document_store.config.workspace_folders = server.client_capabilities.workspace_folders;
+        try server.document_store.updateHandlesInWorkspaceFolders();
     }
 
     if (request.trace) |trace| {
@@ -779,6 +781,9 @@ fn didChangeWorkspaceFoldersHandler(server: *Server, arena: std.mem.Allocator, n
     }
 
     server.client_capabilities.workspace_folders = try folders.toOwnedSlice(server.allocator);
+
+    server.document_store.config.workspace_folders = server.client_capabilities.workspace_folders;
+    try server.document_store.updateHandlesInWorkspaceFolders();
 }
 
 fn didChangeConfigurationHandler(server: *Server, arena: std.mem.Allocator, notification: types.DidChangeConfigurationParams) Error!void {
@@ -881,7 +886,7 @@ pub fn updateConfiguration(server: *Server, new_config: configuration.Configurat
         }
     }
 
-    server.document_store.config = DocumentStore.Config.fromMainConfig(server.config);
+    server.document_store.config = DocumentStore.Config.fromMainConfig(server.config, server.client_capabilities.workspace_folders);
 
     if (new_zig_exe_path or new_build_runner_path) blk: {
         if (!std.process.can_spawn) break :blk;
@@ -1599,6 +1604,29 @@ fn selectionRangeHandler(server: *Server, arena: std.mem.Allocator, request: typ
 fn workspaceSymbolHandler(server: *Server, arena: std.mem.Allocator, request: types.WorkspaceSymbolParams) Error!ResultType("workspace/symbol") {
     if (request.query.len < 3) return null;
 
+    // TODO: implement Uri -> TrigramData map
+    // to reduce long-term memory usage
+
+    // NOTE: this is not one for loop as
+    // the TODO described above will require
+    // these to be two discrete steps
+
+    for (server.client_capabilities.workspace_folders) |workspace_folder| {
+        const path = URI.parse(arena, workspace_folder) catch return error.InternalError;
+        var dir = std.fs.cwd().openDir(path, .{ .iterate = true }) catch return error.InternalError;
+        defer dir.close();
+
+        var walker = try dir.walk(arena);
+        defer walker.deinit();
+
+        while (walker.next() catch return error.InternalError) |entry| {
+            if (std.mem.eql(u8, std.fs.path.extension(entry.basename), ".zig")) {
+                const uri = URI.pathRelative(arena, workspace_folder, entry.path) catch return error.InternalError;
+                _ = server.document_store.getOrLoadHandle(uri);
+            }
+        }
+    }
+
     var trigrams = std.ArrayListUnmanaged(DocumentScope.Trigram){};
     // TODO: ensure capacity
 
@@ -1618,15 +1646,10 @@ fn workspaceSymbolHandler(server: *Server, arena: std.mem.Allocator, request: ty
     } else |_| return null;
 
     var workspace_symbols = std.ArrayListUnmanaged(types.WorkspaceSymbol){};
-
     var candidates_decl_map = std.AutoArrayHashMapUnmanaged(Analyser.Declaration.Index, void){};
-    defer candidates_decl_map.deinit(arena);
-
     var narrowing_decl_map = std.AutoArrayHashMapUnmanaged(Analyser.Declaration.Index, void){};
-    defer narrowing_decl_map.deinit(arena);
 
-    // TODO: make sure we're only looking at handles that are actually in our workspace
-    doc_loop: for (server.document_store.handles.values()) |handle| {
+    doc_loop: for (server.document_store.handles_in_workspace_folders.values()) |handle| {
         const tree = handle.tree;
         const doc_scope = try handle.getDocumentScope();
 
@@ -1667,7 +1690,6 @@ fn workspaceSymbolHandler(server: *Server, arena: std.mem.Allocator, request: ty
             const name_token = decl.nameToken(tree);
 
             // TODO: integrate with document_symbol.zig for right kind info
-            // TODO: only index/lookup non-locals (I believe that is the correct behavior)
             try workspace_symbols.append(arena, .{
                 .name = tree.tokenSlice(name_token),
                 .kind = .Variable,
@@ -1776,7 +1798,7 @@ pub fn create(allocator: std.mem.Allocator) !*Server {
         .config = .{},
         .document_store = .{
             .allocator = allocator,
-            .config = DocumentStore.Config.fromMainConfig(Config{}),
+            .config = DocumentStore.Config.fromMainConfig(Config{}, &.{}),
             .thread_pool = if (zig_builtin.single_threaded) {} else undefined, // set below
         },
         .job_queue = std.fifo.LinearFifo(Job, .Dynamic).init(allocator),

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -1644,13 +1644,12 @@ fn workspaceSymbolHandler(server: *Server, arena: std.mem.Allocator, request: ty
 
     doc_loop: for (server.document_store.trigram_stores.keys(), server.document_store.trigram_stores.values()) |uri, trigram_store| {
         const handle = server.document_store.getOrLoadHandle(uri) orelse continue;
-        if (trigram_store.filter == null) continue;
 
         const tree = handle.tree;
         const doc_scope = try handle.getDocumentScope();
 
         for (trigrams.items) |trigram| {
-            if (!trigram_store.filter.?.contain(@bitCast(trigram))) continue :doc_loop;
+            if (!trigram_store.filter.contain(@bitCast(trigram))) continue :doc_loop;
         }
 
         candidate_decls_buffer.clearRetainingCapacity();

--- a/src/TrigramStore.zig
+++ b/src/TrigramStore.zig
@@ -1,0 +1,125 @@
+//! `Trigram -> Declaration` mapping.
+//! `finalize` must be called before any queries are executed.
+
+const std = @import("std");
+const analysis = @import("analysis.zig");
+const fastfilter = @import("fastfilter");
+const Declaration = analysis.Declaration;
+const DocumentStore = @import("DocumentStore.zig");
+
+const TrigramStore = @This();
+
+/// Fast lookup with false positives.
+filter: ?fastfilter.BinaryFuse8 = null,
+/// Index into `extra`.
+/// Body:
+///     prev: u32 or none = maxInt(u32)
+///     decl: Declaration.Index
+lookup: std.AutoArrayHashMapUnmanaged(Trigram, u32) = .{},
+extra: std.ArrayListUnmanaged(u32) = .{},
+
+pub const Trigram = packed struct(u64) {
+    codepoint_0: u21,
+    codepoint_1: u21,
+    codepoint_2: u21,
+    padding: u1 = 0,
+};
+
+pub fn init(allocator: std.mem.Allocator, handle: *DocumentStore.Handle) error{ InvalidUtf8, OutOfMemory }!TrigramStore {
+    const doc_scope = try handle.getDocumentScope();
+    var store = TrigramStore{};
+    for (doc_scope.declarations_that_should_be_trigram_indexed.items) |decl_idx| {
+        const decl = doc_scope.declarations.get(@intFromEnum(decl_idx));
+        try store.append(allocator, handle.tree.tokenSlice(decl.nameToken(handle.tree)), decl_idx);
+    }
+    try store.finalize(allocator);
+    return store;
+}
+
+/// Must be called before any queries are executed.
+pub fn finalize(store: *TrigramStore, allocator: std.mem.Allocator) error{OutOfMemory}!void {
+    store.filter = try fastfilter.BinaryFuse8.init(allocator, store.lookup.count());
+    store.filter.?.populate(allocator, @ptrCast(store.lookup.keys())) catch |err| switch (err) {
+        error.KeysLikelyNotUnique => {
+            // NOTE(SuperAuguste): Ignore this? It shouldn't happen ever
+            // and should, at worst, break lookups for one document, unless
+            // the filter state is all messed up (might crash at lookup time?).
+            // TODO: Look into this more.
+        },
+        else => |e| return e,
+    };
+}
+
+pub fn reset(store: *TrigramStore, allocator: std.mem.Allocator) void {
+    if (store.filter) |filter| {
+        filter.deinit(allocator);
+        store.filter = null;
+    }
+    store.lookup.clearRetainingCapacity();
+    store.extra.items.len = 0;
+}
+
+pub fn deinit(store: *TrigramStore, allocator: std.mem.Allocator) void {
+    if (store.filter) |filter| filter.deinit(allocator);
+    store.lookup.deinit(allocator);
+    store.extra.deinit(allocator);
+    store.* = undefined;
+}
+
+/// Appends declaration with `name`'s trigrams to store.
+pub fn append(
+    store: *TrigramStore,
+    allocator: std.mem.Allocator,
+    name: []const u8,
+    declaration: Declaration.Index,
+) error{ OutOfMemory, InvalidUtf8 }!void {
+    std.debug.assert(name.len >= 3);
+
+    // These will either be exact, or in the case of non-ASCII text
+    // be a slight overshoot.
+    try store.lookup.ensureUnusedCapacity(allocator, name.len - 2);
+    try store.extra.ensureUnusedCapacity(allocator, (name.len - 2) * 2);
+
+    const view = try std.unicode.Utf8View.init(name);
+
+    var iterator = view.iterator();
+    while (iterator.nextCodepoint()) |codepoint_0| {
+        const next_idx = iterator.i;
+        const codepoint_1 = iterator.nextCodepoint() orelse break;
+        const codepoint_2 = iterator.nextCodepoint() orelse break;
+
+        const gop = store.lookup.getOrPutAssumeCapacity(.{
+            .codepoint_0 = codepoint_0,
+            .codepoint_1 = codepoint_1,
+            .codepoint_2 = codepoint_2,
+        });
+
+        const prev_or_none = if (gop.found_existing) gop.value_ptr.* else std.math.maxInt(u32);
+        const new_last = store.extra.items.len;
+        store.extra.appendSliceAssumeCapacity(&.{ prev_or_none, @intFromEnum(declaration) });
+
+        gop.value_ptr.* = @intCast(new_last);
+
+        iterator.i = next_idx;
+    }
+}
+
+pub const TrigramIterator = struct {
+    extra: []const u32,
+    extra_index: ?u32,
+
+    pub fn next(iterator: *TrigramIterator) Declaration.OptionalIndex {
+        if (iterator.extra_index == null) return .none;
+        const prev, const decl = iterator.extra[iterator.extra_index.?..][0..2].*;
+        iterator.extra_index = if (prev == std.math.maxInt(u32)) null else prev;
+        return @as(Declaration.Index, @enumFromInt(decl)).toOptional();
+    }
+};
+
+/// Iterates all declarations containing `trigram`.
+pub fn iterate(store: TrigramStore, trigram: Trigram) TrigramIterator {
+    return .{
+        .extra = store.extra.items,
+        .extra_index = store.lookup.get(trigram),
+    };
+}

--- a/src/TrigramStore.zig
+++ b/src/TrigramStore.zig
@@ -11,7 +11,7 @@ const CompactingMultiList = @import("compacting_multi_list.zig").CompactingMulti
 const TrigramStore = @This();
 
 /// Fast lookup with false positives.
-filter: ?fastfilter.BinaryFuse8,
+filter: fastfilter.BinaryFuse8,
 /// Map index is a slice in decls.
 lookup: std.AutoArrayHashMapUnmanaged(Trigram, void),
 decls: CompactingMultiList(Declaration.Index).Compacted,
@@ -114,7 +114,7 @@ pub fn reset(store: *TrigramStore, allocator: std.mem.Allocator) void {
 }
 
 pub fn deinit(store: *TrigramStore, allocator: std.mem.Allocator) void {
-    if (store.filter) |filter| filter.deinit(allocator);
+    store.filter.deinit(allocator);
     store.lookup.deinit(allocator);
     store.decls.deinit(allocator);
     store.* = undefined;

--- a/src/TrigramStore.zig
+++ b/src/TrigramStore.zig
@@ -6,17 +6,86 @@ const analysis = @import("analysis.zig");
 const fastfilter = @import("fastfilter");
 const Declaration = analysis.Declaration;
 const DocumentStore = @import("DocumentStore.zig");
+const CompactingMultiList = @import("compacting_multi_list.zig").CompactingMultiList;
 
 const TrigramStore = @This();
 
 /// Fast lookup with false positives.
-filter: ?fastfilter.BinaryFuse8 = null,
-/// Index into `extra`.
-/// Body:
-///     prev: u32 or none = maxInt(u32)
-///     decl: Declaration.Index
-lookup: std.AutoArrayHashMapUnmanaged(Trigram, u32) = .{},
-extra: std.ArrayListUnmanaged(u32) = .{},
+filter: ?fastfilter.BinaryFuse8,
+/// Map index is a slice in decls.
+lookup: std.AutoArrayHashMapUnmanaged(Trigram, void),
+decls: CompactingMultiList(Declaration.Index).Compacted,
+
+pub const Builder = struct {
+    lookup: std.AutoArrayHashMapUnmanaged(Trigram, void),
+    decls: CompactingMultiList(Declaration.Index),
+
+    pub fn init(allocator: std.mem.Allocator, decls_capacity: u32) error{OutOfMemory}!Builder {
+        var builder = Builder{ .lookup = .{}, .decls = .{} };
+        try builder.decls.ensureTotalCapacity(allocator, decls_capacity);
+        return builder;
+    }
+
+    /// Appends declaration with `name`'s trigrams to store.
+    pub fn append(
+        builder: *Builder,
+        allocator: std.mem.Allocator,
+        name: []const u8,
+        declaration: Declaration.Index,
+    ) error{ OutOfMemory, InvalidUtf8 }!void {
+        std.debug.assert(name.len >= 3);
+
+        // These will either be exact, or in the case of non-ASCII text
+        // be a slight overshoot.
+        try builder.lookup.ensureUnusedCapacity(allocator, name.len - 2);
+
+        const view = try std.unicode.Utf8View.init(name);
+
+        var iterator = view.iterator();
+        while (iterator.nextCodepoint()) |codepoint_0| {
+            const next_idx = iterator.i;
+            const codepoint_1 = iterator.nextCodepoint() orelse break;
+            const codepoint_2 = iterator.nextCodepoint() orelse break;
+
+            const gop = builder.lookup.getOrPutAssumeCapacity(.{
+                .codepoint_0 = codepoint_0,
+                .codepoint_1 = codepoint_1,
+                .codepoint_2 = codepoint_2,
+            });
+
+            if (!gop.found_existing) {
+                _ = try builder.decls.appendToNewListAssumeCapacity(allocator, declaration);
+            } else {
+                builder.decls.appendAssumeCapacity(@intCast(gop.index), declaration);
+            }
+
+            iterator.i = next_idx;
+        }
+    }
+
+    /// Must be called before any queries are executed.
+    pub fn finalize(builder: *Builder, allocator: std.mem.Allocator) error{OutOfMemory}!TrigramStore {
+        var filter = try fastfilter.BinaryFuse8.init(allocator, builder.lookup.count());
+        filter.populate(allocator, @ptrCast(builder.lookup.keys())) catch |err| switch (err) {
+            error.KeysLikelyNotUnique => {
+                // NOTE(SuperAuguste): Ignore this? It shouldn't happen ever
+                // and should, at worst, break lookups for one document, unless
+                // the filter state is all messed up (might crash at lookup time?).
+                // TODO: Look into this more.
+            },
+            else => |e| return e,
+        };
+
+        const store = TrigramStore{
+            .filter = filter,
+            .lookup = builder.lookup,
+            .decls = try builder.decls.compact(allocator),
+        };
+        builder.decls.deinit(allocator);
+
+        return store;
+    }
+};
 
 pub const Trigram = packed struct(u64) {
     codepoint_0: u21,
@@ -27,27 +96,12 @@ pub const Trigram = packed struct(u64) {
 
 pub fn init(allocator: std.mem.Allocator, handle: *DocumentStore.Handle) error{ InvalidUtf8, OutOfMemory }!TrigramStore {
     const doc_scope = try handle.getDocumentScope();
-    var store = TrigramStore{};
+    var builder = try Builder.init(allocator, doc_scope.trigram_decls_mapping_capacity);
     for (doc_scope.declarations_that_should_be_trigram_indexed.items) |decl_idx| {
         const decl = doc_scope.declarations.get(@intFromEnum(decl_idx));
-        try store.append(allocator, handle.tree.tokenSlice(decl.nameToken(handle.tree)), decl_idx);
+        try builder.append(allocator, handle.tree.tokenSlice(decl.nameToken(handle.tree)), decl_idx);
     }
-    try store.finalize(allocator);
-    return store;
-}
-
-/// Must be called before any queries are executed.
-pub fn finalize(store: *TrigramStore, allocator: std.mem.Allocator) error{OutOfMemory}!void {
-    store.filter = try fastfilter.BinaryFuse8.init(allocator, store.lookup.count());
-    store.filter.?.populate(allocator, @ptrCast(store.lookup.keys())) catch |err| switch (err) {
-        error.KeysLikelyNotUnique => {
-            // NOTE(SuperAuguste): Ignore this? It shouldn't happen ever
-            // and should, at worst, break lookups for one document, unless
-            // the filter state is all messed up (might crash at lookup time?).
-            // TODO: Look into this more.
-        },
-        else => |e| return e,
-    };
+    return try builder.finalize(allocator);
 }
 
 pub fn reset(store: *TrigramStore, allocator: std.mem.Allocator) void {
@@ -62,64 +116,10 @@ pub fn reset(store: *TrigramStore, allocator: std.mem.Allocator) void {
 pub fn deinit(store: *TrigramStore, allocator: std.mem.Allocator) void {
     if (store.filter) |filter| filter.deinit(allocator);
     store.lookup.deinit(allocator);
-    store.extra.deinit(allocator);
+    store.decls.deinit(allocator);
     store.* = undefined;
 }
 
-/// Appends declaration with `name`'s trigrams to store.
-pub fn append(
-    store: *TrigramStore,
-    allocator: std.mem.Allocator,
-    name: []const u8,
-    declaration: Declaration.Index,
-) error{ OutOfMemory, InvalidUtf8 }!void {
-    std.debug.assert(name.len >= 3);
-
-    // These will either be exact, or in the case of non-ASCII text
-    // be a slight overshoot.
-    try store.lookup.ensureUnusedCapacity(allocator, name.len - 2);
-    try store.extra.ensureUnusedCapacity(allocator, (name.len - 2) * 2);
-
-    const view = try std.unicode.Utf8View.init(name);
-
-    var iterator = view.iterator();
-    while (iterator.nextCodepoint()) |codepoint_0| {
-        const next_idx = iterator.i;
-        const codepoint_1 = iterator.nextCodepoint() orelse break;
-        const codepoint_2 = iterator.nextCodepoint() orelse break;
-
-        const gop = store.lookup.getOrPutAssumeCapacity(.{
-            .codepoint_0 = codepoint_0,
-            .codepoint_1 = codepoint_1,
-            .codepoint_2 = codepoint_2,
-        });
-
-        const prev_or_none = if (gop.found_existing) gop.value_ptr.* else std.math.maxInt(u32);
-        const new_last = store.extra.items.len;
-        store.extra.appendSliceAssumeCapacity(&.{ prev_or_none, @intFromEnum(declaration) });
-
-        gop.value_ptr.* = @intCast(new_last);
-
-        iterator.i = next_idx;
-    }
-}
-
-pub const TrigramIterator = struct {
-    extra: []const u32,
-    extra_index: ?u32,
-
-    pub fn next(iterator: *TrigramIterator) Declaration.OptionalIndex {
-        if (iterator.extra_index == null) return .none;
-        const prev, const decl = iterator.extra[iterator.extra_index.?..][0..2].*;
-        iterator.extra_index = if (prev == std.math.maxInt(u32)) null else prev;
-        return @as(Declaration.Index, @enumFromInt(decl)).toOptional();
-    }
-};
-
-/// Iterates all declarations containing `trigram`.
-pub fn iterate(store: TrigramStore, trigram: Trigram) TrigramIterator {
-    return .{
-        .extra = store.extra.items,
-        .extra_index = store.lookup.get(trigram),
-    };
+pub fn getDeclarationsForTrigram(store: TrigramStore, trigram: Trigram) ?[]const Declaration.Index {
+    return store.decls.slice(@intCast(store.lookup.getIndex(trigram) orelse return null));
 }

--- a/src/compacting_multi_list.zig
+++ b/src/compacting_multi_list.zig
@@ -1,0 +1,153 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+fn growCapacity(current: u32, minimum: u32) u32 {
+    var new = current;
+    while (true) {
+        new +|= new / 2 + 8;
+        if (new >= minimum)
+            return new;
+    }
+}
+
+/// Represents multiple append-only lists efficiently.
+/// Intended for use in MultiMap-like scenarios.
+/// Requires a known capacity.
+///
+/// Used in two phases:
+///     - Compacting: fast append-only
+///     - Compacted: made contiguous, fast to access
+pub fn CompactingMultiList(comptime T: type) type {
+    return struct {
+        const MultiList = @This();
+
+        pub const Compacted = struct {
+            data: []T,
+            starts: []u32,
+
+            pub fn len(compacted: Compacted, list: u32) u32 {
+                return compacted.starts[list + 1] - compacted.starts[list];
+            }
+
+            pub fn slice(compacted: Compacted, list: u32) []T {
+                return compacted.data[compacted.starts[list]..][0..compacted.len(list)];
+            }
+
+            pub fn deinit(compacted: *Compacted, allocator: std.mem.Allocator) void {
+                allocator.free(compacted.data);
+                allocator.free(compacted.starts);
+                compacted.* = undefined;
+            }
+        };
+
+        const ListAndIndex = struct { list: u32, index: u32 };
+        comptime {
+            std.debug.assert(@bitSizeOf(ListAndIndex) == 64);
+        }
+
+        // MultiArrayList causes a slowdown here.
+        data: [*]T = undefined,
+        lists_and_indices: [*]ListAndIndex = undefined,
+
+        len: u32 = 0,
+        capacity: u32 = 0,
+
+        next_list_indices: std.ArrayListUnmanaged(u32) = .{},
+
+        pub fn ensureTotalCapacity(multi: *MultiList, allocator: std.mem.Allocator, minimum_capacity: u32) Allocator.Error!void {
+            if (multi.capacity >= minimum_capacity) return;
+
+            const new_capacity = growCapacity(multi.capacity, minimum_capacity);
+
+            inline for (.{ &multi.data, &multi.lists_and_indices }, .{ T, ListAndIndex }) |many, MT| {
+                if (!allocator.resize(many.*[0..multi.capacity], new_capacity)) {
+                    const new_memory = try allocator.alloc(MT, new_capacity);
+                    @memcpy(new_memory[0..multi.len], many.*[0..multi.len]);
+                    allocator.free(many.*[0..multi.capacity]);
+                    many.* = new_memory.ptr;
+                }
+            }
+
+            multi.capacity = new_capacity;
+        }
+
+        fn addOneAssumeCapacity(multi: *MultiList) u32 {
+            multi.len += 1;
+            return @intCast(multi.len - 1);
+        }
+
+        pub fn appendToNewListAssumeCapacity(multi: *MultiList, allocator: std.mem.Allocator, item: T) Allocator.Error!u32 {
+            const new = multi.addOneAssumeCapacity();
+
+            const new_list: u32 = @intCast(multi.next_list_indices.items.len);
+
+            multi.data[new] = item;
+            multi.lists_and_indices[new] = .{
+                .list = new_list,
+                .index = 0,
+            };
+
+            try multi.next_list_indices.append(allocator, 1);
+
+            return new_list;
+        }
+
+        pub fn appendAssumeCapacity(multi: *MultiList, list: u32, item: T) void {
+            const index = &multi.next_list_indices.items[list];
+
+            const new = multi.addOneAssumeCapacity();
+
+            multi.data[new] = item;
+            multi.lists_and_indices[new] = .{
+                .list = list,
+                .index = index.*,
+            };
+
+            index.* += 1;
+        }
+
+        pub fn deinit(multi: *MultiList, allocator: std.mem.Allocator) void {
+            if (multi.capacity != 0) {
+                allocator.free(multi.data[0..multi.capacity]);
+                allocator.free(multi.lists_and_indices[0..multi.capacity]);
+            }
+
+            multi.next_list_indices.deinit(allocator);
+
+            multi.* = undefined;
+        }
+
+        /// `CompactingMultiList` may be `deinit`ed after this function.
+        pub fn compact(multi: MultiList, allocator: std.mem.Allocator) Allocator.Error!Compacted {
+            const lens = multi.next_list_indices.items;
+
+            if (lens.len == 0) {
+                return .{
+                    .data = &.{},
+                    .starts = &.{},
+                };
+            }
+
+            const data = try allocator.alloc(T, multi.len);
+            const starts = try allocator.alloc(u32, multi.next_list_indices.items.len + 1);
+
+            starts[0] = 0;
+            starts[starts.len - 1] = multi.len;
+
+            var sum: u32 = 0;
+            for (lens[0 .. lens.len - 1], starts[1 .. starts.len - 1]) |len, *start| {
+                sum += len;
+                start.* = sum;
+            }
+
+            for (multi.data[0..multi.len], multi.lists_and_indices[0..multi.len]) |datum, list_and_index| {
+                data[starts[list_and_index.list] + list_and_index.index] = datum;
+            }
+
+            return .{
+                .data = data,
+                .starts = starts,
+            };
+        }
+    };
+}

--- a/src/features/workspace_symbols.zig
+++ b/src/features/workspace_symbols.zig
@@ -1,0 +1,30 @@
+const std = @import("std");
+const DeclarationIndex = @import("../analysis.zig").Declaration.Index;
+
+/// Asserts `@min(a.len, b.len) <= out.len`.
+pub fn mergeIntersection(a: []const DeclarationIndex, b: []const DeclarationIndex, out: []DeclarationIndex) u32 {
+    std.debug.assert(@min(a.len, b.len) <= out.len);
+
+    var out_idx: u32 = 0;
+
+    var a_idx: u32 = 0;
+    var b_idx: u32 = 0;
+
+    while (a_idx < a.len and b_idx < b.len) {
+        const a_val = a[a_idx];
+        const b_val = b[b_idx];
+
+        if (a_val == b_val) {
+            out[out_idx] = a_val;
+            out_idx += 1;
+            a_idx += 1;
+            b_idx += 1;
+        } else if (@intFromEnum(a_val) < @intFromEnum(b_val)) {
+            a_idx += 1;
+        } else {
+            b_idx += 1;
+        }
+    }
+
+    return out_idx;
+}

--- a/tests/language_features/cimport.zig
+++ b/tests/language_features/cimport.zig
@@ -109,7 +109,7 @@ fn testTranslate(c_source: []const u8) !translate_c.Result {
     var ctx = try Context.init();
     defer ctx.deinit();
 
-    const result = (try translate_c.translate(allocator, zls.DocumentStore.Config.fromMainConfig(ctx.server.config), &.{}, c_source)).?;
+    const result = (try translate_c.translate(allocator, zls.DocumentStore.Config.fromMainConfig(ctx.server.config, &.{}), &.{}, c_source)).?;
 
     switch (result) {
         .success => |uri| {


### PR DESCRIPTION
**Note: I plan on editing this write-up and publishing it someplace once this PR is merged :)**

## Introduction

We're seeking to add workspace symbols, that is the ability to search for declarations by name across all the files in your editor's file tree, to ZLS. This incurs significant construction and access overhead which must be minimized to maintain interactivity, which is crucial in the editor environments where ZLS is run.

## N-grams and trigrams

An n-gram is a chunk of text of size `n`. It is produced by sliding a window of size `n` and stride 1 across a larger chunk of text, ending when a new window of size `n` cannot be created. A trigram is an n-gram where `n = 3`.

To obtain the trigrams of `agent`, for example, we obtain the first 3 characters, `age`, then shift our window by 1 to obtain `gen`, and again to obtain `ent`. Shifting our window by 1 again would not yield 3 characters, so we stop here. Thus, the trigrams of agent are `age`, `gen`, and `ent`.

N-grams are a nice way to execute approximate searches over a large corpus of text, allowing the consideration not only the entirety, prefix, or suffix of a search target, but also all of its constituent parts. Trigrams also enable efficient large-scale regular expression searches (see [Zoekt](https://github.com/sourcegraph/zoekt) from my ex-employer Sourcegraph), but that's out of scope for this article.

## Indexing

We need to index the name of every single global constant, variable, and function declaration. This is easily doable with the now-refactored [DocumentScope](https://github.com/zigtools/zls/blob/34ab587a9e8c180a1a808e7fd52007b67b35663f/src/DocumentScope.zig), which lists all declarations in a single contiguous list.

<!-- TODO: Explain what DocumentScope is -->

Note that we could perform trigram indexing immediately during the construction of the `DocumentScope`, but that would incur overhead on every edit that we'd rather split into a separate task in our multithreaded setup to keep ZLS fast and responsive.

We can begin by attaching a flag, `should_be_indexed_for_trigrams`, during the construction of the `DocumentScope` to each declaration identifying whether it's one of our search targets, thus preventing locals and symbols with names shorter than three characters long from being indexed.

During indexing, we iterate over the declarations for each document and find the trigrams for their names. We then create an inverse mapping from each trigram in the declaration's name to the declaration.

So for example, if declaration `Declaration.Index(1)` has name `agent`, our inverse mapping would look like this:
```
age -> [all other declarations containing trigram age ..., Declaration.Index(1)]
gen -> [all other declarations containing trigram gen ..., Declaration.Index(1)]
ent -> [all other declarations containing trigram ent ..., Declaration.Index(1)]
```

This inverse mapping is constructed per-document. After it is constructed, we also construct a Binary Fuse filter to quickly disqualify documents that do not contain certain trigrams at query time.

## Querying

We begin by obtaining the trigrams for our query. We then iterate through all our documents and check if each document contains each trigram in our query via the Binary Fuse filter, which cannot return false negatives but can return false positives, albeit with a very low false positive rate. This allows us to reduce our computation to only documents that likely have all our query trigrams, and is especially effective for longer queries.

Once we've gathered our candidate documents, querying is essentially just performing an intersection.

We use a "merge intersection," which is ripped out of merge sort, to intersect lists. [King](https://github.com/kprotty) tried beating this approach in a couple of purely hashmap-based ways, but with our setup which mostly involves many small inverse mappings (~10,000 trigrams with ~30 declarations each, for example), the merge intersection always won out.

I took a look at and partially implemented [Fast Set Intersection in Memory](https://arxiv.org/pdf/1103.2409), but it seems to be significant overkill for this sort of small intersection application. In Section 4, "Experimental Evaluation," they show that merge intersection performs rather well and sometimes comparably to the implementations shown in the paper for small intersection sizes, so that's what we're sticking with unless [someone can find a better solution](https://github.com/zigtools/trigram-bench).
