### PR TITLE
Typo fixes in messages/comments

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -484,7 +484,7 @@ const PostMultiPartForm = struct {
                 .owner = owner,
                 .makeFn = make,
             }),
-            .uri = std.Uri.parse(owner.fmt("{}", .{uri})) catch unreachable, // super efficent dupe
+            .uri = std.Uri.parse(owner.fmt("{}", .{uri})) catch unreachable, // super efficient dupe
             .headers = headers,
         };
         return self;

--- a/src/DocumentStore.zig
+++ b/src/DocumentStore.zig
@@ -1065,7 +1065,7 @@ fn loadBuildConfiguration(self: *DocumentStore, build_file_uri: Uri) !std.json.P
     const parse_options = std.json.ParseOptions{
         // We ignore unknown fields so people can roll
         // their own build runners in libraries with
-        // the only requirement being general adherance
+        // the only requirement being general adherence
         // to the BuildConfig type
         .ignore_unknown_fields = true,
         .allocate = .alloc_always,

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -736,11 +736,11 @@ fn handleConfiguration(server: *Server, json: std.json.Value) error{OutOfMemory}
     const fields = std.meta.fields(configuration.Configuration);
     const result = switch (json) {
         .array => |arr| if (arr.items.len == fields.len) arr.items else {
-            log.err("workspace/configuration expectes an array of size {d} but received {d}", .{ fields.len, arr.items.len });
+            log.err("workspace/configuration expects an array of size {d} but received {d}", .{ fields.len, arr.items.len });
             return;
         },
         else => {
-            log.err("workspace/configuration expectes an array but received {s}", .{@tagName(json)});
+            log.err("workspace/configuration expects an array but received {s}", .{@tagName(json)});
             return;
         },
     };
@@ -931,7 +931,7 @@ pub fn updateConfiguration(server: *Server, new_config: configuration.Configurat
     // <---------------------------------------------------------->
 
     if (std.process.can_spawn and server.status == .initialized and server.config.zig_exe_path == null) {
-        // TODO there should a way to supress this message
+        // TODO there should a way to suppress this message
         server.showMessage(.Warning, "zig executable could not be found", .{});
     }
 

--- a/src/analyser/InternPool.zig
+++ b/src/analyser/InternPool.zig
@@ -3761,7 +3761,7 @@ const FormatContext = struct {
     ip: *InternPool,
 };
 
-// TODO add options for controling how types show be formatted
+// TODO add options for controlling how types show be formatted
 pub const FormatOptions = struct {
     debug: bool = false,
 };

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -3838,7 +3838,7 @@ pub const DeclWithHandle = struct {
             ),
             .function_parameter => |pay| blk: {
                 // the `get` function never fails on declarations from the DocumentScope but
-                // there may be manually created Declarations with invalid parameter indicies.
+                // there may be manually created Declarations with invalid parameter indices.
                 const param = pay.get(tree) orelse return null;
 
                 // handle anytype
@@ -4045,7 +4045,7 @@ fn findContainerScopeIndex(container_handle: NodeWithHandle) !?Scope.Index {
     } else null;
 }
 
-/// Collects all symbols/declarations that can be a acccessed on the given container type.
+/// Collects all symbols/declarations that can be a accessed on the given container type.
 pub fn collectDeclarationsOfContainer(
     analyser: *Analyser,
     /// a ast-node to a container type (i.e. `struct`, `union`, `enum`, `opaque`)

--- a/src/ast.zig
+++ b/src/ast.zig
@@ -543,7 +543,7 @@ pub fn lastToken(tree: Ast, node: Ast.Node.Index) Ast.TokenIndex {
             }
         },
         .@"defer" => {
-            // rhs is the defered expr
+            // rhs is the deferred expr
             if (datas[n].rhs != 0) {
                 n = datas[n].rhs;
             } else {

--- a/src/config_gen/config_gen.zig
+++ b/src/config_gen/config_gen.zig
@@ -425,7 +425,7 @@ const Builtin = struct {
 };
 
 /// parses a `langref.html.in` file and extracts builtins from this section: `https://ziglang.org/documentation/master/#Builtin-Functions`
-/// the documentation field contains poorly formated html
+/// the documentation field contains poorly formatted html
 fn collectBuiltinData(allocator: std.mem.Allocator, version: []const u8, langref_file: []const u8) error{OutOfMemory}![]Builtin {
     var tokenizer = Tokenizer{ .buffer = langref_file };
 

--- a/src/configuration.zig
+++ b/src/configuration.zig
@@ -214,7 +214,7 @@ pub fn findZig(allocator: std.mem.Allocator) error{OutOfMemory}!?[]const u8 {
         error.EnvironmentVariableNotFound => return null,
         error.OutOfMemory => |e| return e,
         error.InvalidWtf8 => |e| {
-            logger.err("failed to load 'PATH' enviorment variable: {}", .{e});
+            logger.err("failed to load 'PATH' environment variable: {}", .{e});
             return null;
         },
     };

--- a/src/features/code_actions.zig
+++ b/src/features/code_actions.zig
@@ -424,7 +424,7 @@ fn createCamelcaseText(allocator: std.mem.Allocator, identifier: []const u8) ![]
 /// indentation so that a discard is on a new line after the `insert_token`.
 ///
 /// `add_block_indentation` is used to add one level of indentation to the discard.
-/// `add_suffix_newline` is used to add a traling newline with indentation.
+/// `add_suffix_newline` is used to add a trailing newline with indentation.
 fn createDiscardText(
     builder: *Builder,
     identifier_name: []const u8,

--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -663,18 +663,18 @@ fn completeFileSystemStringLiteral(builder: *Builder, pos_context: Analyser.Posi
     if (pos_context == .string_literal and !DocumentStore.isBuildFile(builder.orig_handle.uri)) return;
     if (builder.source_index < string_content_loc.start or string_content_loc.end < builder.source_index) return;
 
-    const previous_seperator_index: ?usize = blk: {
+    const previous_separator_index: ?usize = blk: {
         var index: usize = builder.source_index;
         break :blk while (index > string_content_loc.start) : (index -= 1) {
             if (std.fs.path.isSep(source[index - 1])) break index - 1;
         } else null;
     };
 
-    const next_seperator_index: ?usize = for (builder.source_index..string_content_loc.end) |index| {
+    const next_separator_index: ?usize = for (builder.source_index..string_content_loc.end) |index| {
         if (std.fs.path.isSep(source[index])) break index;
     } else null;
 
-    const completing = offsets.locToSlice(source, .{ .start = string_content_loc.start, .end = previous_seperator_index orelse string_content_loc.start });
+    const completing = offsets.locToSlice(source, .{ .start = string_content_loc.start, .end = previous_separator_index orelse string_content_loc.start });
 
     var search_paths: std.ArrayListUnmanaged([]const u8) = .{};
     if (std.fs.path.isAbsolute(completing) and pos_context != .import_string_literal) {
@@ -689,9 +689,9 @@ fn completeFileSystemStringLiteral(builder: *Builder, pos_context: Analyser.Posi
         try search_paths.append(builder.arena, std.fs.path.dirname(document_path).?);
     }
 
-    const after_seperator_index = if (previous_seperator_index) |index| index + 1 else string_content_loc.start;
-    const insert_loc: offsets.Loc = .{ .start = after_seperator_index, .end = builder.source_index };
-    const replace_loc: offsets.Loc = .{ .start = after_seperator_index, .end = next_seperator_index orelse string_content_loc.end };
+    const after_separator_index = if (previous_separator_index) |index| index + 1 else string_content_loc.start;
+    const insert_loc: offsets.Loc = .{ .start = after_separator_index, .end = builder.source_index };
+    const replace_loc: offsets.Loc = .{ .start = after_separator_index, .end = next_separator_index orelse string_content_loc.end };
 
     const insert_range = offsets.locToRange(source, insert_loc, builder.server.offset_encoding);
     const replace_range = offsets.locToRange(source, replace_loc, builder.server.offset_encoding);
@@ -1049,7 +1049,7 @@ fn getEnumLiteralContext(
 }
 
 /// Looks for an identifier that can be passed to `collectContainerNodes()`
-/// Returns the token index of the identifer
+/// Returns the token index of the identifier
 /// If the identifier is a `fn_name`, `fn_arg_index` is the index of the fn's param
 fn getSwitchOrStructInitContext(
     tree: Ast,

--- a/src/offsets.zig
+++ b/src/offsets.zig
@@ -11,7 +11,7 @@ const types = @import("lsp.zig");
 const ast = @import("ast.zig");
 const Ast = std.zig.Ast;
 
-/// Specificies how the `character` field in `types.Position` is defined.
+/// Specifies how the `character` field in `types.Position` is defined.
 /// The Character encoding is negotiated during initialization with the Client/Editor.
 pub const Encoding = enum {
     /// Character offsets count UTF-8 code units (e.g. bytes).

--- a/tests/ErrorBuilder.zig
+++ b/tests/ErrorBuilder.zig
@@ -384,11 +384,11 @@ test "ErrorBuilder - write" {
     {
         eb.clearMessages();
         eb.unified = 0;
-        try eb.msgAtLoc("what about equallity?", "", .{ .start = 175, .end = 195 }, .warn, .{});
+        try eb.msgAtLoc("what about equality?", "", .{ .start = 175, .end = 195 }, .warn, .{});
 
         try std.testing.expectFmt(
             \\(whichever is greater), it obtains a difference, or deviation.
-            \\ ^^^^^^^^^^^^^^^^^^^^ warning: what about equallity?
+            \\ ^^^^^^^^^^^^^^^^^^^^ warning: what about equality?
         , "{}", .{eb});
     }
 

--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -3343,7 +3343,7 @@ fn testCompletionWithOptions(
             return error.InvalidCompletionDoc;
         }
 
-        try std.testing.expect(actual_completion.insertText == null); // 'insertText' is subject to interpretation on the client so 'textEdit' should be prefered
+        try std.testing.expect(actual_completion.insertText == null); // 'insertText' is subject to interpretation on the client so 'textEdit' should be preferred
 
         if (!ctx.server.client_capabilities.supports_snippets) {
             try std.testing.expectEqual(types.InsertTextFormat.PlainText, actual_completion.insertTextFormat orelse .PlainText);

--- a/tests/lsp_features/definition.zig
+++ b/tests/lsp_features/definition.zig
@@ -388,7 +388,7 @@ fn parseTaggedLoc(old_source: []const u8, phr: helper.CollectPlaceholdersResult,
 
     if (start.? > end.?) {
         std.debug.print("opening tag of '{s}' is after the closing tag", .{offsets.locToSlice(old_source, old_start_loc.?)});
-        return error.MissmatchedTags;
+        return error.MismatchedTags;
     }
 
     return .{ .start = start.?, .end = end.? };

--- a/tests/lsp_features/semantic_tokens.zig
+++ b/tests/lsp_features/semantic_tokens.zig
@@ -1276,7 +1276,7 @@ test "extern function" {
     });
 }
 
-test "builtin fuctions" {
+test "builtin functions" {
     try testSemanticTokens(
         \\const foo = @as(type, u32);
     , &.{


### PR DESCRIPTION
Was going through some ZLS changes and noticed that certain error messages had typos. Ended up doing a general pass to clean up typos in both comments and messages. Also includes a brief rename of a couple local variables and one error name.