### PR TITLE
WIP: fix: multiline string literals

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -2064,10 +2064,9 @@ fn resolveTypeOfNodeUncached(analyser: *Analyser, node_handle: NodeWithHandle) e
 
             var length: u64 = 0;
 
-            for (start..end + 1, 0..) |token_index, i| {
+            for (start..end + 1) |token_index| {
                 const slice = tree.tokenSlice(@intCast(token_index));
-                const carriage_return_ending: usize = if (slice[slice.len - 2] == '\r') 2 else 1;
-                length += slice.len - carriage_return_ending - 2 + @intFromBool(i != 0);
+                length += slice.len;
             }
 
             const string_literal_type = try analyser.ip.get(analyser.gpa, .{ .pointer_type = .{


### PR DESCRIPTION
Fix for Zig #21358, #21360, which change tokenizing of multiline string literals to not include newlines.  See [ziglang/zig#21371](https://github.com/ziglang/zig/pull/21371/).

This just changes the tokenizer, ZLS no longer SIGKILLs immediately, the integer underflow is gone from the tests, but several tests don't pass (which is to be expected).

I wanted to get some eyes on the fix, since I'm unfamiliar with the codebase, before trying to modify the tests to pass.  Changing tests to pass a newly introduced bug would be unfriendly, after all.

Also, the fix includes doc comments, I don't think that affects ZLS the same way, but I could be wrong and it seemed worth mentioning.