### PR TITLE
Solved last master build system changes to EmitBinPath

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -15,7 +15,7 @@ const zls_version = std.SemanticVersion{ .major = 0, .minor = 14, .patch = 0, .p
 /// ```
 ///
 /// Must match the `minimum_zig_version` in `build.zig.zon`.
-const minimum_build_zig_version = "0.14.0-dev.1076+78fb9c0a1";
+const minimum_build_zig_version = "0.14.0-dev.1232+61919fe63";
 
 /// Specify the minimum Zig version that is required to run ZLS:
 /// Release 0.12.0

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -20,8 +20,8 @@
             .hash = "1220102cb2c669d82184fb1dc5380193d37d68b54e8d75b76b2d155b9af7d7e2e76d",
         },
         .@"lsp-codegen" = .{
-            .url = "https://github.com/zigtools/zig-lsp-codegen/archive/13d1d9e44e1c602953437438b163950298ff8d85.tar.gz",
-            .hash = "1220518fd5cefa481497bb3484ffab48a42e69c31088e37f52ea361f9ce884d2131c",
+            .url = "https://github.com/zigtools/zig-lsp-codegen/archive/193a210ebe4a090a6f1bf1cb538375b56472688d.tar.gz",
+            .hash = "1220c527c348bd6ce5dd545aacaf811a47f7f08dfeb2cb6fd9325680b788b5272041",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,7 +3,7 @@
     // Must match the `zls_version` in `build.zig`
     .version = "0.14.0-dev",
     // Must match the `minimum_build_zig_version` in `build.zig`
-    .minimum_zig_version = "0.14.0-dev.1076+78fb9c0a1",
+    .minimum_zig_version = "0.14.0-dev.1232+61919fe63",
     // If you do not use Nix, a ZLS maintainer can take care of this.
     // Whenever the dependencies are updated, run the following command:
     // ```bash

--- a/deps.nix
+++ b/deps.nix
@@ -20,11 +20,13 @@ let
 
   fetchGitZig = { name, url, hash }: let
     parts = splitString "#" url;
-    base = elemAt parts 0;
-    rev = elemAt parts 1;
+    url_base = elemAt parts 0;
+    url_without_query = elemAt (splitString "?" url_base) 0;
+    rev_base = elemAt parts 1;
+    rev = if match "^[a-fA-F0-9]{40}$" rev_base != null then rev_base else "refs/heads/${rev_base}";
   in fetchgit {
     inherit name rev hash;
-    url = base;
+    url = url_without_query;
     deepClone = false;
   };
 
@@ -58,11 +60,11 @@ in linkFarm name [
     };
   }
   {
-    name = "1220518fd5cefa481497bb3484ffab48a42e69c31088e37f52ea361f9ce884d2131c";
+    name = "1220c527c348bd6ce5dd545aacaf811a47f7f08dfeb2cb6fd9325680b788b5272041";
     path = fetchZigArtifact {
       name = "lsp-codegen";
-      url = "https://github.com/zigtools/zig-lsp-codegen/archive/13d1d9e44e1c602953437438b163950298ff8d85.tar.gz";
-      hash = "sha256-13twCDbxhnF7Zb2tLsBUySc8nOOQXzC0XbV4RAE5HCc=";
+      url = "https://github.com/zigtools/zig-lsp-codegen/archive/193a210ebe4a090a6f1bf1cb538375b56472688d.tar.gz";
+      hash = "sha256-JqtvsWdQULNfLlesil24Dzms9RWODdoTAKblRjL5z1M=";
     };
   }
 ]

--- a/flake.lock
+++ b/flake.lock
@@ -86,11 +86,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1723688146,
-        "narHash": "sha256-sqLwJcHYeWLOeP/XoLwAtYjr01TISlkOfz+NG82pbdg=",
+        "lastModified": 1724242322,
+        "narHash": "sha256-HMpK7hNjhEk4z5SFg5UtxEio9OWFocHdaQzCfW1pE7w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c3d4ac725177c030b1e289015989da2ad9d56af0",
+        "rev": "224042e9a3039291f22f4f2ded12af95a616cca0",
         "type": "github"
       },
       "original": {
@@ -148,11 +148,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723810261,
-        "narHash": "sha256-bqeoaCSMPFZ3l3A3s3TydeCn7xUtUva6jpf/SS0i7UY=",
+        "lastModified": 1724328603,
+        "narHash": "sha256-5udGQrqbdxkQ/nIuI0KAdohxuZtOzYhxVuERUkqde+E=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "f7606d2b29799b15f401b0501c712d50c2fbb90d",
+        "rev": "1f0785c9b064455d5ba78002470f6dfad65de2a8",
         "type": "github"
       },
       "original": {

--- a/src/ZigCompileServer.zig
+++ b/src/ZigCompileServer.zig
@@ -59,9 +59,9 @@ pub fn receiveMessage(client: *Client) !InMessage.Header {
     return error.Timeout;
 }
 
-pub fn receiveEmitBinPath(client: *Client) !InMessage.EmitBinPath {
+pub fn receiveEmitBinPath(client: *Client) !InMessage.EmitDigest {
     const reader = client.pooler.fifo(.in).reader();
-    return reader.readStruct(InMessage.EmitBinPath);
+    return reader.readStruct(InMessage.EmitDigest);
 }
 
 pub fn receiveErrorBundle(client: *Client) !InMessage.ErrorBundle {

--- a/src/ZigCompileServer.zig
+++ b/src/ZigCompileServer.zig
@@ -59,7 +59,7 @@ pub fn receiveMessage(client: *Client) !InMessage.Header {
     return error.Timeout;
 }
 
-pub fn receiveEmitBinPath(client: *Client) !InMessage.EmitDigest {
+pub fn receiveEmitDigest(client: *Client) !InMessage.EmitDigest {
     const reader = client.pooler.fifo(.in).reader();
     return reader.readStruct(InMessage.EmitDigest);
 }

--- a/src/build_runner/BuildRunnerVersion.zig
+++ b/src/build_runner/BuildRunnerVersion.zig
@@ -90,6 +90,7 @@ fn selectVersionInternal(
 }
 
 test selectVersionInternal {
+    @setEvalBranchQuota(6_000);
     const expect = std.testing.expect;
     const expectEqual = std.testing.expectEqual;
     const parse = std.SemanticVersion.parse;

--- a/src/translate_c.zig
+++ b/src/translate_c.zig
@@ -223,8 +223,8 @@ pub fn translate(
                 // log.debug("zig-version: {s}", .{zcs.receive_fifo.readableSliceOfLen(header.bytes_len)});
                 zcs.pooler.fifo(.in).discard(header.bytes_len);
             },
-            .emit_bin_path => {
-                const body_size = @sizeOf(std.zig.Server.Message.EmitBinPath);
+            .emit_digest => {
+                const body_size = @sizeOf(std.zig.Server.Message.EmitDigest);
                 if (header.bytes_len <= body_size) return error.InvalidResponse;
 
                 _ = try zcs.receiveEmitBinPath();

--- a/tests/language_features/cimport.zig
+++ b/tests/language_features/cimport.zig
@@ -117,6 +117,7 @@ fn testTranslate(c_source: []const u8) !translate_c.Result {
             const path = try zls.URI.parse(allocator, uri);
             defer allocator.free(path);
             try std.testing.expect(std.fs.path.isAbsolute(path));
+            try std.fs.accessAbsolute(path, .{});
         },
         .failure => |message| {
             try std.testing.expect(message.errorMessageCount() != 0);


### PR DESCRIPTION
From the last master changes of the commit: "dffc8c4", they changed "emit_bin_path" to "emit_digest", so the build of zls was broken for the latest master, updating these result in a succeful build