### PR TITLE
feat: Code action for variable discards

### DIFF
--- a/src/features/code_actions.zig
+++ b/src/features/code_actions.zig
@@ -238,7 +238,7 @@ fn discardVariableOrConstant(
 
     try actions.append(builder.arena, .{
         .title = "discard value",
-        .kind = .@"source.fixAll",
+        .kind = if (discard_ref) .quickfix else .@"source.fixAll",
         .isPreferred = !discard_ref,
         .edit = try builder.createWorkspaceEdit(&.{builder.createTextEditPos(insert_index, new_text)}),
     });


### PR DESCRIPTION
I was interested in addressing https://github.com/ziglang/zig/issues/20584#issuecomment-2225438135, so I added a code action to discard variables using the `_ = &x;` "trick". Happy to close this PR if this isn't a desired feature; I really just wanted a reason to dig around the code action/ quick fix code a bit :)

Quick demo:

![var_discard](https://github.com/user-attachments/assets/c845cf8a-18b5-4c0a-a9b5-1b40de262b9f)
