### PR TITLE
feat: Integer literal hover support

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -3118,6 +3118,7 @@ pub const PositionContext = union(enum) {
     var_access: offsets.Loc,
     global_error_set,
     enum_literal: offsets.Loc,
+    number_literal: offsets.Loc,
     pre_label,
     label: bool,
     other,
@@ -3134,6 +3135,7 @@ pub const PositionContext = union(enum) {
             .field_access => |r| r,
             .var_access => |r| r,
             .enum_literal => |r| r,
+            .number_literal => |r| r,
             .pre_label => null,
             .label => null,
             .other => null,
@@ -3351,6 +3353,11 @@ pub fn getPositionContext(
                     }
                 },
                 .keyword_error => curr_ctx.ctx = .global_error_set,
+                .number_literal => {
+                    if (tok.loc.start <= doc_index and tok.loc.end >= doc_index) {
+                        return PositionContext{ .number_literal = tok.loc };
+                    }
+                },
                 else => curr_ctx.ctx = .empty,
             }
 

--- a/tests/lsp_features/hover.zig
+++ b/tests/lsp_features/hover.zig
@@ -96,63 +96,79 @@ test "integer literal" {
     try testHover(
         \\const foo = 4<cursor>2;
     ,
-        \\|||
-        \\|-|-|
-        \\|BIN|0b101010|
-        \\|OCT|0o52|
-        \\|DEC|42|
-        \\|HEX|0x2A|
+        \\| Base | Value    |
+        \\| ---- | -------- |
+        \\| BIN  | 0b101010 |
+        \\| OCT  | 0o52     |
+        \\| DEC  | 42       |
+        \\| HEX  | 0x2A     |
     );
     try testHover(
         \\const foo = -4<cursor>2;
     ,
-        \\|||
-        \\|-|-|
-        \\|BIN|-0b101010|
-        \\|OCT|-0o52|
-        \\|DEC|-42|
-        \\|HEX|-0x2A|
+        \\| Base | Value     |
+        \\| ---- | --------- |
+        \\| BIN  | -0b101010 |
+        \\| OCT  | -0o52     |
+        \\| DEC  | -42       |
+        \\| HEX  | -0x2A     |
     );
     try testHover(
         \\const foo = 0b101<cursor>010;
     ,
-        \\|||
-        \\|-|-|
-        \\|BIN|0b101010|
-        \\|OCT|0o52|
-        \\|DEC|42|
-        \\|HEX|0x2A|
+        \\| Base | Value    |
+        \\| ---- | -------- |
+        \\| BIN  | 0b101010 |
+        \\| OCT  | 0o52     |
+        \\| DEC  | 42       |
+        \\| HEX  | 0x2A     |
     );
     try testHover(
         \\const foo = -0b101<cursor>010;
     ,
-        \\|||
-        \\|-|-|
-        \\|BIN|-0b101010|
-        \\|OCT|-0o52|
-        \\|DEC|-42|
-        \\|HEX|-0x2A|
+        \\| Base | Value     |
+        \\| ---- | --------- |
+        \\| BIN  | -0b101010 |
+        \\| OCT  | -0o52     |
+        \\| DEC  | -42       |
+        \\| HEX  | -0x2A     |
     );
     try testHover(
         \\const foo = 0x2<cursor>A;
     ,
-        \\|||
-        \\|-|-|
-        \\|BIN|0b101010|
-        \\|OCT|0o52|
-        \\|DEC|42|
-        \\|HEX|0x2A|
+        \\| Base | Value    |
+        \\| ---- | -------- |
+        \\| BIN  | 0b101010 |
+        \\| OCT  | 0o52     |
+        \\| DEC  | 42       |
+        \\| HEX  | 0x2A     |
     );
     try testHover(
         \\const foo = -0x2<cursor>A;
     ,
-        \\|||
-        \\|-|-|
-        \\|BIN|-0b101010|
-        \\|OCT|-0o52|
-        \\|DEC|-42|
-        \\|HEX|-0x2A|
+        \\| Base | Value     |
+        \\| ---- | --------- |
+        \\| BIN  | -0b101010 |
+        \\| OCT  | -0o52     |
+        \\| DEC  | -42       |
+        \\| HEX  | -0x2A     |
     );
+    try testHoverWithOptions(
+        \\const foo = 4<cursor>2;
+    ,
+        \\BIN: 0b101010
+        \\OCT: 0o52
+        \\DEC: 42
+        \\HEX: 0x2A
+    , .{ .markup_kind = .plaintext });
+    try testHoverWithOptions(
+        \\const foo = -4<cursor>2;
+    ,
+        \\BIN: -0b101010
+        \\OCT: -0o52
+        \\DEC: -42
+        \\HEX: -0x2A
+    , .{ .markup_kind = .plaintext });
 }
 
 test "string literal" {

--- a/tests/lsp_features/hover.zig
+++ b/tests/lsp_features/hover.zig
@@ -96,44 +96,62 @@ test "integer literal" {
     try testHover(
         \\const foo = 4<cursor>2;
     ,
-        \\```zig
-        \\0b101010 | 42 | 0x2A
-        \\```
+        \\|||
+        \\|-|-|
+        \\|BIN|0b101010|
+        \\|OCT|0o52|
+        \\|DEC|42|
+        \\|HEX|0x2A|
     );
     try testHover(
         \\const foo = -4<cursor>2;
     ,
-        \\```zig
-        \\-0b101010 | -42 | -0x2A
-        \\```
+        \\|||
+        \\|-|-|
+        \\|BIN|-0b101010|
+        \\|OCT|-0o52|
+        \\|DEC|-42|
+        \\|HEX|-0x2A|
     );
     try testHover(
         \\const foo = 0b101<cursor>010;
     ,
-        \\```zig
-        \\0b101010 | 42 | 0x2A
-        \\```
+        \\|||
+        \\|-|-|
+        \\|BIN|0b101010|
+        \\|OCT|0o52|
+        \\|DEC|42|
+        \\|HEX|0x2A|
     );
     try testHover(
         \\const foo = -0b101<cursor>010;
     ,
-        \\```zig
-        \\-0b101010 | -42 | -0x2A
-        \\```
+        \\|||
+        \\|-|-|
+        \\|BIN|-0b101010|
+        \\|OCT|-0o52|
+        \\|DEC|-42|
+        \\|HEX|-0x2A|
     );
     try testHover(
         \\const foo = 0x2<cursor>A;
     ,
-        \\```zig
-        \\0b101010 | 42 | 0x2A
-        \\```
+        \\|||
+        \\|-|-|
+        \\|BIN|0b101010|
+        \\|OCT|0o52|
+        \\|DEC|42|
+        \\|HEX|0x2A|
     );
     try testHover(
         \\const foo = -0x2<cursor>A;
     ,
-        \\```zig
-        \\-0b101010 | -42 | -0x2A
-        \\```
+        \\|||
+        \\|-|-|
+        \\|BIN|-0b101010|
+        \\|OCT|-0o52|
+        \\|DEC|-42|
+        \\|HEX|-0x2A|
     );
 }
 

--- a/tests/lsp_features/hover.zig
+++ b/tests/lsp_features/hover.zig
@@ -92,6 +92,51 @@ test "literal" {
     );
 }
 
+test "integer literal" {
+    try testHover(
+        \\const foo = 4<cursor>2;
+    ,
+        \\```zig
+        \\0b101010 | 42 | 0x2A
+        \\```
+    );
+    try testHover(
+        \\const foo = -4<cursor>2;
+    ,
+        \\```zig
+        \\-0b101010 | -42 | -0x2A
+        \\```
+    );
+    try testHover(
+        \\const foo = 0b101<cursor>010;
+    ,
+        \\```zig
+        \\0b101010 | 42 | 0x2A
+        \\```
+    );
+    try testHover(
+        \\const foo = -0b101<cursor>010;
+    ,
+        \\```zig
+        \\-0b101010 | -42 | -0x2A
+        \\```
+    );
+    try testHover(
+        \\const foo = 0x2<cursor>A;
+    ,
+        \\```zig
+        \\0b101010 | 42 | 0x2A
+        \\```
+    );
+    try testHover(
+        \\const foo = -0x2<cursor>A;
+    ,
+        \\```zig
+        \\-0b101010 | -42 | -0x2A
+        \\```
+    );
+}
+
 test "string literal" {
     try testHover(
         \\const f<cursor>oo = "ipsum lorem";


### PR DESCRIPTION
This PR implements the base 2, 10, and 16 hover information for integer literals as proposed in #1835.

A few notes:

- I somewhat arbitrarily chose `i256` as the maximum width for parsing integer literals that won't fit within 64 bits as given by `std.zig.parseNumberLiteral()`. Should this be a wider type?

- fmt currently treats negatives a little oddly, but it is being given [some attention](https://github.com/ziglang/zig/issues/20152). Maybe the treatment of negative values here can be cleaned up a bit once some change are made?

- Octal encoding wasn't originally  requested in the issue, but that could be added here as well. Should it?