### PR TITLE
fix: 0.13.0-dev.68+b86c4bde6 compatibility

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -7,10 +7,10 @@ const zls_version = std.SemanticVersion{ .major = 0, .minor = 13, .patch = 0 };
 const zls_version_is_tagged: bool = false;
 
 /// Specify the minimum Zig version that is required to compile and test ZLS:
-/// ComptimeStringMap: return a regular struct and optimize
+/// Rename Dir.writeFile2 -> Dir.writeFile and update all callsites
 ///
 /// Must match the `minimum_zig_version` in `build.zig.zon`.
-const minimum_zig_version = "0.13.0-dev.33+8af59d1f9";
+const minimum_zig_version = "0.13.0-dev.68+b86c4bde6";
 
 /// Specify the minimum Zig version that is required to run ZLS:
 /// Release 0.12.0

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,7 +3,7 @@
     // Must match the `zls_version` in `build.zig`
     .version = "0.13.0-dev",
     // Must match the `minimum_zig_version` in `build.zig`
-    .minimum_zig_version = "0.12.0",
+    .minimum_zig_version = "0.13.0-dev.68+b86c4bde6",
     // whenever the dependencies are updated, run `zon2nix > deps.nix`
     .dependencies = .{
         .known_folders = .{

--- a/flake.lock
+++ b/flake.lock
@@ -83,11 +83,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1713995372,
-        "narHash": "sha256-fFE3M0vCoiSwCX02z8VF58jXFRj9enYUSTqjyHAjrds=",
+        "lastModified": 1714971268,
+        "narHash": "sha256-IKwMSwHj9+ec660l+I4tki/1NRoeGpyA2GdtdYpAgEw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dd37924974b9202f8226ed5d74a252a9785aedf8",
+        "rev": "27c13997bf450a01219899f5a83bd6ffbfc70d3c",
         "type": "github"
       },
       "original": {
@@ -130,11 +130,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714133353,
-        "narHash": "sha256-oDA4fGiFPxwiLHTJjY2hWn06Dg4yFW+EH/U9FTL8oRY=",
+        "lastModified": 1715041400,
+        "narHash": "sha256-yI67g+yU2J/tjytr9cTk51feKjLc+f9+BKE1KjlMNLQ=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "751dd89e227c60e89c6362fc5cdd5cb814e3f1ba",
+        "rev": "48bcb35d1d59509010af9a3da06af8750ab9593b",
         "type": "github"
       },
       "original": {

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -1169,7 +1169,7 @@ fn resolveConfiguration(
         const build_config_path = try std.fs.path.join(allocator, &[_][]const u8{ global_cache_path, "BuildConfig.zig" });
         defer allocator.free(build_config_path);
 
-        std.fs.cwd().writeFile2(.{
+        std.fs.cwd().writeFile(.{
             .sub_path = build_config_path,
             .data = @embedFile("build_runner/BuildConfig.zig"),
         }) catch |err| {
@@ -1177,7 +1177,7 @@ fn resolveConfiguration(
             break :blk;
         };
 
-        std.fs.cwd().writeFile2(.{
+        std.fs.cwd().writeFile(.{
             .sub_path = build_runner_path,
             .data = switch (result.build_runner_version.?) {
                 inline else => |tag| @embedFile("build_runner/" ++ @tagName(tag) ++ ".zig"),
@@ -1215,7 +1215,7 @@ fn resolveConfiguration(
 
         const builtin_path = try std.fs.path.join(config_arena, &.{ global_cache_path, "builtin.zig" });
 
-        std.fs.cwd().writeFile2(.{
+        std.fs.cwd().writeFile(.{
             .sub_path = builtin_path,
             .data = run_result.stdout,
         }) catch |err| {

--- a/src/ZigCompileServer.zig
+++ b/src/ZigCompileServer.zig
@@ -100,13 +100,13 @@ pub fn serveMessage(
     var iovecs: [10]std.posix.iovec_const = undefined;
     const header_le = bswap(header);
     iovecs[0] = .{
-        .iov_base = @as([*]const u8, @ptrCast(&header_le)),
-        .iov_len = @sizeOf(OutMessage.Header),
+        .base = @as([*]const u8, @ptrCast(&header_le)),
+        .len = @sizeOf(OutMessage.Header),
     };
     for (bufs, iovecs[1 .. bufs.len + 1]) |buf, *iovec| {
         iovec.* = .{
-            .iov_base = buf.ptr,
-            .iov_len = buf.len,
+            .base = buf.ptr,
+            .len = buf.len,
         };
     }
     try client.out.writevAll(iovecs[0 .. bufs.len + 1]);


### PR DESCRIPTION
Summary:
- use std.fs.cwd().writeFile instead of deprecated std.fs.cwd().writeFile2
- rename the members of the new std.posix.iovec_const
- bump minimum_zig_version 0.13.0-dev.33+8af59d1f9 => 0.13.0-dev.68+b86c4bde6