### PR TITLE
fix: goto type definition for annotated variable declarations

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -3111,6 +3111,10 @@ pub const NodeWithHandle = struct {
         if (a.node != b.node) return false;
         return std.mem.eql(u8, a.handle.uri, b.handle.uri);
     }
+
+    pub fn resolveType(self: NodeWithHandle, analyser: *Analyser) error{OutOfMemory}!?Type {
+        return analyser.resolveTypeOfNodeInternal(self);
+    }
 };
 
 pub fn getFieldAccessType(

--- a/tests/lsp_features/definition.zig
+++ b/tests/lsp_features/definition.zig
@@ -30,6 +30,11 @@ test "global variable" {
     try testDefinition(
         \\const <def><decl><>foo</decl></def>: <tdef>u32</tdef> = 5;
     );
+
+    try testDefinition(
+        \\const S = <tdef>struct</tdef> { alpha: u32 };
+        \\const <>s: S  = S{ .alpha = 5 };
+    );
 }
 
 test "local variable" {


### PR DESCRIPTION
Fixes #2020.
Includes a test as well.

Previously, to serve `textDocument/typeDefinition`, we just called `resolveType`, which could return annotations.
But we never resolved those annotations to their place of declaration.
Now, we attempt to do that and fall back to the old logic (of resolving to the annotation) if the resolution fails.