### PR TITLE
revamp CLI and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,15 @@
 <img src="https://raw.githubusercontent.com/zigtools/zls/master/.github/assets/zls-opt.svg" alt="Zig Language Server" width=200>
 
-[![CI](https://github.com/zigtools/zls/workflows/CI/badge.svg)](https://github.com/zigtools/zls/actions) [![codecov](https://codecov.io/github/zigtools/zls/graph/badge.svg?token=WE18MPF00W)](https://codecov.io/github/zigtools/zls)
+[![CI](https://github.com/zigtools/zls/workflows/CI/badge.svg)](https://github.com/zigtools/zls/actions)
+[![codecov](https://codecov.io/github/zigtools/zls/graph/badge.svg?token=WE18MPF00W)](https://codecov.io/github/zigtools/zls)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 **Need support? Wanna help out? Join our [Discord server](https://discord.gg/5m5U3qpUhk)!**
 
 The Zig Language Server (ZLS) is a tool that implements Microsoft's Language Server Protocol for Zig in Zig. In simpler terms: it'll provide you with completions, go-to definition, [etc.](#features) when you write Zig code!
 
-<!-- omit in toc -->
-## Table Of Contents
-
-- [Installation](#installation)
-  - [From Source](#from-source)
-  - [Configuration Options](#configuration-options)
-  - [Per-build Configuration Options](#per-build-configuration-options)
-    - [`BuildOption`](#buildoption)
-- [Features](#features)
-- [Using as a library](#using-as-a-library)
-- [Related Projects](#related-projects)
-- [Quick Thanks :)](#quick-thanks-)
-- [License](#license)
-
 ## Installation
 
-<!-- omit in toc -->
 ### See the [Installation Guide](https://github.com/zigtools/zls/wiki/Installation) for editor and binary installation instructions.
 
 ### From Source
@@ -35,74 +22,12 @@ cd zls
 zig build -Doptimize=ReleaseSafe
 ```
 
-### Configuration Options
-
-You can configure ZLS by editing your `zls.json` configuration file.
-Running `zls --show-config-path` will show a path to an already existing `zls.json` or a path to the local configuration folder instead.
-
-ZLS will look for a `zls.json` configuration file in multiple locations with the following priority:
-- In the local configuration folder of your OS (as provided by [known-folders](https://github.com/ziglibs/known-folders/blob/master/RESOURCES.md#folder-list))
-- In the global configuration folder of your OS (as provided by [known-folders](https://github.com/ziglibs/known-folders/blob/master/RESOURCES.md#folder-list))
-
-The following options are currently available.
-
-<!-- DO NOT EDIT | THIS SECTION IS AUTO-GENERATED | DO NOT EDIT -->
-| Option | Type | Default value | What it Does |
-| --- | --- | --- | --- |
-| `enable_snippets` | `bool` | `true` | Enables snippet completions when the client also supports them |
-| `enable_argument_placeholders` | `bool` | `true` | Whether to enable function argument placeholder completions |
-| `enable_build_on_save` | `bool` | `false` | Whether to enable build-on-save diagnostics |
-| `build_on_save_step` | `[]const u8` | `"install"` | Select which step should be executed on build-on-save |
-| `enable_autofix` | `bool` | `false` | Whether to automatically fix errors on save. Currently supports adding and removing discards. |
-| `semantic_tokens` | `enum` | `.full` | Set level of semantic tokens. Partial only includes information that requires semantic analysis. |
-| `enable_inlay_hints` | `bool` | `true` | Enables inlay hint support when the client also supports it |
-| `inlay_hints_show_variable_type_hints` | `bool` | `true` | Enable inlay hints for variable types |
-| `inlay_hints_show_struct_literal_field_type` | `bool` | `true` | Enable inlay hints for fields in struct and union literals |
-| `inlay_hints_show_parameter_name` | `bool` | `true` | Enable inlay hints for parameter names |
-| `inlay_hints_show_builtin` | `bool` | `true` | Enable inlay hints for builtin functions |
-| `inlay_hints_exclude_single_argument` | `bool` | `true` | Don't show inlay hints for single argument calls |
-| `inlay_hints_hide_redundant_param_names` | `bool` | `false` | Hides inlay hints when parameter name matches the identifier (e.g. foo: foo) |
-| `inlay_hints_hide_redundant_param_names_last_token` | `bool` | `false` | Hides inlay hints when parameter name matches the last token of a parameter node (e.g. foo: bar.foo, foo: &foo) |
-| `warn_style` | `bool` | `false` | Enables warnings for style guideline mismatches |
-| `highlight_global_var_declarations` | `bool` | `false` | Whether to highlight global var declarations |
-| `dangerous_comptime_experiments_do_not_enable` | `bool` | `false` | Whether to use the comptime interpreter |
-| `skip_std_references` | `bool` | `false` | When true, skips searching for references in std. Improves lookup speed for functions in user's code. Renaming and go-to-definition will continue to work as is |
-| `prefer_ast_check_as_child_process` | `bool` | `true` | Favor using `zig ast-check` instead of ZLS's fork |
-| `builtin_path` | `?[]const u8` | `null` | Path to 'builtin;' useful for debugging, automatically set if let null |
-| `zig_lib_path` | `?[]const u8` | `null` | Zig library path, e.g. `/path/to/zig/lib/zig`, used to analyze std library imports |
-| `zig_exe_path` | `?[]const u8` | `null` | Zig executable path, e.g. `/path/to/zig/zig`, used to run the custom build runner. If `null`, zig is looked up in `PATH`. Will be used to infer the zig standard library path if none is provided |
-| `build_runner_path` | `?[]const u8` | `null` | Path to the `build_runner.zig` file provided by ZLS. null is equivalent to `${executable_directory}/build_runner.zig` |
-| `global_cache_path` | `?[]const u8` | `null` | Path to a directory that will be used as zig's cache. null is equivalent to `${KnownFolders.Cache}/zls` |
-| `completion_label_details` | `bool` | `true` | When false, the function signature of completion results is hidden. Improves readability in some editors |
-<!-- DO NOT EDIT -->
-
-### Per-build Configuration Options
-
-The following options can be set on a per-project basis by placing `zls.build.json` in the project root directory next to `build.zig`.
-
-| Option | Type | Default value | What it Does |
-| --- | --- | --- | --- |
-| `relative_builtin_path` | `?[]const u8` | `null` | If present, this path is used to resolve `@import("builtin")` |
-| `build_options` | `?[]BuildOption` | `null` | If present, this contains a list of user options to pass to the build. This is useful when options are used to conditionally add packages in `build.zig`. |
-
-#### `BuildOption`
-
-`BuildOption` is defined as follows:
-
-```zig
-const BuildOption = struct {
-    name: []const u8,
-    value: ?[]const u8 = null,
-};
-```
-
-When `value` is present, the option will be passed the same as in `zig build -Dname=value`. When `value` is `null`, the option will be passed as a flag instead as in `zig build -Dflag`.
-
 ## Features
 
 ZLS supports most language features, including simple type function support, using namespace, payload capture type resolution, custom packages, cImport and others. Support for comptime and semantic analysis is Work-in-Progress.
 
 The following LSP features are supported:
+
 - Completions
 - Hover
 - Goto definition/declaration
@@ -115,10 +40,6 @@ The following LSP features are supported:
 - Code actions
 - Selection ranges
 - Folding regions
-
-## Using as a library
-
-You can use ZLS as a library! [Check out this demo repo](https://github.com/zigtools/zls-as-lib-demo) for a good reference.
 
 ## Related Projects
 
@@ -137,7 +58,3 @@ You can use ZLS as a library! [Check out this demo repo](https://github.com/zigt
 We'd like to take a second to thank all our awesome [contributors](https://github.com/zigtools/zls/graphs/contributors) and donators/backers/sponsors; if you have time or money to spare, consider partaking in either of these options - they help keep ZLS awesome for everyone!
 
 [![OpenCollective Backers](https://opencollective.com/zigtools/backers.svg?width=890&limit=1000)](https://opencollective.com/zigtools#category-CONTRIBUTE)
-
-## License
-
-MIT

--- a/build.zig
+++ b/build.zig
@@ -91,8 +91,6 @@ pub fn build(b: *Build) !void {
 
     const gen_cmd = b.addRunArtifact(gen_exe);
     gen_cmd.addArgs(&.{
-        "--readme-path",
-        b.pathFromRoot("README.md"),
         "--generate-config-path",
         b.pathFromRoot("src/Config.zig"),
         "--generate-schema-path",

--- a/build.zig
+++ b/build.zig
@@ -60,7 +60,6 @@ pub fn build(b: *Build) !void {
     const exe_options = b.addOptions();
     exe_options.step.name = "ZLS exe options";
     const exe_options_module = exe_options.createModule();
-    exe_options.addOption(std.log.Level, "log_level", b.option(std.log.Level, "log_level", "The Log Level to be used.") orelse .info);
     exe_options.addOption(bool, "enable_failing_allocator", b.option(bool, "enable_failing_allocator", "Whether to use a randomly failing allocator.") orelse false);
     exe_options.addOption(u32, "enable_failing_allocator_likelihood", b.option(u32, "enable_failing_allocator_likelihood", "The chance that an allocation will fail is `1/likelihood`") orelse 256);
     exe_options.addOption(bool, "use_gpa", b.option(bool, "use_gpa", "Good for debugging") orelse (optimize == .Debug));

--- a/src/DocumentStore.zig
+++ b/src/DocumentStore.zig
@@ -325,7 +325,7 @@ pub const Handle = struct {
         // special case when there is only one potential build file
         if (unresolved.potential_build_files.len == 1) blk: {
             const build_file = document_store.getOrLoadBuildFile(unresolved.potential_build_files[0]) orelse break :blk;
-            log.debug("Resolved build file of `{s}` as `{s}`", .{ self.uri, build_file.uri });
+            log.debug("Resolved build file of '{s}' as '{s}'", .{ self.uri, build_file.uri });
             unresolved.deinit(document_store.allocator);
             self.impl.associated_build_file = .{ .resolved = build_file.uri };
             return .{ .resolved = build_file.uri };
@@ -351,7 +351,7 @@ pub const Handle = struct {
                 continue;
             }
 
-            log.debug("Resolved build file of `{s}` as `{s}`", .{ self.uri, build_file.uri });
+            log.debug("Resolved build file of '{s}' as '{s}'", .{ self.uri, build_file.uri });
             unresolved.deinit(document_store.allocator);
             self.impl.associated_build_file = .{ .resolved = build_file.uri };
             return .{ .resolved = build_file.uri };
@@ -669,13 +669,13 @@ pub fn getOrLoadHandle(self: *DocumentStore, uri: Uri) ?*Handle {
     if (self.getHandle(uri)) |handle| return handle;
 
     const file_path = URI.parse(self.allocator, uri) catch |err| {
-        log.err("failed to parse URI `{s}`: {}", .{ uri, err });
+        log.err("failed to parse URI '{s}': {}", .{ uri, err });
         return null;
     };
     defer self.allocator.free(file_path);
 
     if (!std.fs.path.isAbsolute(file_path)) {
-        log.err("file path is not absolute `{s}`", .{file_path});
+        log.err("file path is not absolute '{s}'", .{file_path});
         return null;
     }
     const file_contents = std.fs.cwd().readFileAllocOptions(
@@ -686,7 +686,7 @@ pub fn getOrLoadHandle(self: *DocumentStore, uri: Uri) ?*Handle {
         @alignOf(u8),
         0,
     ) catch |err| {
-        log.err("failed to load document `{s}`: {}", .{ file_path, err });
+        log.err("failed to load document '{s}': {}", .{ file_path, err });
         return null;
     };
 
@@ -740,9 +740,10 @@ pub fn openDocument(self: *DocumentStore, uri: Uri, text: []const u8) error{OutO
         defer self.lock.unlockShared();
 
         if (self.handles.get(uri)) |handle| {
-            if (!handle.setOpen(true)) {
-                log.warn("Document already open: {s}", .{uri});
-            }
+            _ = handle;
+            // if (!handle.setOpen(true)) {
+            //     log.warn("Document already open: {s}", .{uri});
+            // }
             return;
         }
     }
@@ -1186,6 +1187,8 @@ fn createBuildFile(self: *DocumentStore, uri: Uri) error{OutOfMemory}!BuildFile 
         try self.invalidateBuildFile(build_file.uri);
     }
 
+    log.info("Loaded build file '{s}'", .{build_file.uri});
+
     return build_file;
 }
 
@@ -1272,7 +1275,7 @@ fn createDocument(self: *DocumentStore, uri: Uri, text: [:0]const u8, open: bool
         _ = self.getOrLoadBuildFile(handle.uri);
     } else if (!isBuiltinFile(handle.uri) and !isInStd(handle.uri)) blk: {
         const potential_build_files = self.collectPotentialBuildFiles(uri) catch {
-            log.err("failed to collect potential build files of `{s}`", .{handle.uri});
+            log.err("failed to collect potential build files of '{s}'", .{handle.uri});
             break :blk;
         };
         errdefer {
@@ -1317,9 +1320,9 @@ fn createAndStoreDocument(self: *DocumentStore, uri: Uri, text: [:0]const u8, op
     }
 
     if (isBuildFile(gop.value_ptr.*.uri)) {
-        log.debug("Opened document `{s}` (build file)", .{gop.value_ptr.*.uri});
+        log.debug("Opened document '{s}' (build file)", .{gop.value_ptr.*.uri});
     } else {
-        log.debug("Opened document `{s}`", .{gop.value_ptr.*.uri});
+        log.debug("Opened document '{s}'", .{gop.value_ptr.*.uri});
     }
 
     return gop.value_ptr.*;

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -2918,7 +2918,7 @@ pub const Type = struct {
                     const token_tags = tree.tokens.items(.tag);
                     const token_starts = tree.tokens.items(.start);
 
-                    // NOTE: This is a hacky nightmare but it works :P
+                    // This is a hacky nightmare but it works :P
                     const token = tree.firstToken(node);
                     if (token >= 2 and token_tags[token - 2] == .identifier and token_tags[token - 1] == .equal) {
                         try writer.writeAll(tree.tokenSlice(token - 2));
@@ -5114,7 +5114,7 @@ fn addReferencedTypes(
                 const token_tags = tree.tokens.items(.tag);
                 const token_starts = tree.tokens.items(.start);
 
-                // NOTE: This is a hacky nightmare but it works :P
+                // This is a hacky nightmare but it works :P
                 const token = tree.firstToken(node);
                 if (token >= 2 and token_tags[token - 2] == .identifier and token_tags[token - 1] == .equal) {
                     const str = tree.tokenSlice(token - 2);

--- a/src/diff.zig
+++ b/src/diff.zig
@@ -67,9 +67,6 @@ pub fn edits(
 }
 
 /// Caller owns returned memory.
-/// NOTE: As far as I know, this implementation is actually incorrect
-/// as we use intermediate state, but at the same time, it works so
-/// I really don't want to touch it right now. TODO: Investigate + fix.
 pub fn applyContentChanges(
     allocator: std.mem.Allocator,
     text: []const u8,

--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -1329,7 +1329,7 @@ fn collectFieldAccessContainerNodes(
             // don't have the luxury of referencing an `Ast.full.Call`
             // check if the first symbol is a `T` or an instance_of_T
             const additional_index: usize = blk: {
-                // NOTE: `loc` points to offsets within `handle`, not `node_type.decl.handle`
+                // `loc` points to offsets within `handle`, not `node_type.decl.handle`
                 const field_access_slice = handle.tree.source[loc.start..loc.end];
                 if (field_access_slice[0] == '@') break :blk 1; // assume `@import("..").some.Other{.}`
                 var symbol_iter = std.mem.tokenizeScalar(u8, field_access_slice, '.');

--- a/src/features/diagnostics.zig
+++ b/src/features/diagnostics.zig
@@ -280,7 +280,7 @@ pub fn generateBuildOnSaveDiagnostics(
     // its stored in last_related_diagnostics because we need an ArrayList
     var last_related_diagnostics: std.ArrayListUnmanaged(types.DiagnosticRelatedInformation) = .{};
 
-    // NOTE: I believe that with color off it's one diag per line; is this correct?
+    // I believe that with color off it's one diag per line; is this correct?
     var line_iterator = std.mem.splitScalar(u8, result.stderr, '\n');
 
     while (line_iterator.next()) |line| {
@@ -431,7 +431,7 @@ fn getDiagnosticsFromAstCheck(
     // its stored in last_related_diagnostics because we need an ArrayList
     var last_related_diagnostics: std.ArrayListUnmanaged(types.DiagnosticRelatedInformation) = .{};
 
-    // NOTE: I believe that with color off it's one diag per line; is this correct?
+    // I believe that with color off it's one diag per line; is this correct?
     var line_iterator = std.mem.splitScalar(u8, stderr_bytes, '\n');
 
     while (line_iterator.next()) |line| lin: {

--- a/src/features/diagnostics.zig
+++ b/src/features/diagnostics.zig
@@ -205,7 +205,7 @@ pub fn generateBuildOnSaveDiagnostics(
     comptime std.debug.assert(std.process.can_spawn);
 
     const workspace_path = URI.parse(server.allocator, workspace_uri) catch |err| {
-        log.err("failed to parse invalid uri `{s}`: {}", .{ workspace_uri, err });
+        log.err("failed to parse invalid uri '{s}': {}", .{ workspace_uri, err });
         return;
     };
     defer server.allocator.free(workspace_path);
@@ -218,7 +218,7 @@ pub fn generateBuildOnSaveDiagnostics(
     std.fs.accessAbsolute(build_zig_path, .{}) catch |err| switch (err) {
         error.FileNotFound => return,
         else => |e| {
-            log.err("failed to load build.zig at `{s}`: {}", .{ build_zig_path, e });
+            log.err("failed to load build.zig at '{s}': {}", .{ build_zig_path, e });
             return e;
         },
     };

--- a/src/main.zig
+++ b/src/main.zig
@@ -9,6 +9,27 @@ const binned_allocator = @import("binned_allocator.zig");
 
 const log = std.log.scoped(.zls_main);
 
+const usage =
+    \\ZLS - A non-official Zig Language Server
+    \\
+    \\Commands:
+    \\  help, --help,             Print this help and exit
+    \\  version, --version        Print version number and exit
+    \\  env                       Print config path, log path and version
+    \\
+    \\General Options:
+    \\  --config-path [path]      Set path to the 'zls.json' configuration file
+    \\  --enable-message-tracing  Enable message tracing
+    \\  --log-file [path]         Set path to the 'zls.log' log file
+    \\  --log-level [enum]        The Log Level to be used.
+    \\                              Supported Values:
+    \\                                err
+    \\                                warn
+    \\                                info (default)
+    \\                                debug
+    \\
+;
+
 pub const std_options: std.Options = .{
     // Always set this to debug to make std.log call into our handler, then control the runtime
     // value in logFn itself
@@ -52,27 +73,6 @@ fn logFn(
         file.writer().writeByte('\n') catch break :blk;
     }
 }
-
-const usage =
-    \\ZLS - A non-official Zig Language Server
-    \\
-    \\Commands:
-    \\  help, --help,             Print this help and exit
-    \\  version, --version        Print version number and exit
-    \\  env                       Print config path, log path and version
-    \\
-    \\General Options:
-    \\  --config-path [path]      Set path to the 'zls.json' configuration file
-    \\  --enable-message-tracing  Enable message tracing
-    \\  --log-file [path]         Set path to the 'zls.log' log file
-    \\  --log-level [enum]        The Log Level to be used.
-    \\                              Supported Values:
-    \\                                err
-    \\                                warn
-    \\                                info (default)
-    \\                                debug
-    \\
-;
 
 fn defaultLogFilePath(allocator: std.mem.Allocator) std.mem.Allocator.Error!?[]const u8 {
     const cache_path = known_folders.getPath(allocator, .cache) catch |err| switch (err) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -94,7 +94,7 @@ fn createLogFile(allocator: std.mem.Allocator, override_log_file_path: ?[]const 
     const file = std.fs.cwd().createFile(log_file_path, .{ .truncate = false }) catch return null;
     errdefer file.close();
 
-    log.info("Log File:        {s}", .{log_file_path});
+    log.info("Log File:         {s}", .{log_file_path});
 
     return file;
 }
@@ -316,12 +316,12 @@ pub fn main() !u8 {
 
     const resolved_log_level = result.log_level orelse runtime_log_level;
 
-    log.info("Starting ZLS {s} @ '{s}'", .{ zls.build_options.version_string, result.zls_exe_path });
-    log.info("Message Tracing: {}", .{result.enable_message_tracing});
-    log.info("Log Level:       {s}", .{@tagName(resolved_log_level)});
+    log.info("Starting ZLS      {s} @ '{s}'", .{ zls.build_options.version_string, result.zls_exe_path });
+    log.info("Message Tracing:  {}", .{result.enable_message_tracing});
+    log.info("Log Level:        {s}", .{@tagName(resolved_log_level)});
 
     const new_log_file = createLogFile(allocator, result.log_file_path) orelse blk: {
-        log.info("Log File:        null", .{});
+        log.info("Log File:         null", .{});
         break :blk null;
     };
     defer if (new_log_file) |file| file.close();


### PR DESCRIPTION
- CLI argument parser has been replaced to be less comptime heavy
- logs will also be written to a `zls.log` file in the user's cache
- new `--log-file` flag to override the path to `zls.log`
- `--log-level` replaces `--enable-debug-log` and `-Dlog_level`
- new `zls env` command
- deprecate `--show-config-path` in favor of `zls env`

Running `./zls` through a terminal will now show the following:
```
techatrix@nixos-desktop:~/repos/zls/ > ./zig-out/bin/zls 
warn  ( main ): ZLS is not a CLI tool, it communicates over the Language Server Protocol.
warn  ( main ): Did you mean to run 'zls --help'?
warn  ( main ): 
info  ( main ): Starting ZLS      0.14.0-dev.39+4263bb89 @ './zig-out/bin/zls'
info  ( main ): Message Tracing:  false
info  ( main ): Log Level:        debug
info  ( main ): Log File:         /home/techatrix/.cache/zls/zls.log
```

Running `./zls --help` will now show the following:
```
techatrix@nixos-desktop:~/repos/zls/ > ./zig-out/bin/zls --help
ZLS - A non-official Zig Language Server

Commands:
  help, --help,             Print this help and exit
  version, --version        Print version number and exit
  env                       Print config path, log path and version

General Options:
  --config-path [path]      Set path to the 'zls.json' configuration file
  --enable-message-tracing  Enable message tracing
  --log-file [path]         Set path to the 'zls.log' log file
  --log-level [enum]        The Log Level to be used.
                              Supported Values:
                                err
                                warn
                                info (default)
                                debug
```
Running `./zls env` will print the following:
```
{
 "version": "0.14.0-dev.46+efed0c93",
 "global_cache_dir": "/home/techatrix/.cache/zls",
 "global_config_dir": "/etc/xdg",
 "local_config_dir": "/home/techatrix/.config",
 "config_file": "/home/techatrix/.config/zls.json",
 "log_file": "/home/techatrix/.cache/zls/zls.log"
}
```

Running ZLS in VSCode will log the following:
```
info  ( main ): Starting ZLS      0.14.0-dev.39+4263bb89 @ '/home/techatrix/repos/zls/zig-out/bin/zls'
info  ( main ): Message Tracing:  false
info  ( main ): Log Level:        info
info  ( main ): Log File:         /home/techatrix/.cache/zls/zls.log
info  (server): Client Info:      VSCodium-1.88.1
info  (server): Workspace Folder: 'file:///home/techatrix/repos/zls'
info  (server): Set config option 'global_cache_path' to '/home/techatrix/.cache/zls'
info  (store ): Loaded build file 'file:///home/techatrix/repos/zls/build.zig'
info  (server): Set config option 'enable_autofix' to 'true'
info  (server): Set config option 'semantic_tokens' to 'partial'
info  (server): Set config option 'builtin_path' to '/home/techatrix/.cache/zls/builtin.zig'
info  (server): Set config option 'zig_lib_path' to '/nix/store/vq1y3pymnf17xc95vz5kinff93sf37hk-zig-0.13.0/lib'
info  (server): Set config option 'zig_exe_path' to '/nix/store/vq1y3pymnf17xc95vz5kinff93sf37hk-zig-0.13.0/bin/zig'
info  (server): Set config option 'build_runner_path' to '/home/techatrix/.cache/zls/build_runner/63d2fe03007ad08cffec78d2fa000aa0/build_runner.zig'
```

The old logs looked like this:
```
info : ( main ): Starting ZLS 0.14.0-dev.36+e6f9242e @ '/home/techatrix/repos/zls/zig-out/bin/zls'
info : (server): Client is 'VSCodium-1.88.1'
info : (server): No config file zls.json found. This is not an error.
info : (server): Set config option 'global_cache_path' to '/home/techatrix/.cache/zls'
info : (server): Set config option 'enable_autofix' to 'true'
info : (server): Set config option 'semantic_tokens' to 'partial'
info : (server): Set config option 'builtin_path' to '/home/techatrix/.cache/zls/builtin.zig'
info : (server): Set config option 'zig_lib_path' to '/nix/store/vq1y3pymnf17xc95vz5kinff93sf37hk-zig-0.13.0/lib'
info : (server): Set config option 'zig_exe_path' to '/nix/store/vq1y3pymnf17xc95vz5kinff93sf37hk-zig-0.13.0/bin/zig'
info : (server): Set config option 'build_runner_path' to '/home/techatrix/.cache/zls/build_runner/63d2fe03007ad08cffec78d2fa000aa0/build_runner.zig'
```