### PR TITLE
lsp_hover: format function signatures if needed

### DIFF
--- a/src/features/hover.zig
+++ b/src/features/hover.zig
@@ -152,7 +152,7 @@ fn hoverSymbolRecursive(
         for (doc_strings.items) |doc|
             try writer.print("{s}\n\n", .{doc});
         if (is_fn) {
-            try writer.print("```zig\n{s}\n```", .{def_str});
+            try Analyser.formatFunctionSignatureMarkdown(def_str, writer);
         } else {
             try writer.print("```zig\n{s}\n```\n```zig\n({s})\n```", .{ def_str, resolved_type_str });
         }

--- a/tests/lsp_features/hover.zig
+++ b/tests/lsp_features/hover.zig
@@ -923,6 +923,33 @@ test "function parameter" {
     );
 }
 
+test "nested" {
+    try testHover(
+        \\const Error = error{InvalidBaz};
+        \\pub fn FooResponse(comptime T: type) type {
+        \\  return struct {baz: T};
+        \\}
+        \\
+        \\pub fn Foo(comptime T: type) type {
+        \\  return struct {
+        \\      pub fn fooAnd<cursor>Bar(self: *T, baz: u8) (Error || error{
+        \\          InvalidFoo,
+        \\          InvalidBar,
+        \\      })!FooResponse(T) {}
+        \\  };
+        \\}
+    ,
+        \\```zig
+        \\fn fooAndBar(self: *T, baz: u8) (Error || error{
+        \\    InvalidFoo,
+        \\    InvalidBar,
+        \\})!FooResponse(T)
+        \\```
+        \\
+        \\Go to [FooResponse](file:///test.zig#L2)
+    );
+}
+
 test "optional" {
     try testHover(
         \\const S = struct { a: i32 };


### PR DESCRIPTION
Some function signatures when you hover don't get indented if they are nested decls. This pr is to add the ability to format them.

On hover before:
![image](https://github.com/user-attachments/assets/e304c05e-bc60-4c11-8f96-fd4da267711f)

On hover after
![image](https://github.com/user-attachments/assets/8f1b0f9c-b718-47df-86be-151824c56c2c)
