### PR TITLE
chore: trim trailing whitespace in multiline strings

### DIFF
--- a/src/config_gen/config_gen.zig
+++ b/src/config_gen/config_gen.zig
@@ -1005,7 +1005,7 @@ pub fn main() !void {
                 \\
                 \\    --help                               Prints this message
                 \\    --readme-path [path]                 Update readme file (see README.md)
-                \\    --vscode-config-path [path]          Output zls-vscode configurations 
+                \\    --vscode-config-path [path]          Output zls-vscode configurations
                 \\    --generate-config-path [path]        Output path to config file (see src/Config.zig)
                 \\    --generate-schema-path [path]        Output json schema file (see schema.json)
                 \\    --generate-version-data [version]    Specify version of data file

--- a/tests/lsp_features/code_actions.zig
+++ b/tests/lsp_features/code_actions.zig
@@ -353,7 +353,7 @@ test "ignore autofix comment whitespace" {
     );
     try testAutofix(
         \\fn foo() void {
-        \\    _ = a;   //   autofix  
+        \\    _ = a;   //   autofix
         \\}
         \\
     ,

--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -813,7 +813,7 @@ test "if/for/while/catch scopes" {
         \\const S = struct { pub const T = u32; };
         \\test {
         \\    for (undefined) |_| {
-        \\        
+        \\
         \\    } else {
         \\        S.<cursor>
         \\    }
@@ -835,7 +835,7 @@ test "if/for/while/catch scopes" {
         \\const S = struct { pub const T = u32; };
         \\test {
         \\    for (undefined) {
-        \\        
+        \\
         \\    } else {
         \\        S.<cursor>
         \\    }
@@ -1211,7 +1211,7 @@ test "enum" {
         \\const E = enum {
         \\    _,
         \\    const bar = 5;
-        \\    fn inner(_: E) void {} 
+        \\    fn inner(_: E) void {}
         \\};
         \\const foo = E.<cursor>
     , &.{
@@ -1222,7 +1222,7 @@ test "enum" {
         \\const E = enum {
         \\    _,
         \\    const bar = 5;
-        \\    fn inner(_: E) void {} 
+        \\    fn inner(_: E) void {}
         \\};
         \\const e: E = undefined;
         \\const foo = e.<cursor>

--- a/tests/lsp_features/inlay_hints.zig
+++ b/tests/lsp_features/inlay_hints.zig
@@ -267,7 +267,7 @@ test "var decl" {
         \\             .d<usize> = 0,
         \\             .e<[]const u8> = "Testing",
         \\         }
-        \\     }; 
+        \\     };
         \\ }
         \\
         \\ var a<struct {...}> = thing(10, -4);
@@ -287,7 +287,7 @@ test "function alias" {
         \\  // some documentation
         \\  comptime alpha: u32,
         \\) u32 {
-        \\    return alpha; 
+        \\    return alpha;
         \\}
         \\const bar<*fn (comptime alpha: u32) u32> = &foo;
     , .{ .kind = .Type });

--- a/tests/lsp_features/semantic_tokens.zig
+++ b/tests/lsp_features/semantic_tokens.zig
@@ -1363,7 +1363,7 @@ test "if" {
 
 test "if error union with invalid then expression" {
     try testSemanticTokens(
-        \\const foo = 
+        \\const foo =
         \\  if (undefined) |value| {
         \\      switch (value) {} catch |err| {};
         \\  } else |err| {};


### PR DESCRIPTION
After reading through the discussion in https://github.com/ziglang/zig/issues/19299, I figured it couldn't hurt to cleanup instances of trailing whitespace in multiline strings here.