### PR TITLE
Inconsistent use of case on the index

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ zig build -Doptimize=ReleaseSafe
 
 ### Configuration Options
 
-You can configure zls by editing your `zls.json` configuration file.
+You can configure ZLS by editing your `zls.json` configuration file.
 Running `zls --show-config-path` will show a path to an already existing `zls.json` or a path to the local configuration folder instead.
 
-zls will look for a `zls.json` configuration file in multiple locations with the following priority:
+ZLS will look for a `zls.json` configuration file in multiple locations with the following priority:
 - In the local configuration folder of your OS (as provided by [known-folders](https://github.com/ziglibs/known-folders/blob/master/RESOURCES.md#folder-list))
 - In the global configuration folder of your OS (as provided by [known-folders](https://github.com/ziglibs/known-folders/blob/master/RESOURCES.md#folder-list))
 
@@ -118,7 +118,7 @@ The following LSP features are supported:
 
 ## Using as a library
 
-You can use zls as a library! [Check out this demo repo](https://github.com/zigtools/zls-as-lib-demo) for a good reference.
+You can use ZLS as a library! [Check out this demo repo](https://github.com/zigtools/zls-as-lib-demo) for a good reference.
 
 ## Related Projects
 


### PR DESCRIPTION
I think it's highly preferable to be consistent in how things are written in terms of what the eye gets, especially on the index page where new people usually look around for what's in store and how it might benefit them. Though it may seem like a minor detail, you'd be surprised how often inconsistencies like these catch the eye. It also happens to be the abbreviation of what this repository's all about and if you use it uppercase two times here and three times there, it's always better to do it everywhere, except for calling commands.