### PR TITLE
Add option to opt-out of closing argument parameter brace when completing a function

### DIFF
--- a/src/Config.zig
+++ b/src/Config.zig
@@ -10,6 +10,9 @@ enable_snippets: bool = true,
 /// Whether to enable function argument placeholder completions
 enable_argument_placeholders: bool = true,
 
+/// Whether to automatically close parameter braces
+enable_auto_close_parameter_braces: bool = true,
+
 /// Whether to enable build-on-save diagnostics. Will be automatically enabled if the `build.zig` has declared a 'check' step.
 enable_build_on_save: ?bool = null,
 

--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -338,26 +338,28 @@ fn functionTypeCompletion(
                     .snippet_placeholders = true,
                 })});
             }
+            if (builder.server.config.enable_auto_close_parameter_braces) {
+                switch (func.ast.params.len) {
+                    // No arguments, leave cursor at the end
+                    0 => break :blk try std.fmt.allocPrint(builder.arena, "{s}()", .{func_name}),
+                    1 => {
+                        if (has_self_param) {
+                            // The one argument is a self parameter, leave cursor at the end
+                            break :blk try std.fmt.allocPrint(builder.arena, "{s}()", .{func_name});
+                        }
 
-            switch (func.ast.params.len) {
-                // No arguments, leave cursor at the end
-                0 => break :blk try std.fmt.allocPrint(builder.arena, "{s}()", .{func_name}),
-                1 => {
-                    if (has_self_param) {
-                        // The one argument is a self parameter, leave cursor at the end
-                        break :blk try std.fmt.allocPrint(builder.arena, "{s}()", .{func_name});
-                    }
-
-                    // Non-self parameter, leave the cursor in the parentheses
-                    if (!use_snippets) break :blk func_name;
-                    break :blk try std.fmt.allocPrint(builder.arena, "{s}(${{1:}})", .{func_name});
-                },
-                else => {
-                    // Atleast one non-self parameter, leave the cursor in the parentheses
-                    if (!use_snippets) break :blk func_name;
-                    break :blk try std.fmt.allocPrint(builder.arena, "{s}(${{1:}})", .{func_name});
-                },
+                        // Non-self parameter, leave the cursor in the parentheses
+                        if (!use_snippets) break :blk func_name;
+                        break :blk try std.fmt.allocPrint(builder.arena, "{s}(${{1:}})", .{func_name});
+                    },
+                    else => {
+                        // Atleast one non-self parameter, leave the cursor in the parentheses
+                        if (!use_snippets) break :blk func_name;
+                        break :blk try std.fmt.allocPrint(builder.arena, "{s}(${{1:}})", .{func_name});
+                    },
+                }
             }
+            break :blk try std.fmt.allocPrint(builder.arena, "{s}(", .{func_name});
         },
     };
 


### PR DESCRIPTION
Still creates the first open parameter brace

This helps me when I want to wrap an existing value in a new function, since I tend to program inside-out, and the closing brace was creating a lot of friction.

I don't know if maybe this setting should just be grouped with enable_argument_placeholders somehow, since they conflict with each other when both enabled.