### PR TITLE
fix: completion with try inside parens

### DIFF
--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -1041,6 +1041,11 @@ fn getEnumLiteralContext(
         .l_brace, .comma, .l_paren => {
             dot_context = getSwitchOrStructInitContext(tree, dot_token_index) orelse return null;
         },
+        .r_paren => { // i.e. `(try foo()).`
+            dot_context.likely = .enum_assignment;
+            dot_context.identifier_token_index = token_index - 3;
+            dot_context.need_ret_type = true;
+        },
         else => return null,
     }
     return dot_context;

--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -1769,15 +1769,15 @@ test "error union" {
         .{ .label = "alpha", .kind = .Field, .detail = "u32" },
     });
 
-    // try testCompletion(
-    //     \\const S = struct { alpha: u32 };
-    //     \\fn foo() error{Foo}!S {}
-    //     \\fn bar() error{Foo}!void {
-    //     \\    (try foo()).<cursor>
-    //     \\}
-    // , &.{
-    //     .{ .label = "alpha", .kind = .Field, .detail = "u32" },
-    // });
+    try testCompletion(
+        \\const S = struct { alpha: u32 };
+        \\fn foo() error{Foo}!S {}
+        \\fn bar() error{Foo}!void {
+        \\    (try foo()).<cursor>
+        \\}
+    , &.{
+        .{ .label = "alpha", .kind = .Field, .detail = "u32" },
+    });
 
     try testCompletion(
         \\const S = struct { alpha: u32 };


### PR DESCRIPTION
Was reading through old issues and worked out a fix for the commented out test case mentioned in [this comment](https://github.com/zigtools/zls/issues/1752#issuecomment-1931062895) from #1752. While this fixes the completion issue, it unfortunately does not address the original hover issue.