### PR TITLE
functions inside namespaces can't have self parameters

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -352,6 +352,7 @@ pub fn hasSelfParam(analyser: *Analyser, func_ty: Type) error{OutOfMemory}!bool 
     const fn_token = func_node.handle.tree.nodes.items(.main_token)[func_node.node];
     const in_container = try innermostContainer(func_node.handle, func_node.handle.tree.tokens.items(.start)[fn_token]);
     std.debug.assert(in_container.is_type_val);
+    if (in_container.isNamespace()) return false;
     return analyser.firstParamIs(func_ty, in_container);
 }
 

--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -321,10 +321,11 @@ fn functionTypeCompletion(
 
     const use_snippets = builder.server.config.enable_snippets and builder.server.client_capabilities.supports_snippets;
 
-    const has_self_param = if (parent_container_ty) |container_ty|
-        if (container_ty.is_type_val) false else try builder.analyser.firstParamIs(func_ty, container_ty.typeOf(builder.analyser))
-    else
-        false;
+    const has_self_param = if (parent_container_ty) |container_ty| blk: {
+        if (container_ty.is_type_val) break :blk false;
+        if (container_ty.isNamespace()) break :blk false;
+        break :blk try builder.analyser.firstParamIs(func_ty, container_ty.typeOf(builder.analyser));
+    } else false;
 
     const insert_range, const replace_range, const new_text_format = prepareFunctionCompletion(builder);
 

--- a/tests/lsp_features/semantic_tokens.zig
+++ b/tests/lsp_features/semantic_tokens.zig
@@ -419,7 +419,7 @@ test "call" {
         \\const alpha = foo(0);
     , &.{
         .{ "fn", .keyword, .{} },
-        .{ "foo", .method, .{ .declaration = true, .generic = true } },
+        .{ "foo", .function, .{ .declaration = true, .generic = true } },
         .{ "a", .parameter, .{ .declaration = true } },
         .{ "anytype", .type, .{} },
         .{ "void", .type, .{} },
@@ -430,7 +430,7 @@ test "call" {
         .{ "const", .keyword, .{} },
         .{ "alpha", .variable, .{ .declaration = true } },
         .{ "=", .operator, .{} },
-        .{ "foo", .method, .{ .generic = true } },
+        .{ "foo", .function, .{ .generic = true } },
         .{ "0", .number, .{} },
     });
 }
@@ -1233,23 +1233,27 @@ test "function" {
 test "method" {
     try testSemanticTokens(
         \\const S = struct {
+        \\    alpha: u32,
         \\    fn create() S {}
         \\    fn doTheThing(self: S) void {}
         \\};
     , &.{
         .{ "const", .keyword, .{} },
-        .{ "S", .namespace, .{ .declaration = true } },
+        .{ "S", .@"struct", .{ .declaration = true } },
         .{ "=", .operator, .{} },
         .{ "struct", .keyword, .{} },
 
+        .{ "alpha", .property, .{ .declaration = true } },
+        .{ "u32", .type, .{} },
+
         .{ "fn", .keyword, .{} },
         .{ "create", .function, .{ .declaration = true } },
-        .{ "S", .namespace, .{} },
+        .{ "S", .@"struct", .{} },
 
         .{ "fn", .keyword, .{} },
         .{ "doTheThing", .method, .{ .declaration = true } },
         .{ "self", .parameter, .{ .declaration = true } },
-        .{ "S", .namespace, .{} },
+        .{ "S", .@"struct", .{} },
         .{ "void", .type, .{} },
     });
 }

--- a/tests/lsp_features/signature_help.zig
+++ b/tests/lsp_features/signature_help.zig
@@ -152,6 +152,7 @@ test "self parameter" {
     // argument: S
     try testSignatureHelp(
         \\const S = struct {
+        \\    alpha: u32,
         \\    fn foo(self: @This(), a: u32, b: void) bool {}
         \\};
         \\const s: S = undefined;
@@ -159,6 +160,7 @@ test "self parameter" {
     , "fn foo(self: @This(), a: u32, b: void) bool", 2);
     try testSignatureHelp(
         \\const S = struct {
+        \\    alpha: u32,
         \\    fn foo(self: @This(), a: u32, b: void) bool {}
         \\};
         \\const foo = S.foo(undefined,<cursor>);
@@ -168,6 +170,7 @@ test "self parameter" {
     // argument: S
     try testSignatureHelp(
         \\const S = struct {
+        \\    alpha: u32,
         \\    fn foo(self: *@This(), a: u32, b: void) bool {}
         \\};
         \\const s: S = undefined;
@@ -175,6 +178,7 @@ test "self parameter" {
     , "fn foo(self: *@This(), a: u32, b: void) bool", 2);
     try testSignatureHelp(
         \\const S = struct {
+        \\    alpha: u32,
         \\    fn foo(self: *@This(), a: u32, b: void) bool {}
         \\};
         \\const foo = S.foo(undefined,<cursor>);
@@ -184,6 +188,7 @@ test "self parameter" {
     // argument: *S
     try testSignatureHelp(
         \\const S = struct {
+        \\    alpha: u32,
         \\    fn foo(self: @This(), a: u32, b: void) bool {}
         \\};
         \\const s: *S = undefined;
@@ -194,6 +199,7 @@ test "self parameter" {
     // argument: *S
     try testSignatureHelp(
         \\const S = struct {
+        \\    alpha: u32,
         \\    fn foo(self: *@This(), a: u32, b: void) bool {}
         \\};
         \\const s: *S = undefined;
@@ -204,6 +210,7 @@ test "self parameter" {
 test "self parameter is anytype" {
     try testSignatureHelp(
         \\const S = struct {
+        \\    alpha: u32,
         \\    fn foo(self: anytype, a: u32, b: void) bool {}
         \\};
         \\const s: S = undefined;


### PR DESCRIPTION

```zig
// before: 'foo' is a function
// after:  'foo' is a function
fn foo() void {}

// before: 'bar' is a method
// after:  'bar' is a function
fn bar(_: @This()) void {}

// before: 'baz' is a method
// after:  'baz' is a function
fn baz(_: anytype) void {}
```

```zig
some_field: u32,
// before: 'foo' is a function
// after:  'foo' is a function
fn foo() void {}

// before: 'bar' is a method
// after:  'bar' is a method
fn bar(_: @This()) void {}

// before: 'baz' is a method
// after:  'baz' is a method
fn baz(_: anytype) void {}
```
