### PR TITLE
Ignore failure in Watch.init and just return

### DIFF
--- a/src/build_runner/0.12.0.zig
+++ b/src/build_runner/0.12.0.zig
@@ -419,7 +419,7 @@ pub fn main() !void {
         else => false,
     };
     if (!watch_suported) return;
-    var w = try Watch.init();
+    var w = Watch.init() catch return;
 
     var step_stack = try stepNamesToStepStack(gpa, builder, targets.items);
 


### PR DESCRIPTION
Addresses #2040 but a change in Zig is required before it closes our bug: https://github.com/ziglang/zig/issues/21543#issuecomment-2381281698
