### PR TITLE
test: cache configuration values

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -65,16 +65,12 @@ pub fn build(b: *Build) !void {
     exe_options.addOption(u32, "enable_failing_allocator_likelihood", b.option(u32, "enable_failing_allocator_likelihood", "The chance that an allocation will fail is `1/likelihood`") orelse 256);
     exe_options.addOption(bool, "use_gpa", b.option(bool, "use_gpa", "Good for debugging") orelse (optimize == .Debug));
 
-    const global_cache_path = try b.cache_root.join(b.allocator, &.{"zls"});
-    b.cache_root.handle.makePath(global_cache_path) catch |err| {
-        std.debug.panic("unable to make tmp path '{s}': {}", .{ global_cache_path, err });
-    };
-
     const test_options = b.addOptions();
     test_options.step.name = "ZLS test options";
     const test_options_module = test_options.createModule();
     test_options.addOption([]const u8, "zig_exe_path", b.graph.zig_exe);
-    test_options.addOption([]const u8, "global_cache_path", global_cache_path);
+    test_options.addOption([]const u8, "zig_lib_path", b.graph.zig_lib_directory.path.?);
+    test_options.addOption([]const u8, "global_cache_path", b.graph.global_cache_root.join(b.allocator, &.{"zls"}) catch @panic("OOM"));
 
     const known_folders_module = b.dependency("known_folders", .{}).module("known-folders");
     const diffz_module = b.dependency("diffz", .{}).module("diffz");

--- a/tests/lifecycle.zig
+++ b/tests/lifecycle.zig
@@ -12,7 +12,7 @@ test "LSP lifecycle" {
         .zig_exe_path = test_options.zig_exe_path,
         .zig_lib_path = null,
         .global_cache_path = test_options.global_cache_path,
-    });
+    }, .{});
 
     var arena_allocator = std.heap.ArenaAllocator.init(allocator);
     defer arena_allocator.deinit();


### PR DESCRIPTION
I've noticed that running tests on ZLS takes considerably longer on windows. Most of the time was spent resolving config values which required running `zig env` at lot. Caching these values makes running the tests goes from 59 seconds to 3 seconds. 

### Before

```
PS C:\Users\Techatrix\zls> zig build test --summary all
Build Summary: 12/12 steps succeeded; 352/367 tests passed; 15 skipped       
test success
├─ run test 282 passed 15 skipped 59s MaxRSS:11M
│  └─ zig test Debug native success 23s MaxRSS:810M
│     ├─ ZLS build options success
│     ├─ run zls_gen (version_data_master_19921.zig) success 426ms MaxRSS:10M
│     │  └─ zig build-exe zls_gen Debug native success 15s MaxRSS:487M       
│     ├─ run lsp-codegen (lsp_types.zig) success 105ms MaxRSS:9M
│     │  └─ zig build-exe lsp-codegen Debug native success 15s MaxRSS:254M   
│     ├─ tracy options success
│     └─ ZLS test options success
└─ run src test 70 passed 39ms MaxRSS:5M
   └─ zig test src test Debug native success 10s MaxRSS:392M
      ├─ ZLS build options (reused)
      ├─ ZLS test options (reused)
      └─ run lsp-codegen (lsp_types.zig) (+1 more reused dependencies)
```

### After

```
PS C:\Users\Techatrix\zls> zig build test --summary all
Build Summary: 12/12 steps succeeded; 352/367 tests passed; 15 skipped
test success
├─ run test 282 passed 15 skipped 3s MaxRSS:11M
│  └─ zig test Debug native success 22s MaxRSS:818M
│     ├─ ZLS build options success
│     ├─ run zls_gen (version_data_master_19921.zig) success 243ms MaxRSS:10M
│     │  └─ zig build-exe zls_gen Debug native success 15s MaxRSS:488M
│     ├─ run lsp-codegen (lsp_types.zig) success 95ms MaxRSS:9M
│     │  └─ zig build-exe lsp-codegen Debug native success 15s MaxRSS:254M
│     ├─ tracy options success
│     └─ ZLS test options success
└─ run src test 70 passed 40ms MaxRSS:5M
   └─ zig test src test Debug native success 10s MaxRSS:391M
      ├─ ZLS build options (reused)
      ├─ ZLS test options (reused)
      └─ run lsp-codegen (lsp_types.zig) (+1 more reused dependencies)
```

---

This is also helps when combined with the native x86 where running the tests would previously take longer than compiling them. 

```
[techatrix@nixos-desktop:~/repos/zls]$ zig build test -Duse_llvm=false --summary all
Build Summary: 12/12 steps succeeded; 352/367 tests passed; 15 skipped
test success
├─ run test 282 passed 15 skipped 3s MaxRSS:47M
│  └─ zig test Debug native success 4s MaxRSS:148M
│     ├─ ZLS build options success
│     ├─ run zls_gen (version_data_master_19922.zig) success 324ms MaxRSS:7M
│     │  └─ zig build-exe zls_gen Debug native success 10s MaxRSS:555M
│     ├─ run lsp-codegen (lsp_types.zig) success 75ms MaxRSS:7M
│     │  └─ zig build-exe lsp-codegen Debug native success 3s MaxRSS:324M
│     ├─ tracy options success
│     └─ ZLS test options success
└─ run src test 70 passed 52ms MaxRSS:4M
   └─ zig test src test Debug native success 2s MaxRSS:120M
      ├─ ZLS build options (reused)
      ├─ ZLS test options (reused)
      └─ run lsp-codegen (lsp_types.zig) (+1 more reused dependencies)
```