### PR TITLE
fix: enum member declarations can now be renamed correctly.

### DIFF
--- a/src/features/references.zig
+++ b/src/features/references.zig
@@ -68,6 +68,8 @@ const Builder = struct {
     locations: std.ArrayListUnmanaged(types.Location) = .{},
     /// this is the declaration we are searching for
     decl_handle: Analyser.DeclWithHandle,
+    /// Whether the `decl_handle` has been added
+    did_add_decl_handle: bool = false,
     analyser: *Analyser,
     encoding: offsets.Encoding,
 
@@ -81,6 +83,12 @@ const Builder = struct {
     }
 
     fn add(self: *Builder, handle: *DocumentStore.Handle, token_index: Ast.TokenIndex) error{OutOfMemory}!void {
+        if (self.decl_handle.handle == handle and
+            self.decl_handle.nameToken() == token_index)
+        {
+            if (self.did_add_decl_handle) return;
+            self.did_add_decl_handle = true;
+        }
         try self.locations.append(self.allocator, .{
             .uri = handle.uri,
             .range = offsets.tokenToRange(handle.tree, token_index, self.encoding),

--- a/tests/lsp_features/references.zig
+++ b/tests/lsp_features/references.zig
@@ -97,6 +97,16 @@ test "for/while capture" {
     );
 }
 
+test "enum field access" {
+    try testReferences(
+        \\const E = enum {
+        \\  <0>,
+        \\  bar
+        \\};
+        \\const e = E.<0>;
+    );
+}
+
 test "struct field access" {
     try testReferences(
         \\const S = struct {<0>: u32 = 3};


### PR DESCRIPTION
Fixes #2042.

Currently, renaming enum field members will return two duplicate edit actions in the LSP response.
On VSCode, this causes the editor to raise an error.
On Emacs, Neovim, and Helix, the edits made are incorrect.

The`symbolReferences` function tries to find all references to a declaration *and* the declaration itself (when `include_decls` flag is set). However, when searching for the references to an enum member like in here:

```zig
const Number = enum {
  zero, // <-- rename triggered from here
  one
};

const myZero = Number.zero; // <-- rename should happen here too
_ = myZero;
```

The first identifier `zero` is treated first as a declaration and then *also as a reference*.
This edge case can be handled by ensuring the name token for a symbol's declaration is never the same as its reference's name token.

Ideally, the `lookup` function should never be called for a container field init identifier, but the way AST traversal works right now, there is no straightforward way to figure out if the node we're currently on declares an enum member.

Before:


https://github.com/user-attachments/assets/289b466b-f8a0-4edd-9516-cf70a6530543


After:

https://github.com/user-attachments/assets/142d1995-9377-4bda-9488-53508a582bcd


