### PR TITLE
fix semanticTokens/range when enclosing the root node

### DIFF
--- a/src/features/semantic_tokens.zig
+++ b/src/features/semantic_tokens.zig
@@ -1041,7 +1041,10 @@ pub fn writeSemanticTokens(
         .limited = limited,
     };
 
-    const nodes = if (loc) |l| try ast.nodesAtLoc(arena, handle.tree, l) else handle.tree.rootDecls();
+    var nodes = if (loc) |l| try ast.nodesAtLoc(arena, handle.tree, l) else handle.tree.rootDecls();
+    if (nodes.len == 1 and nodes[0] == 0) {
+        nodes = handle.tree.rootDecls();
+    }
 
     // reverse the ast from the root declarations
     for (nodes) |child| {


### PR DESCRIPTION
Ideally, when reaching the end of the document, ZLS should not try to send over all semantic tokens of the document on a range request. I will open a separate issue for this