### PR TITLE
display number details on char literal hover

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -3301,6 +3301,7 @@ pub const PositionContext = union(enum) {
     global_error_set,
     enum_literal: offsets.Loc,
     number_literal: offsets.Loc,
+    char_literal: offsets.Loc,
     /// XXX: Internal use only, currently points to the loc of the first l_paren
     parens_expr: offsets.Loc,
     pre_label,
@@ -3320,6 +3321,7 @@ pub const PositionContext = union(enum) {
             .var_access => |r| r,
             .enum_literal => |r| r,
             .number_literal => |r| r,
+            .char_literal => |r| r,
             .parens_expr => |r| r,
             .pre_label => null,
             .label => null,
@@ -3369,17 +3371,28 @@ pub fn getPositionContext(
     defer tracy_zone.end();
 
     var new_index = doc_index;
-    if (lookahead and new_index + 2 < text.len) {
-        if (text[new_index] == '@') new_index += 2;
-        while (new_index < text.len and isSymbolChar(text[new_index])) : (new_index += 1) {}
-        switch (text[new_index]) {
-            ':' => { // look for `id:`, but avoid `a: T` by checking for a `{` following the ':'
-                var b_index = new_index + 1;
-                while (b_index < text.len and text[b_index] == ' ') : (b_index += 1) {} // eat spaces
-                if (text[b_index] == '{') new_index += 1; // current new_index points to ':', but slc ends are exclusive => `text[0..pos_of_r_brace]`
-            },
-            // ';' => new_index += 1, // XXX: currently given `some;` the last letter gets cut off, ie `som`, but fixing it breaks existing logic.. ?
-            else => {},
+    if (lookahead) {
+        // looking for possible end of char literal
+        if (std.mem.indexOf(u8, text[doc_index..@min(doc_index + 2, text.len)], &.{'\''})) |char_index| {
+            if (text[new_index + char_index - 1] == '\\') {
+                // handles escaped single quotes '\''
+                new_index = @min(new_index + char_index + 2, text.len - 1);
+            } else {
+                new_index += char_index + 1;
+            }
+        } else if (new_index + 2 < text.len) {
+            if (text[new_index] == '@') new_index += 2;
+            while (new_index < text.len and isSymbolChar(text[new_index])) : (new_index += 1) {}
+            switch (text[new_index]) {
+                ':' => { // look for `id:`, but avoid `a: T` by checking for a `{` following the ':'
+                    var b_index = new_index + 1;
+                    while (b_index < text.len and text[b_index] == ' ') : (b_index += 1) {} // eat spaces
+                    if (text[b_index] == '{') new_index += 1; // current new_index points to ':', but slc ends are exclusive => `text[0..pos_of_r_brace]`
+                },
+
+                // ';' => new_index += 1, // XXX: currently given `some;` the last letter gets cut off, ie `som`, but fixing it breaks existing logic.. ?
+                else => {},
+            }
         }
     }
 
@@ -3543,6 +3556,11 @@ pub fn getPositionContext(
                 .number_literal => {
                     if (tok.loc.start <= doc_index and tok.loc.end >= doc_index) {
                         return PositionContext{ .number_literal = tok.loc };
+                    }
+                },
+                .char_literal => {
+                    if (tok.loc.start <= doc_index and tok.loc.end >= doc_index) {
+                        return PositionContext{ .char_literal = tok.loc };
                     }
                 },
                 else => curr_ctx.ctx = .empty,

--- a/tests/lsp_features/hover.zig
+++ b/tests/lsp_features/hover.zig
@@ -92,6 +92,40 @@ test "literal" {
     );
 }
 
+test "char literal" {
+    try testHover(
+        \\const foo = '<cursor>a';
+    ,
+        \\| Base | Value     |
+        \\| ---- | --------- |
+        \\| BIN  | 0b1100001 |
+        \\| OCT  | 0o141     |
+        \\| DEC  | 97        |
+        \\| HEX  | 0x61      |
+    );
+
+    try testHover(
+        \\const foo = '<cursor>\'';
+    ,
+        \\| Base | Value    |
+        \\| ---- | -------- |
+        \\| BIN  | 0b100111 |
+        \\| OCT  | 0o47     |
+        \\| DEC  | 39       |
+        \\| HEX  | 0x27     |
+    );
+
+    try testHover(
+        \\const foo = '\'<cursor>';
+    ,
+        \\| Base | Value    |
+        \\| ---- | -------- |
+        \\| BIN  | 0b100111 |
+        \\| OCT  | 0o47     |
+        \\| DEC  | 39       |
+        \\| HEX  | 0x27     |
+    );
+}
 test "integer literal" {
     try testHover(
         \\const foo = 4<cursor>2;


### PR DESCRIPTION
<img width="554" alt="image" src="https://github.com/user-attachments/assets/45089c1a-5daf-4499-8b08-7507563bef8a">


Maybe that's too niched but it seemed like a low hanging fruit. I actually miss that from Rust LSP
