### PR TITLE
fix: references/rename for struct_init_one, struct_init_one_comma

### DIFF
--- a/src/features/references.zig
+++ b/src/features/references.zig
@@ -100,6 +100,7 @@ const Builder = struct {
         const datas = tree.nodes.items(.data);
         const token_tags = tree.tokens.items(.tag);
         const starts = tree.tokens.items(.start);
+        const main_tokens = tree.nodes.items(.main_token);
 
         switch (node_tags[node]) {
             .identifier,
@@ -127,6 +128,23 @@ const Builder = struct {
 
                 if (builder.decl_handle.eql(child)) {
                     try builder.add(handle, datas[node].rhs);
+                }
+            },
+            .struct_init_one,
+            .struct_init_one_comma,
+            => {
+                if (datas[node].rhs == 0) {
+                    return;
+                }
+
+                const field_token_idx = main_tokens[node] + 2; // lbrace, '.', *then* the field we're looking for
+                const field_symbol = offsets.tokenToSlice(tree, field_token_idx);
+
+                var nodes = [_]Ast.Node.Index{datas[node].lhs};
+                const lookup = try builder.analyser.lookupSymbolFieldInit(handle, field_symbol, &nodes) orelse return;
+
+                if (builder.decl_handle.eql(lookup)) {
+                    try builder.add(handle, field_token_idx);
                 }
             },
             else => {},

--- a/src/features/references.zig
+++ b/src/features/references.zig
@@ -147,6 +147,28 @@ const Builder = struct {
                     try builder.add(handle, field_token_idx);
                 }
             },
+            .struct_init,
+            .struct_init_comma,
+            .struct_init_dot,
+            .struct_init_dot_comma,
+            .struct_init_dot_two,
+            .struct_init_dot_two_comma,
+            => {
+                var buffer: [2]Ast.Node.Index = undefined;
+                const struct_init = tree.fullStructInit(&buffer, node).?;
+                for (struct_init.ast.fields) |value_node| { // the node of `value` in `.name = value`
+                    const name_token = tree.firstToken(value_node) - 2; // math our way two token indexes back to get the `name`
+                    const name_loc = offsets.tokenToLoc(tree, name_token);
+                    const name = offsets.locToSlice(tree.source, name_loc);
+
+                    var nodes = [_]Ast.Node.Index{datas[node].lhs};
+                    const lookup = try builder.analyser.lookupSymbolFieldInit(handle, name, &nodes) orelse continue;
+
+                    if (builder.decl_handle.eql(lookup)) {
+                        try builder.add(handle, name_token);
+                    }
+                }
+            },
             else => {},
         }
     }

--- a/src/features/references.zig
+++ b/src/features/references.zig
@@ -100,7 +100,6 @@ const Builder = struct {
         const datas = tree.nodes.items(.data);
         const token_tags = tree.tokens.items(.tag);
         const starts = tree.tokens.items(.start);
-        const main_tokens = tree.nodes.items(.main_token);
 
         switch (node_tags[node]) {
             .identifier,
@@ -132,21 +131,6 @@ const Builder = struct {
             },
             .struct_init_one,
             .struct_init_one_comma,
-            => {
-                if (datas[node].rhs == 0) {
-                    return;
-                }
-
-                const field_token_idx = main_tokens[node] + 2; // lbrace, '.', *then* the field we're looking for
-                const field_symbol = offsets.tokenToSlice(tree, field_token_idx);
-
-                var nodes = [_]Ast.Node.Index{datas[node].lhs};
-                const lookup = try builder.analyser.lookupSymbolFieldInit(handle, field_symbol, &nodes) orelse return;
-
-                if (builder.decl_handle.eql(lookup)) {
-                    try builder.add(handle, field_token_idx);
-                }
-            },
             .struct_init,
             .struct_init_comma,
             .struct_init_dot,

--- a/src/features/references.zig
+++ b/src/features/references.zig
@@ -443,6 +443,7 @@ pub fn referencesHandler(server: *Server, arena: std.mem.Allocator, request: Gen
             break :z null;
         },
         .label => try Analyser.getLabelGlobal(source_index, handle, name),
+        .enum_literal => try analyser.getSymbolEnumLiteral(arena, handle, source_index, name),
         else => null,
     } orelse return null;
 

--- a/tests/lsp_features/references.zig
+++ b/tests/lsp_features/references.zig
@@ -107,6 +107,13 @@ test "struct field access" {
     );
 }
 
+// test "struct field init" {
+//     try testReferences(
+//         \\const S = struct {<0>: u32};
+//         \\const s = S{.<0> = 0 };
+//     );
+// }
+
 test "struct decl access" {
     try testReferences(
         \\const S = struct {

--- a/tests/lsp_features/references.zig
+++ b/tests/lsp_features/references.zig
@@ -107,7 +107,6 @@ test "struct field access" {
     );
 }
 
-
 test "struct decl access" {
     try testReferences(
         \\const S = struct {

--- a/tests/lsp_features/references.zig
+++ b/tests/lsp_features/references.zig
@@ -107,12 +107,6 @@ test "struct field access" {
     );
 }
 
-test "struct field init" {
-    try testReferences(
-        \\const S = struct {<0>: u32};
-        \\const s = S{.<0> = 0 };
-    );
-}
 
 test "struct decl access" {
     try testReferences(
@@ -126,6 +120,20 @@ test "struct decl access" {
         \\    <1>();
         \\}
         \\fn <1>() void {}
+    );
+}
+
+test "struct one field init" {
+    try testReferences(
+        \\const S = struct {<0>: u32};
+        \\const s = S{.<0> = 0 };
+    );
+}
+
+test "struct multi-field init" {
+    try testReferences(
+        \\const S = struct {<0>: u32, a: bool};
+        \\const s = S{.<0> = 0, .a = true};
     );
 }
 

--- a/tests/lsp_features/references.zig
+++ b/tests/lsp_features/references.zig
@@ -107,12 +107,12 @@ test "struct field access" {
     );
 }
 
-// test "struct field init" {
-//     try testReferences(
-//         \\const S = struct {<0>: u32};
-//         \\const s = S{.<0> = 0 };
-//     );
-// }
+test "struct field init" {
+    try testReferences(
+        \\const S = struct {<0>: u32};
+        \\const s = S{.<0> = 0 };
+    );
+}
 
 test "struct decl access" {
     try testReferences(


### PR DESCRIPTION
This fixes some cases where references to fields in some struct initializations aren't picked up, causing features like renaming and reference viewing to fail. Currently the fix only works *one* way, in that a rename invoked on the actual struct initialization will still fail, but *will* work when invoked on other locations such as the struct's definition or a field access. I took some time to try and fix the other direction, but I don't think I'm familiar enough with the codebase to do that yet. I added a test case for this but left it commented out as it currently fails. 

This fix only covers the cases of `.struct_init_one` and `.struct_init_one_comma`. I'd really like to look into fixing the other node cases (e.g. `.struct_init`, `.struct_init_comma`, etc. if I'm understanding things properly) but wanted to cover this first case and get some feedback/ a sanity check before proceeding on. Here's a quick demo showing both renaming and references with the improvements:

![zls_rename](https://github.com/zigtools/zls/assets/87077023/438a0e14-97fd-4e45-b8c8-9a5f46a61421)

Related Issues: #1837, #1700 
