### PR TITLE
feat: Add hover for structs

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -496,6 +496,13 @@ pub fn getVariableSignature(
                 };
                 try members_source.append('\n');
                 try members_source.appendSlice(try trimCommonIndentation(arena, member_source_indented, 4));
+                switch (tree.nodes.items(.tag)[member]) {
+                    .container_field_init,
+                    .container_field_align,
+                    .container_field,
+                    => try members_source.append(','),
+                    else => {},
+                }
             }
 
             if (members_source.items.len == 0) break :end_token token + offset;

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -474,35 +474,15 @@ pub fn getVariableSignature(
                 if (!isNodePublic(tree, member)) continue;
 
                 const member_source_indented = switch (tree.nodes.items(.tag)[member]) {
-                    .fn_proto,
-                    .fn_proto_multi,
-                    .fn_proto_one,
-                    .fn_proto_simple,
-                    .fn_decl,
-                    => blk: {
-                        var inner_buffer: [1]Ast.Node.Index = undefined;
-                        const fn_proto = Ast.fullFnProto(tree, &inner_buffer, member).?;
-                        break :blk tree.source[member_line_start..offsets.tokenToLoc(tree, ast.lastToken(tree, fn_proto.ast.return_type)).end];
-                    },
                     .container_field_init,
                     .container_field_align,
                     .container_field,
-                    .global_var_decl,
-                    .local_var_decl,
-                    .aligned_var_decl,
-                    .simple_var_decl,
                     => tree.source[member_line_start..offsets.tokenToLoc(tree, ast.lastToken(tree, member)).end],
                     else => continue,
                 };
                 try members_source.append('\n');
                 try members_source.appendSlice(try trimCommonIndentation(arena, member_source_indented, 4));
-                switch (tree.nodes.items(.tag)[member]) {
-                    .container_field_init,
-                    .container_field_align,
-                    .container_field,
-                    => try members_source.append(','),
-                    else => {},
-                }
+                try members_source.append(',');
             }
 
             if (members_source.items.len == 0) break :end_token token + offset;

--- a/src/features/hover.zig
+++ b/src/features/hover.zig
@@ -125,13 +125,13 @@ fn hoverSymbolRecursive(
     var hover_text = std.ArrayList(u8).init(arena);
     const writer = hover_text.writer();
     if (markup_kind == .markdown) {
+        for (doc_strings.items) |doc|
+            try writer.print("{s}\n\n", .{doc});
         if (is_fn) {
             try writer.print("```zig\n{s}\n```", .{def_str});
         } else {
             try writer.print("```zig\n{s}\n```\n```zig\n({s})\n```", .{ def_str, resolved_type_str });
         }
-        for (doc_strings.items) |doc|
-            try writer.print("\n\n{s}", .{doc});
         if (referenced_types.len > 0)
             try writer.print("\n\n" ++ "Go to ", .{});
         for (referenced_types, 0..) |ref, index| {
@@ -142,13 +142,13 @@ fn hoverSymbolRecursive(
             try writer.print("[{s}]({s}#L{d})", .{ ref.str, ref.handle.uri, line });
         }
     } else {
+        for (doc_strings.items) |doc|
+            try writer.print("{s}\n\n", .{doc});
         if (is_fn) {
             try writer.print("{s}", .{def_str});
         } else {
             try writer.print("{s}\n({s})", .{ def_str, resolved_type_str });
         }
-        for (doc_strings.items) |doc|
-            try writer.print("\n\n{s}", .{doc});
     }
 
     return hover_text.items;

--- a/tests/lsp_features/hover.zig
+++ b/tests/lsp_features/hover.zig
@@ -326,7 +326,7 @@ test "struct" {
     ,
         \\```zig
         \\const S = struct {
-        \\    fld: u8
+        \\    fld: u8,
         \\}
         \\```
         \\```zig
@@ -349,9 +349,9 @@ test "struct" {
         \\
         \\```zig
         \\const FooStruct = struct {
-        \\    bar: u32
-        \\    baz: bool
-        \\    boo: MyInner
+        \\    bar: u32,
+        \\    baz: bool,
+        \\    boo: MyInner,
         \\    pub const MyInner = struct {
         \\        another_field: bool,
         \\    }
@@ -395,9 +395,9 @@ test "enum" {
     ,
         \\```zig
         \\const MyEnum = enum {
-        \\    foo
-        \\    bar
-        \\    baz
+        \\    foo,
+        \\    bar,
+        \\    baz,
         \\}
         \\```
         \\```zig
@@ -440,13 +440,13 @@ test "union" {
         \\  c_import: struct {
         \\      block: *Block,
         \\      src: LazySrcLoc,
-        \\  }
+        \\  },
         \\  comptime_ret_ty: struct {
         \\      block: *Block,
         \\      func: Air.Inst.Ref,
         \\      func_src: LazySrcLoc,
         \\      return_ty: Type,
-        \\  }
+        \\  },
         \\}
         \\```
         \\```zig

--- a/tests/lsp_features/hover.zig
+++ b/tests/lsp_features/hover.zig
@@ -309,13 +309,13 @@ test "struct" {
         \\		// many lines here
         \\    }
         \\
-        \\	fld: u8,
+        \\         fld: u8,
         \\};
     ,
         \\```zig
         \\const S = struct {
-        \\	fld: u8,
-        \\};
+        \\    fld: u8
+        \\}
         \\```
         \\```zig
         \\(type)
@@ -337,14 +337,13 @@ test "struct" {
         \\
         \\```zig
         \\const FooStruct = struct {
-        \\	bar: u32,
-        \\	baz: bool,
-        \\	boo: MyInner,
-        \\
-        \\	pub const MyInner = struct {
-        \\		another_field: bool,
-        \\	};
-        \\};
+        \\    bar: u32
+        \\    baz: bool
+        \\    boo: MyInner
+        \\    pub const MyInner = struct {
+        \\        another_field: bool,
+        \\    }
+        \\}
         \\```
         \\```zig
         \\(type)
@@ -361,27 +360,8 @@ test "struct" {
     ,
         \\```zig
         \\const EdgeCases = struct {
-        \\	pub fn myEdgeCase() void
-        \\};
-        \\```
-        \\```zig
-        \\(type)
-        \\```
-    );
-    try testHover(
-        \\const Edge<cursor>Cases = struct {
-        \\    const str = "something";
-        \\    pub const s = S{
-        \\                .fld = 0,
-        \\        };
-        \\};
-    ,
-        \\```zig
-        \\const EdgeCases = struct {
-        \\	pub const s = S{
-        \\	    .fld = 0,
-        \\	};
-        \\};
+        \\    pub fn myEdgeCase() void
+        \\}
         \\```
         \\```zig
         \\(type)
@@ -403,10 +383,20 @@ test "enum" {
     ,
         \\```zig
         \\const MyEnum = enum {
-        \\	foo,
-        \\	bar,
-        \\	baz,
-        \\};
+        \\    foo
+        \\    bar
+        \\    baz
+        \\}
+        \\```
+        \\```zig
+        \\(type)
+        \\```
+    );
+    try testHover(
+        \\pub const M<cursor>ode = enum { zig, zon };
+    ,
+        \\```zig
+        \\const Mode = enum { zig, zon }
         \\```
         \\```zig
         \\(type)
@@ -435,17 +425,17 @@ test "union" {
     ,
         \\```zig
         \\const ComptimeReason = union(enum) {
-        \\	c_import: struct {
-        \\		block: *Block,
-        \\		src: LazySrcLoc,
-        \\	},
-        \\	comptime_ret_ty: struct {
-        \\		block: *Block,
-        \\		func: Air.Inst.Ref,
-        \\		func_src: LazySrcLoc,
-        \\		return_ty: Type,
-        \\	},
-        \\};
+        \\  c_import: struct {
+        \\      block: *Block,
+        \\      src: LazySrcLoc,
+        \\  }
+        \\  comptime_ret_ty: struct {
+        \\      block: *Block,
+        \\      func: Air.Inst.Ref,
+        \\      func_src: LazySrcLoc,
+        \\      return_ty: Type,
+        \\  }
+        \\}
         \\```
         \\```zig
         \\(type)

--- a/tests/lsp_features/hover.zig
+++ b/tests/lsp_features/hover.zig
@@ -352,9 +352,6 @@ test "struct" {
         \\    bar: u32,
         \\    baz: bool,
         \\    boo: MyInner,
-        \\    pub const MyInner = struct {
-        \\        another_field: bool,
-        \\    }
         \\}
         \\```
         \\```zig
@@ -371,9 +368,7 @@ test "struct" {
         \\};
     ,
         \\```zig
-        \\const EdgeCases = struct {
-        \\    pub fn myEdgeCase() void
-        \\}
+        \\const EdgeCases = struct
         \\```
         \\```zig
         \\(type)

--- a/tests/lsp_features/hover.zig
+++ b/tests/lsp_features/hover.zig
@@ -303,6 +303,154 @@ test "struct" {
         \\(type)
         \\```
     );
+    try testHover(
+        \\const <cursor>S = struct {
+        \\	fn foo() void {
+        \\		// many lines here
+        \\    }
+        \\
+        \\	fld: u8,
+        \\};
+    ,
+        \\```zig
+        \\const S = struct {
+        \\	fld: u8,
+        \\};
+        \\```
+        \\```zig
+        \\(type)
+        \\```
+    );
+    try testHover(
+        \\/// Foo doc comment
+        \\const Foo<cursor>Struct = struct {
+        \\    bar: u32,
+        \\    baz: bool,
+        \\    boo: MyInner,
+        \\
+        \\    pub const MyInner = struct {
+        \\        another_field: bool,
+        \\    };
+        \\};
+    ,
+        \\ Foo doc comment
+        \\
+        \\```zig
+        \\const FooStruct = struct {
+        \\	bar: u32,
+        \\	baz: bool,
+        \\	boo: MyInner,
+        \\
+        \\	pub const MyInner = struct {
+        \\		another_field: bool,
+        \\	};
+        \\};
+        \\```
+        \\```zig
+        \\(type)
+        \\```
+    );
+    try testHover(
+        \\const Edge<cursor>Cases = struct {
+        \\    const str = "something";
+        \\    const s = S{
+        \\        .fld = 0,
+        \\    };
+        \\    pub fn myEdgeCase() void {}
+        \\};
+    ,
+        \\```zig
+        \\const EdgeCases = struct {
+        \\	pub fn myEdgeCase() void
+        \\};
+        \\```
+        \\```zig
+        \\(type)
+        \\```
+    );
+    try testHover(
+        \\const Edge<cursor>Cases = struct {
+        \\    const str = "something";
+        \\    pub const s = S{
+        \\                .fld = 0,
+        \\        };
+        \\};
+    ,
+        \\```zig
+        \\const EdgeCases = struct {
+        \\	pub const s = S{
+        \\	    .fld = 0,
+        \\	};
+        \\};
+        \\```
+        \\```zig
+        \\(type)
+        \\```
+    );
+}
+
+test "enum" {
+    try testHover(
+        \\const My<cursor>Enum = enum {
+        \\    foo,
+        \\    bar,
+        \\    baz,
+        \\
+        \\    fn enum_method() !void {
+        \\        return .{};
+        \\    }
+        \\};
+    ,
+        \\```zig
+        \\const MyEnum = enum {
+        \\	foo,
+        \\	bar,
+        \\	baz,
+        \\};
+        \\```
+        \\```zig
+        \\(type)
+        \\```
+    );
+}
+
+test "union" {
+    try testHover(
+        \\const Comptime<cursor>Reason = union(enum) {
+        \\  c_import: struct {
+        \\      block: *Block,
+        \\      src: LazySrcLoc,
+        \\  },
+        \\  comptime_ret_ty: struct {
+        \\      block: *Block,
+        \\      func: Air.Inst.Ref,
+        \\      func_src: LazySrcLoc,
+        \\      return_ty: Type,
+        \\  },
+        \\
+        \\  fn explain(cr: ComptimeReason, sema: *Sema, msg: ?*Module.ErrorMsg) !void {
+        \\      // many lines here
+        \\  }
+        \\};
+    ,
+        \\```zig
+        \\const ComptimeReason = union(enum) {
+        \\	c_import: struct {
+        \\		block: *Block,
+        \\		src: LazySrcLoc,
+        \\	},
+        \\	comptime_ret_ty: struct {
+        \\		block: *Block,
+        \\		func: Air.Inst.Ref,
+        \\		func_src: LazySrcLoc,
+        \\		return_ty: Type,
+        \\	},
+        \\};
+        \\```
+        \\```zig
+        \\(type)
+        \\```
+    );
 }
 
 test "sentinel values" {
@@ -733,14 +881,14 @@ test "function parameter" {
         \\    return a;
         \\}
     ,
+        \\ hello world
+        \\
         \\```zig
         \\a: u32
         \\```
         \\```zig
         \\(u32)
         \\```
-        \\
-        \\ hello world
     );
 }
 
@@ -855,6 +1003,8 @@ test "either types" {
         \\const either = if (undefined) A else B;
         \\const bar = either.<cursor>T;
     ,
+        \\small type
+        \\
         \\```zig
         \\const T = u32
         \\```
@@ -862,7 +1012,7 @@ test "either types" {
         \\(type)
         \\```
         \\
-        \\small type
+        \\large type
         \\
         \\```zig
         \\const T = u64
@@ -870,8 +1020,6 @@ test "either types" {
         \\```zig
         \\(type)
         \\```
-        \\
-        \\large type
     );
     try testHoverWithOptions(
         \\const A = struct {
@@ -885,15 +1033,15 @@ test "either types" {
         \\const either = if (undefined) A else B;
         \\const bar = either.<cursor>T;
     ,
+        \\small type
+        \\
         \\const T = u32
         \\(type)
         \\
-        \\small type
+        \\large type
         \\
         \\const T = u64
         \\(type)
-        \\
-        \\large type
     , .{ .markup_kind = .plaintext });
 }
 
@@ -902,14 +1050,14 @@ test "var decl comments" {
         \\///this is a comment
         \\const f<cursor>oo = 0 + 0;
     ,
+        \\this is a comment
+        \\
         \\```zig
         \\const foo = 0 + 0
         \\```
         \\```zig
         \\(unknown)
         \\```
-        \\
-        \\this is a comment
     );
 }
 
@@ -1043,16 +1191,16 @@ test "combine doc comments of declaration and definition" {
         \\    const baz = struct {};
         \\};
     ,
+        \\ Foo
+        \\
+        \\ Bar
+        \\
         \\```zig
         \\const baz = struct
         \\```
         \\```zig
         \\(type)
         \\```
-        \\
-        \\ Foo
-        \\
-        \\ Bar
     );
     try testHoverWithOptions(
         \\/// Foo
@@ -1062,12 +1210,12 @@ test "combine doc comments of declaration and definition" {
         \\    const baz = struct {};
         \\};
     ,
-        \\const baz = struct
-        \\(type)
-        \\
         \\ Foo
         \\
         \\ Bar
+        \\
+        \\const baz = struct
+        \\(type)
     , .{ .markup_kind = .plaintext });
 }
 
@@ -1078,16 +1226,16 @@ test "top-level doc comment" {
         \\/// A
         \\const S<cursor>elf = @This();
     ,
+        \\ A
+        \\
+        \\ B
+        \\
         \\```zig
         \\const Self = @This()
         \\```
         \\```zig
         \\(type)
         \\```
-        \\
-        \\ A
-        \\
-        \\ B
     );
 }
 

--- a/tests/lsp_features/hover.zig
+++ b/tests/lsp_features/hover.zig
@@ -304,6 +304,18 @@ test "struct" {
         \\```
     );
     try testHover(
+        \\const Str<cursor>uct = struct {
+        \\    fn foo() void {}
+        \\};
+    ,
+        \\```zig
+        \\const Struct = struct
+        \\```
+        \\```zig
+        \\(type)
+        \\```
+    );
+    try testHover(
         \\const <cursor>S = struct {
         \\	fn foo() void {
         \\		// many lines here


### PR DESCRIPTION
This PR adds hover support for structs, enums, and unions without displaying member functions, as discussed in #1568. Going off of [this comment](https://github.com/zigtools/zls/issues/1568#issuecomment-1813323060) from this issue, I also changed the final layout so that  doc comments appear on top rather than the bottom of the hover window. If this needs to be discussed further/ moved into a separate PR I'm happy to do so! 

A few examples: 

```
const S = struct {
	fn foo() void {
		// many lines here
    }

	fld: u8,
};
```
![image](https://github.com/zigtools/zls/assets/87077023/f5a872f8-9779-4dd3-aa63-a1996d46c0fb)

```zig
    const ComptimeReason = union(enum) {
        c_import: struct {
            block: *Block,
            src: LazySrcLoc,
        },
        comptime_ret_ty: struct {
            block: *Block,
            func: Air.Inst.Ref,
            func_src: LazySrcLoc,
            return_ty: Type,
        },

        fn explain(cr: ComptimeReason, sema: *Sema, msg: ?*Module.ErrorMsg) !void {
            const parent = msg orelse return;
        // many lines later...
    };
```

![image](https://github.com/zigtools/zls/assets/87077023/42352013-8630-482d-96c7-e914dfa50fbb)

cc: @llogick 
Closes #1568 