### PR TITLE
Fix absolute path detection for build on save diagnostics

### DIFF
--- a/src/features/diagnostics.zig
+++ b/src/features/diagnostics.zig
@@ -288,7 +288,11 @@ pub fn generateBuildOnSaveDiagnostics(
 
         const src_path = pos_and_diag_iterator.next() orelse continue;
         const absolute_src_path = if (std.fs.path.isAbsolute(src_path)) src_path else blk: {
-            const absolute_src_path = std.fs.path.join(arena, &.{ workspace_path, src_path }) catch continue;
+            const absolute_src_path = (if (src_path.len == 1)
+                // it's a drive letter
+                std.fs.path.join(arena, &.{ line[0..2], pos_and_diag_iterator.next() orelse continue })
+            else
+                std.fs.path.join(arena, &.{ workspace_path, src_path })) catch continue;
             if (!std.fs.path.isAbsolute(absolute_src_path)) continue;
             break :blk absolute_src_path;
         };


### PR DESCRIPTION
This patch detects drive letters.

I was trying to trigger some diagnostics using std.fmt. For awhile I couldn't tell if anything was working at all. But after a debug session, I figured out that the ':' following a drive letter was causing the line iterator to bail.

After this change I was able to see this:
![screenshot](https://github.com/zigtools/zls/assets/17990536/26a6e8fa-67f0-4196-a516-8fadc1769cc8)