### PR TITLE
Fix `orelse` type resolution

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -1875,13 +1875,29 @@ fn resolveTypeOfNodeUncached(analyser: *Analyser, node_handle: NodeWithHandle) e
                 label_token: ?Ast.TokenIndex,
                 then_expr: Ast.Node.Index,
                 else_expr: Ast.Node.Index,
-            } = if (ast.fullWhile(tree, node)) |while_node|
-                .{
+            } = if (ast.fullWhile(tree, node)) |while_node| no_hang: {
+
+                // while (true) {} is a noreturn type
+                if (try analyser.resolveTypeOfNodeInternal(.{ .node = while_node.ast.cond_expr, .handle = handle })) |cond_type| {
+                    switch (cond_type.data) {
+                        .ip_index => |payload| {
+                            switch (payload.index) {
+                                .bool_true => {
+                                    return try Type.typeValFromIP(analyser, .noreturn_type);
+                                },
+                                else => {},
+                            }
+                        },
+                        else => {},
+                    }
+                }
+
+                break :no_hang .{
                     .label_token = while_node.label_token,
                     .then_expr = while_node.ast.then_expr,
                     .else_expr = while_node.ast.else_expr,
-                }
-            else if (ast.fullFor(tree, node)) |for_node|
+                };
+            } else if (ast.fullFor(tree, node)) |for_node|
                 .{
                     .label_token = for_node.label_token,
                     .then_expr = for_node.ast.then_expr,
@@ -2144,10 +2160,13 @@ fn resolveTypeOfNodeUncached(analyser: *Analyser, node_handle: NodeWithHandle) e
         .switch_case,
         .switch_case_inline,
         .switch_range,
+        => {},
         .@"continue",
         .@"break",
         .@"return",
-        => {},
+        => {
+            return try Type.typeValFromIP(analyser, .noreturn_type);
+        },
 
         .@"await",
         .@"suspend",

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -1863,29 +1863,13 @@ fn resolveTypeOfNodeUncached(analyser: *Analyser, node_handle: NodeWithHandle) e
                 label_token: ?Ast.TokenIndex,
                 then_expr: Ast.Node.Index,
                 else_expr: Ast.Node.Index,
-            } = if (ast.fullWhile(tree, node)) |while_node| no_hang: {
-
-                // while (true) {} is a noreturn type
-                if (try analyser.resolveTypeOfNodeInternal(.{ .node = while_node.ast.cond_expr, .handle = handle })) |cond_type| {
-                    switch (cond_type.data) {
-                        .ip_index => |payload| {
-                            switch (payload.index) {
-                                .bool_true => {
-                                    return try Type.typeValFromIP(analyser, .noreturn_type);
-                                },
-                                else => {},
-                            }
-                        },
-                        else => {},
-                    }
-                }
-
-                break :no_hang .{
+            } = if (ast.fullWhile(tree, node)) |while_node|
+                .{
                     .label_token = while_node.label_token,
                     .then_expr = while_node.ast.then_expr,
                     .else_expr = while_node.ast.else_expr,
-                };
-            } else if (ast.fullFor(tree, node)) |for_node|
+                }
+            else if (ast.fullFor(tree, node)) |for_node|
                 .{
                     .label_token = for_node.label_token,
                     .then_expr = for_node.ast.then_expr,

--- a/tests/lsp_features/hover.zig
+++ b/tests/lsp_features/hover.zig
@@ -554,6 +554,84 @@ test "optional" {
         \\
         \\Go to [S](file:///test.zig#L1)
     );
+
+    try testHover(
+        \\const foo: ?i32 = 5;
+        \\const b<cursor>ar = foo orelse 0;
+    ,
+        \\```zig
+        \\const bar = foo orelse 0
+        \\```
+        \\```zig
+        \\(i32)
+        \\```
+    );
+
+    try testHover(
+        \\const foo: ?i32 = 5;
+        \\const b<cursor>ar = foo orelse foo;
+    ,
+        \\```zig
+        \\const bar = foo orelse foo
+        \\```
+        \\```zig
+        \\(?i32)
+        \\```
+    );
+
+    try testHover(
+        \\const foo: ?i32 = 5;
+        \\const b<cursor>ar = foo orelse unreachable;
+    ,
+        \\```zig
+        \\const bar = foo orelse unreachable
+        \\```
+        \\```zig
+        \\(i32)
+        \\```
+    );
+
+    try testHover(
+        \\fn foo(a: ?i32) void {
+        \\    const b<cursor>ar = a orelse return;
+        \\}
+    ,
+        \\```zig
+        \\const bar = a orelse return
+        \\```
+        \\```zig
+        \\(i32)
+        \\```
+    );
+
+    try testHover(
+        \\fn foo() void {
+        \\    const array: [1]?i32 = [1]?i32{ 4 };
+        \\    for (array) |elem| {
+        \\        const b<cursor>ar = elem orelse continue;
+        \\    }
+        \\}
+    ,
+        \\```zig
+        \\const bar = elem orelse continue
+        \\```
+        \\```zig
+        \\(i32)
+        \\```
+    );
+
+    try testHover(
+        \\fn foo(foo: ?i32) void {
+        \\    const b<cursor>ar = foo orelse while (true) {};
+        \\}
+    ,
+        \\```zig
+        \\const bar = foo orelse while (true) {}
+        \\```
+        \\```zig
+        \\(i32)
+        \\```
+    );
 }
 
 test "error union" {

--- a/tests/lsp_features/hover.zig
+++ b/tests/lsp_features/hover.zig
@@ -619,19 +619,6 @@ test "optional" {
         \\(i32)
         \\```
     );
-
-    try testHover(
-        \\fn foo(foo: ?i32) void {
-        \\    const b<cursor>ar = foo orelse while (true) {};
-        \\}
-    ,
-        \\```zig
-        \\const bar = foo orelse while (true) {}
-        \\```
-        \\```zig
-        \\(i32)
-        \\```
-    );
 }
 
 test "error union" {


### PR DESCRIPTION
Fixes #1330 

See the added tests, they make it pretty clear. One example:

```zig
const foo: ?i32 = 5;
const b<cursor>ar = foo orelse foo;
```

outputs

```zig
?i32
```


This is my first PR so I'd be happy for any pointers.