### PR TITLE
fix `identifierLocFromPosition` on escaped identifiers

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -4748,7 +4748,7 @@ pub fn identifierLocFromPosition(pos_index: usize, handle: *DocumentStore.Handle
     const tree = handle.tree;
     const token_index = offsets.sourceIndexToTokenIndex(tree, start_idx);
     if (tree.tokens.items(.tag)[token_index] == .identifier)
-        return offsets.tokenToLoc(tree, token_index);
+        return offsets.identifierTokenToNameLoc(tree, token_index);
 
     var end_idx = pos_index;
     while (end_idx < handle.tree.source.len and Analyser.isSymbolChar(handle.tree.source[end_idx])) {

--- a/tests/lsp_features/hover.zig
+++ b/tests/lsp_features/hover.zig
@@ -982,6 +982,19 @@ test "hover - destructuring" {
     );
 }
 
+test "escaped identifier" {
+    try testHover(
+        \\const @"f<cursor>oo" = 42;
+    ,
+        \\```zig
+        \\const @"foo" = 42
+        \\```
+        \\```zig
+        \\(comptime_int)
+        \\```
+    );
+}
+
 // https://github.com/zigtools/zls/issues/1378
 test "type reference cycle" {
     try testHover(


### PR DESCRIPTION
Fixes #1929