### PR TITLE
build_runner: update to handle the changes made to the build runner when file watching was added

### DIFF
--- a/src/translate_c.zig
+++ b/src/translate_c.zig
@@ -248,8 +248,7 @@ pub fn translate(
                 return Result{ .failure = error_bundle };
             },
             else => {
-                log.warn("received unexpected message {} from zig compile server", .{header.tag});
-                return null;
+                zcs.pooler.fifo(.in).discard(header.bytes_len);
             },
         }
     }


### PR DESCRIPTION
The build runner now takes the zig lib dir as a positional argument: https://github.com/ziglang/zig/commit/a3c20dffaed77727494d34f7b4b03c0d10771270.