### PR TITLE
resolve type of comparison op to @Vector(N, bool) if lhs is a vector

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -2071,6 +2071,28 @@ fn resolveTypeOfNodeUncached(analyser: *Analyser, node_handle: NodeWithHandle) e
         .greater_than,
         .less_or_equal,
         .greater_or_equal,
+        => {
+            const ty = try analyser.resolveTypeOfNodeInternal(
+                .{ .node = datas[node].lhs, .handle = handle },
+            ) orelse return null;
+            const typeof = ty.typeOf(analyser);
+
+            if (typeof.data == .ip_index) {
+                const key = analyser.ip.indexToKey(typeof.data.ip_index.index);
+                if (key == .vector_type) {
+                    const vector_ty_ip_index = try analyser.ip.get(analyser.gpa, .{
+                        .vector_type = .{
+                            .len = key.vector_type.len,
+                            .child = .bool_type,
+                        },
+                    });
+
+                    return try Type.typeValFromIP(analyser, vector_ty_ip_index);
+                }
+            }
+            return try Type.typeValFromIP(analyser, .bool_type);
+        },
+
         .bool_and,
         .bool_or,
         .bool_not,

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -2074,7 +2074,7 @@ fn resolveTypeOfNodeUncached(analyser: *Analyser, node_handle: NodeWithHandle) e
         => {
             const ty = try analyser.resolveTypeOfNodeInternal(
                 .{ .node = datas[node].lhs, .handle = handle },
-            ) orelse return null;
+            ) orelse return try Type.typeValFromIP(analyser, .bool_type);
             const typeof = ty.typeOf(analyser);
 
             if (typeof.data == .ip_index) {

--- a/tests/lsp_features/inlay_hints.zig
+++ b/tests/lsp_features/inlay_hints.zig
@@ -223,6 +223,10 @@ test "inlay destructuring" {
 }
 test "var decl" {
     try testInlayHints(
+        \\const a<@Vector(2,u8)> = @Vector(2, u8){1,2};
+        \\const foo<@Vector(2,bool)> = a == a;
+    , .{ .kind = .Type });
+    try testInlayHints(
         \\const foo<comptime_int> = 5;
     , .{ .kind = .Type });
     try testInlayHints(


### PR DESCRIPTION
zls incorrectly always assumes that comparison operations resolve to `.bool_type`, even if you compare two `@Vector`s

expected:
```
    try testInlayHints(
        \\const a<@Vector(2,u8)> = @Vector(2, u8){1,2};
        \\const foo<@Vector(2,bool)> = a == a;
    , .{ .kind = .Type });
```
actual:
```
    try testInlayHints(
        \\const a<@Vector(2,u8)> = @Vector(2, u8){1,2};
        \\const foo<bool> = a == a;
    , .{ .kind = .Type });
```

I tried solving this but I'm not sure if this is the right way to do it, here's some thoughts I had:
- also check `rhs`
- maybe instead of `orelse return null;` return `.bool_type` like before