### PR TITLE
better build-on-save

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -15,9 +15,9 @@
             "default": true
         },
         "enable_build_on_save": {
-            "description": "Whether to enable build-on-save diagnostics",
+            "description": "Whether to enable build-on-save diagnostics. Will be automatically enabled if the `build.zig` has declared a 'check' step.",
             "type": "boolean",
-            "default": false
+            "default": null
         },
         "build_on_save_args": {
             "description": "Specify which arguments should be passed to Zig when running build-on-save.\n\nIf the `build.zig` has declared a 'check' step, it will be preferred over the default 'install' step.",

--- a/schema.json
+++ b/schema.json
@@ -19,10 +19,13 @@
             "type": "boolean",
             "default": false
         },
-        "build_on_save_step": {
-            "description": "Select which step should be executed on build-on-save",
-            "type": "string",
-            "default": "install"
+        "build_on_save_args": {
+            "description": "Specify which arguments should be passed to Zig when running build-on-save.\n\nIf the `build.zig` has declared a 'check' step, it will be preferred over the default 'install' step.",
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "default": []
         },
         "enable_autofix": {
             "description": "Whether to automatically fix errors on save. Currently supports adding and removing discards.",

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -10,8 +10,8 @@ enable_snippets: bool = true,
 /// Whether to enable function argument placeholder completions
 enable_argument_placeholders: bool = true,
 
-/// Whether to enable build-on-save diagnostics
-enable_build_on_save: bool = false,
+/// Whether to enable build-on-save diagnostics. Will be automatically enabled if the `build.zig` has declared a 'check' step.
+enable_build_on_save: ?bool = null,
 
 /// Specify which arguments should be passed to Zig when running build-on-save.
 ///

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -13,8 +13,10 @@ enable_argument_placeholders: bool = true,
 /// Whether to enable build-on-save diagnostics
 enable_build_on_save: bool = false,
 
-/// Select which step should be executed on build-on-save
-build_on_save_step: []const u8 = "install",
+/// Specify which arguments should be passed to Zig when running build-on-save.
+///
+/// If the `build.zig` has declared a 'check' step, it will be preferred over the default 'install' step.
+build_on_save_args: []const []const u8 = &.{},
 
 /// Whether to automatically fix errors on save. Currently supports adding and removing discards.
 enable_autofix: bool = false,

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -945,7 +945,7 @@ pub fn updateConfiguration(
         server.document_store.cimports.clearAndFree(server.document_store.allocator);
 
         if (std.process.can_spawn and
-            server.config.enable_build_on_save and
+            server.config.enable_build_on_save != false and
             server.client_capabilities.supports_publish_diagnostics)
         {
             try server.pushJob(.run_build_on_save);
@@ -1018,7 +1018,7 @@ pub fn updateConfiguration(
         }
     }
 
-    if (server.config.enable_build_on_save) {
+    if (server.config.enable_build_on_save orelse false) {
         if (!std.process.can_spawn) {
             log.info("'enable_build_on_save' is ignored because your OS can't spawn a child process", .{});
         } else if (server.status == .initialized and server.config.zig_exe_path == null) {
@@ -1354,7 +1354,7 @@ fn saveDocumentHandler(server: *Server, arena: std.mem.Allocator, notification: 
     }
 
     if (std.process.can_spawn and
-        server.config.enable_build_on_save and
+        server.config.enable_build_on_save != false and
         server.client_capabilities.supports_publish_diagnostics)
     {
         try server.pushJob(.run_build_on_save);

--- a/src/features/diagnostics.zig
+++ b/src/features/diagnostics.zig
@@ -215,12 +215,9 @@ pub fn generateBuildOnSaveDiagnostics(
         },
     };
 
-    log.info("Running build-on-save: {s} ({s})", .{ build_zig_path, server.config.build_on_save_step });
-
     const base_args = &[_][]const u8{
         zig_exe_path,
         "build",
-        server.config.build_on_save_step,
         "--zig-lib-dir",
         zig_lib_path,
         "-fno-reference-trace",
@@ -228,9 +225,10 @@ pub fn generateBuildOnSaveDiagnostics(
         "none",
     };
 
-    var argv = try std.ArrayListUnmanaged([]const u8).initCapacity(arena, base_args.len);
+    var argv = try std.ArrayListUnmanaged([]const u8).initCapacity(arena, base_args.len + server.config.build_on_save_args.len);
     defer argv.deinit(arena);
     argv.appendSliceAssumeCapacity(base_args);
+    argv.appendSliceAssumeCapacity(server.config.build_on_save_args);
 
     blk: {
         server.document_store.lock.lockShared();

--- a/src/features/diagnostics.zig
+++ b/src/features/diagnostics.zig
@@ -267,6 +267,10 @@ pub fn generateBuildOnSaveDiagnostics(
         }
     }
 
+    if (!(server.config.enable_build_on_save orelse has_check_step)) {
+        return;
+    }
+
     if (has_check_step) {
         std.debug.assert(!has_explicit_steps);
         try argv.append(arena, "check");

--- a/src/tools/config.json
+++ b/src/tools/config.json
@@ -19,10 +19,10 @@
             "default": false
         },
         {
-            "name": "build_on_save_step",
-            "description": "Select which step should be executed on build-on-save",
-            "type": "[]const u8",
-            "default": "install"
+            "name": "build_on_save_args",
+            "description": "Specify which arguments should be passed to Zig when running build-on-save.\n\nIf the `build.zig` has declared a 'check' step, it will be preferred over the default 'install' step.",
+            "type": "[]const []const u8",
+            "default": []
         },
         {
             "name": "enable_autofix",

--- a/src/tools/config.json
+++ b/src/tools/config.json
@@ -14,9 +14,9 @@
         },
         {
             "name": "enable_build_on_save",
-            "description": "Whether to enable build-on-save diagnostics",
-            "type": "bool",
-            "default": false
+            "description": "Whether to enable build-on-save diagnostics. Will be automatically enabled if the `build.zig` has declared a 'check' step.",
+            "type": "?bool",
+            "default": null
         },
         {
             "name": "build_on_save_args",

--- a/src/tools/config_gen.zig
+++ b/src/tools/config_gen.zig
@@ -16,17 +16,17 @@ const ConfigOption = struct {
     default: std.json.Value,
 
     fn getTypescriptType(self: ConfigOption) error{UnsupportedType}![]const u8 {
-        return if (std.mem.eql(u8, self.type, "[]const []const u8"))
+        std.debug.assert(self.type.len != 0);
+        const ty = self.type[@intFromBool(self.type[0] == '?')..];
+        return if (std.mem.eql(u8, ty, "[]const []const u8"))
             "array"
-        else if (std.mem.eql(u8, self.type, "[]const u8"))
+        else if (std.mem.eql(u8, ty, "[]const u8"))
             "string"
-        else if (std.mem.eql(u8, self.type, "?[]const u8"))
-            "string"
-        else if (std.mem.eql(u8, self.type, "bool"))
+        else if (std.mem.eql(u8, ty, "bool"))
             "boolean"
-        else if (std.mem.eql(u8, self.type, "usize"))
+        else if (std.mem.eql(u8, ty, "usize"))
             "integer"
-        else if (std.mem.eql(u8, self.type, "enum"))
+        else if (std.mem.eql(u8, ty, "enum"))
             "string"
         else
             error.UnsupportedType;
@@ -276,7 +276,8 @@ fn generateVSCodeConfigFile(allocator: std.mem.Allocator, config: Config, path: 
             .description = option.description,
             .@"enum" = option.@"enum",
             .format = if (std.mem.indexOf(u8, option.name, "path") != null) "path" else null,
-            .default = default,
+            // "enable_build_on_save" need to be explicitly set to 'null' so that it doesn't default to 'false'
+            .default = default orelse .null,
         });
     }
 


### PR DESCRIPTION
- `build_on_save_step` has been replaced by `build_on_save_args`
- build-on-save will automatically prefer a 'check' step over the default 'install' if available
- build-on-save will automatically be enabled if a 'check' step is found
fixes #1918

Build on save configuration still needs to be made per-project configurable. 