### PR TITLE
perf: Improve local variable reference finding

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -3811,7 +3811,7 @@ pub const DeclWithHandle = struct {
         };
     }
 
-    fn isPublic(self: DeclWithHandle) bool {
+    pub fn isPublic(self: DeclWithHandle) bool {
         return switch (self.decl) {
             .ast_node => |node| isNodePublic(self.handle.tree, node),
             else => true,

--- a/src/features/references.zig
+++ b/src/features/references.zig
@@ -466,7 +466,17 @@ pub fn referencesHandler(server: *Server, arena: std.mem.Allocator, request: Gen
             const scope_tag = DocumentScope.getScopeTag(try handle.getDocumentScope(), idx);
             switch (scope_tag) {
                 .function, .block => {
-                    break :blk false; // scan only the current document
+                    break :blk false;
+                },
+                .container => {
+                    switch (decl.decl) {
+                        .ast_node => |node_idx| {
+                            if (!Analyser.isNodePublic(decl.handle.tree, node_idx)) {
+                                break :blk false;
+                            }
+                        },
+                        else => {},
+                    }
                 },
                 else => {},
             }

--- a/src/features/references.zig
+++ b/src/features/references.zig
@@ -237,7 +237,7 @@ fn symbolReferences(
         .ast_node => {
             try builder.collectReferences(curr_handle, 0);
 
-            const source_index = offsets.positionToIndex(curr_handle.tree.source, request.position(), encoding);
+            const source_index = offsets.tokenToIndex(decl_handle.handle.tree, decl_handle.nameToken());
             // highlight requests only pertain to the current document, otherwise we can try to narrow things down
             const workspace = if (request == .highlight) false else blk: {
                 const doc_scope = try curr_handle.getDocumentScope();


### PR DESCRIPTION
This PR improves the time to find references and rename local variables. As suggested by @Techatrix in the discord, for certain cases the search for references can be limited to the current document rather than the entire project. After some brief testing with function-local variables in the zls project I saw a typical 4,500ms to <10ms improvement with debug builds. Testing with some of the larger files in zig itself, I saw a typical 20,000ms to 2,500ms improvement. Greater improvements are seen when using a `ReleaseSafe` build. I can spend some time gathering more numbers if that would be helpful :)

Related Issue: #1706 