### PR TITLE
Code action to organize imports

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -1633,10 +1633,8 @@ fn codeActionHandler(server: *Server, arena: std.mem.Allocator, request: types.C
         try builder.generateCodeAction(diagnostic, &actions, &remove_capture_actions);
     }
 
-    const providedDiagnostics = request.context.diagnostics;
-    for (providedDiagnostics) |diagnostic| {
-        try builder.generateCodeAction(diagnostic, &actions, &remove_capture_actions);
-    }
+    // Always generate code action organizeImports
+    try builder.generateOrganizeImportsAction(&actions);
 
     const Result = lsp.types.getRequestMetadata("textDocument/codeAction").?.Result;
     const result = try arena.alloc(std.meta.Child(std.meta.Child(Result)), actions.items.len);

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -1633,6 +1633,11 @@ fn codeActionHandler(server: *Server, arena: std.mem.Allocator, request: types.C
         try builder.generateCodeAction(diagnostic, &actions, &remove_capture_actions);
     }
 
+    const providedDiagnostics = request.context.diagnostics;
+    for (providedDiagnostics) |diagnostic| {
+        try builder.generateCodeAction(diagnostic, &actions, &remove_capture_actions);
+    }
+
     const Result = lsp.types.getRequestMetadata("textDocument/codeAction").?.Result;
     const result = try arena.alloc(std.meta.Child(std.meta.Child(Result)), actions.items.len);
     for (actions.items, result) |action, *out| {

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -615,7 +615,7 @@ fn initializeHandler(server: *Server, arena: std.mem.Allocator, request: types.I
             },
             .documentHighlightProvider = .{ .bool = true },
             .hoverProvider = .{ .bool = true },
-            .codeActionProvider = .{ .CodeActionOptions = .{ .codeActionKinds = code_actions.supportedCodeActions() } },
+            .codeActionProvider = .{ .CodeActionOptions = .{ .codeActionKinds = code_actions.supported_code_actions } },
             .declarationProvider = .{ .bool = true },
             .definitionProvider = .{ .bool = true },
             .typeDefinitionProvider = .{ .bool = true },

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -615,7 +615,7 @@ fn initializeHandler(server: *Server, arena: std.mem.Allocator, request: types.I
             },
             .documentHighlightProvider = .{ .bool = true },
             .hoverProvider = .{ .bool = true },
-            .codeActionProvider = .{ .bool = true },
+            .codeActionProvider = .{ .CodeActionOptions = .{ .codeActionKinds = code_actions.supportedCodeActions() } },
             .declarationProvider = .{ .bool = true },
             .definitionProvider = .{ .bool = true },
             .typeDefinitionProvider = .{ .bool = true },

--- a/src/features/code_actions.zig
+++ b/src/features/code_actions.zig
@@ -373,10 +373,11 @@ fn handleUnorganizedImport(builder: *Builder, actions: *std.ArrayListUnmanaged(t
 
     const imports = try getImportsDecls(tree, builder.arena);
 
+    // The optimization is disabled because it does not detect the case where imports and other decls are mixed
     // if (std.sort.isSorted(ImportDecl, imports.items, tree, ImportDecl.lessThan)) return;
 
     const sorted_imports = try builder.arena.dupe(ImportDecl, imports.items);
-    std.sort.heap(ImportDecl, sorted_imports, tree, ImportDecl.lessThan);
+    std.mem.sort(ImportDecl, sorted_imports, tree, ImportDecl.lessThan);
 
     var edits = std.ArrayListUnmanaged(types.TextEdit){};
 

--- a/src/features/code_actions.zig
+++ b/src/features/code_actions.zig
@@ -413,14 +413,9 @@ fn handleUnorganizedImport(builder: *Builder, actions: *std.ArrayListUnmanaged(t
         }
         try writer.writeByte('\n');
 
-        const insert_pos: types.Position = pos: {
-            const tokens = tree.tokens.items(.tag);
-            if (tokens.len < 2 or tokens[0] != .container_doc_comment) {
-                break :pos .{ .line = 0, .character = 0 };
-            }
-            // Insert after doc comment
-            break :pos offsets.tokenToPosition(tree, 1, builder.offset_encoding);
-        };
+        const tokens = tree.tokens.items(.tag);
+        const first_token = std.mem.indexOfNone(std.zig.Token.Tag, tokens, &.{.container_doc_comment}) orelse tokens.len;
+        const insert_pos = offsets.tokenToPosition(tree, @intCast(first_token), builder.offset_encoding);
 
         try edits.append(builder.arena, .{
             .range = .{ .start = insert_pos, .end = insert_pos },

--- a/src/features/code_actions.zig
+++ b/src/features/code_actions.zig
@@ -51,6 +51,13 @@ pub const Builder = struct {
         }
     }
 
+    pub fn generateOrganizeImportsAction(
+        builder: *Builder,
+        actions: *std.ArrayListUnmanaged(types.CodeAction),
+    ) error{OutOfMemory}!void {
+        try handleUnorganizedImport(builder, actions);
+    }
+
     pub fn createTextEditLoc(self: *Builder, loc: offsets.Loc, new_text: []const u8) types.TextEdit {
         const range = offsets.locToRange(self.handle.tree.source, loc, self.offset_encoding);
         return types.TextEdit{ .range = range, .newText = new_text };

--- a/src/features/code_actions.zig
+++ b/src/features/code_actions.zig
@@ -477,6 +477,7 @@ pub const ImportDecl = struct {
             if (is_lhs_pub != is_rhs_pub) return is_lhs_pub;
         }
 
+        // 'root' gets sorted after 'builtin'
         if (sort_case_sensitive) {
             return std.mem.lessThan(u8, lhs.getSortSlice(), rhs.getSortSlice());
         } else {
@@ -491,6 +492,7 @@ pub const ImportDecl = struct {
 
         if (std.mem.eql(u8, name, "std")) return .std;
         if (std.mem.eql(u8, name, "builtin")) return .builtin;
+        if (std.mem.eql(u8, name, "root")) return .builtin;
         if (std.mem.eql(u8, name, "build_options")) return .build_options;
 
         return .package;

--- a/src/features/code_actions.zig
+++ b/src/features/code_actions.zig
@@ -77,15 +77,13 @@ pub const Builder = struct {
 };
 
 /// To report server capabilities
-pub fn supportedCodeActions() []const types.CodeActionKind {
-    return &.{
-        .quickfix,
-        .refactor,
-        .source,
-        .@"source.organizeImports",
-        .@"source.fixAll",
-    };
-}
+pub const supported_code_actions: []const types.CodeActionKind = &.{
+    .quickfix,
+    .refactor,
+    .source,
+    .@"source.organizeImports",
+    .@"source.fixAll",
+};
 
 pub fn collectAutoDiscardDiagnostics(
     tree: Ast,

--- a/src/features/code_actions.zig
+++ b/src/features/code_actions.zig
@@ -76,6 +76,17 @@ pub const Builder = struct {
     }
 };
 
+/// To report server capabilities
+pub fn supportedCodeActions() []const types.CodeActionKind {
+    return &.{
+        .quickfix,
+        .refactor,
+        .source,
+        .@"source.organizeImports",
+        .@"source.fixAll",
+    };
+}
+
 pub fn collectAutoDiscardDiagnostics(
     tree: Ast,
     arena: std.mem.Allocator,

--- a/src/features/code_actions.zig
+++ b/src/features/code_actions.zig
@@ -535,7 +535,7 @@ pub const ImportDecl = struct {
         switch (self.getKind()) {
             .file => {
                 if (std.mem.indexOfScalar(u8, self.getSortValue(), '/') != null) {
-                    return self.value[1 .. self.getSortValue().len - 1];
+                    return self.getSortValue()[1 .. self.getSortValue().len - 1];
                 }
                 return self.getSortName();
             },

--- a/src/features/diagnostics.zig
+++ b/src/features/diagnostics.zig
@@ -118,47 +118,6 @@ pub fn generateDiagnostics(server: *Server, arena: std.mem.Allocator, handle: *D
                     else => {},
                 }
             }
-
-            // Organize imports
-            const imports = try code_actions.getImportsDecls(tree, arena);
-            const rootDecls = tree.rootDecls();
-            std.log.debug("Imports: {any}", .{imports.items});
-            std.log.debug("RootDecls: {any}", .{rootDecls});
-            // If there are imports mixed in with other declarations, report them
-            var first_bad_import: usize = 0;
-            for (rootDecls) |decl_idx| {
-                if (first_bad_import >= imports.items.len) break;
-                if (decl_idx != imports.items[first_bad_import].var_decl) break;
-                first_bad_import += 1;
-            }
-            if (first_bad_import < imports.items.len) {
-                for (imports.items[first_bad_import..]) |import_decl| {
-                    try diagnostics.append(arena, .{
-                        .range = offsets.nodeToRange(tree, import_decl.var_decl, server.offset_encoding),
-                        .severity = .Hint,
-                        .code = .{ .string = "unorganized_import" },
-                        .source = "zls",
-                        .message = "unorganized @import statement",
-                    });
-                }
-            }
-            // Now check the order of the imports at the correct position by sorting the indexes
-            const sort_checked = imports.items[0..first_bad_import];
-            var decl_indexes = try arena.alloc(usize, sort_checked.len);
-            for (decl_indexes[0..decl_indexes.len], 0..) |*decl_index, i| {
-                decl_index.* = i;
-            }
-            std.sort.block(usize, decl_indexes, .{ sort_checked, tree }, sortIdxLessThen);
-            for (decl_indexes, 0..) |decl_index, i| {
-                if (decl_index == i) continue;
-                try diagnostics.append(arena, .{
-                    .range = offsets.nodeToRange(tree, sort_checked[i].var_decl, server.offset_encoding),
-                    .severity = .Hint,
-                    .code = .{ .string = "unorganized_import" },
-                    .source = "zls",
-                    .message = "unorganized @import statement",
-                });
-            }
         }
     }
 
@@ -220,13 +179,6 @@ pub fn generateDiagnostics(server: *Server, arena: std.mem.Allocator, handle: *D
         .uri = handle.uri,
         .diagnostics = diagnostics.items,
     };
-}
-
-fn sortIdxLessThen(ctx: struct { []code_actions.ImportDecl, Ast }, lhs: usize, rhs: usize) bool {
-    const imports = ctx[0];
-    const lhs_decl = imports[lhs];
-    const rhs_decl = imports[rhs];
-    return code_actions.ImportDecl.lessThan(ctx[1], lhs_decl, rhs_decl);
 }
 
 pub fn generateBuildOnSaveDiagnostics(

--- a/tests/lsp_features/code_actions.zig
+++ b/tests/lsp_features/code_actions.zig
@@ -413,19 +413,6 @@ test "organize imports" {
         \\
         \\
     , importDiagnostic);
-    // Imports bubble up
-    try testDiagnostic(
-        \\const std = @import("std");
-        \\fn main() void {}
-        \\const abc = @import("abc.zig");
-    ,
-        \\const std = @import("std");
-        \\
-        \\const abc = @import("abc.zig");
-        \\
-        \\fn main() void {}
-        \\
-    , importDiagnostic);
     // Relative paths are sorted by import path
     try testDiagnostic(
         \\const y = @import("a/file2.zig");
@@ -438,8 +425,25 @@ test "organize imports" {
         \\
         \\
     , importDiagnostic);
+}
+
+test "organize imports - bubbles up" {
+    try testDiagnostic(
+        \\const std = @import("std");
+        \\fn main() void {}
+        \\const abc = @import("abc.zig");
+    ,
+        \\const std = @import("std");
+        \\
+        \\const abc = @import("abc.zig");
+        \\
+        \\fn main() void {}
+        \\
+    , importDiagnostic);
+}
+
+test "organize imports - scope" {
     // Ignore imports not in root scope
-    // The imports are sorted by import name
     try testDiagnostic(
         \\const b = @import("a.zig");
         \\const a = @import("b.zig");
@@ -460,6 +464,9 @@ test "organize imports" {
         \\  _ = x; // autofix
         \\}
     , importDiagnostic);
+}
+
+test "organize imports - comments" {
     // Doc comments are preserved
     try testDiagnostic(
         \\const xyz = @import("xyz.zig");
@@ -472,6 +479,24 @@ test "organize imports" {
         \\
         \\
     , importDiagnostic);
+    // Respects top-level doc-comment
+    try testDiagnostic(
+        \\//! A module doc
+        \\
+        \\const abc = @import("abc.zig");
+        \\const std = @import("std");
+    ,
+        \\//! A module doc
+        \\
+        \\const std = @import("std");
+        \\
+        \\const abc = @import("abc.zig");
+        \\
+        \\
+    , importDiagnostic);
+}
+
+test "organize imports - field access" {
     // field access on import
     try testDiagnostic(
         \\const xyz = @import("xyz.zig").a.long.chain;
@@ -482,6 +507,7 @@ test "organize imports" {
         \\
         \\
     , importDiagnostic);
+    // declarations without @import move under other imports for now
     try testDiagnostic(
         \\const xyz = @import("xyz.zig").a.long.chain;
         \\const xyz_related = xyz.related;
@@ -493,6 +519,9 @@ test "organize imports" {
         \\const xyz_related = xyz.related;
         \\
     , importDiagnostic);
+}
+
+test "organize imports - edge cases" {
     // Withstands non-standard behavior
     try testDiagnostic(
         \\const std = @import("std");
@@ -500,21 +529,6 @@ test "organize imports" {
         \\const std = @import("std");
     ,
         \\const std = @import("std");
-        \\const std = @import("std");
-        \\
-        \\const abc = @import("abc.zig");
-        \\
-        \\
-    , importDiagnostic);
-    // Respects top-level doc-comment
-    try testDiagnostic(
-        \\//! A module doc
-        \\
-        \\const abc = @import("abc.zig");
-        \\const std = @import("std");
-    ,
-        \\//! A module doc
-        \\
         \\const std = @import("std");
         \\
         \\const abc = @import("abc.zig");

--- a/tests/lsp_features/code_actions.zig
+++ b/tests/lsp_features/code_actions.zig
@@ -387,9 +387,11 @@ test "organize imports" {
         \\const Config = @import("Config.zig");
         \\const debug = @import("debug.zig");
         \\const Server = @import("Server.zig");
+        \\const root = @import("root");
     ,
         \\const std = @import("std");
         \\const builtin = @import("builtin");
+        \\const root = @import("root");
         \\const build_options = @import("build_options");
         \\
         \\const tres = @import("tres");

--- a/tests/lsp_features/code_actions.zig
+++ b/tests/lsp_features/code_actions.zig
@@ -500,16 +500,57 @@ test "organize imports - field access" {
         \\
         \\
     );
-    // declarations without @import move under other imports for now
+    // declarations without @import move under the parent import
     try testDiagnostic(
         \\const xyz = @import("xyz.zig").a.long.chain;
-        \\const xyz_related = xyz.related;
         \\const abc = @import("abc.zig");
+        \\const abc_related = abc.related;
     ,
         \\const abc = @import("abc.zig");
+        \\const abc_related = abc.related;
         \\const xyz = @import("xyz.zig").a.long.chain;
         \\
+        \\
+    );
+    try testDiagnostic(
+        \\const std = @import("std");
+        \\const builtin = @import("builtin");
+        \\
+        \\const mem = std.mem;
+    ,
+        \\const std = @import("std");
+        \\const mem = std.mem;
+        \\const builtin = @import("builtin");
+        \\
+        \\
+    );
+    // Inverse chain of parents
+    try testDiagnostic(
+        \\const abc = @import("abc.zig");
+        \\const isLower = ascii.isLower;
+        \\const ascii = std.ascii;
+        \\const std = @import("std");
+    ,
+        \\const std = @import("std");
+        \\const ascii = std.ascii;
+        \\const isLower = ascii.isLower;
+        \\
+        \\const abc = @import("abc.zig");
+        \\
+        \\
+    );
+    // Parent chains are not mixed
+    try testDiagnostic(
+        \\const xyz = @import("xyz.zig");
+        \\const abc = @import("abc.zig");
         \\const xyz_related = xyz.related;
+        \\const abc_related = abc.related;
+    ,
+        \\const abc = @import("abc.zig");
+        \\const abc_related = abc.related;
+        \\const xyz = @import("xyz.zig");
+        \\const xyz_related = xyz.related;
+        \\
         \\
     );
 }

--- a/tests/lsp_features/code_actions.zig
+++ b/tests/lsp_features/code_actions.zig
@@ -573,8 +573,6 @@ fn testAutofixOptions(before: []const u8, after: []const u8, want_zir: bool) !vo
     var text_edits: std.ArrayListUnmanaged(types.TextEdit) = .{};
     defer text_edits.deinit(allocator);
 
-    // std.log.err("Response: {any}", .{response});
-
     for (response) |action| {
         const code_action = action.CodeAction;
         if (code_action.kind.? != .@"source.fixAll") continue;
@@ -601,17 +599,13 @@ fn testDiagnostic(before: []const u8, after: []const u8, diagnostic: types.Diagn
     const uri = try ctx.addDocument(before);
     const handle = ctx.server.document_store.getHandle(uri).?;
 
-    var diagnostics: std.ArrayListUnmanaged(types.Diagnostic) = .{};
-    try diagnostics.append(allocator, diagnostic);
-    defer diagnostics.deinit(allocator);
-
     const params = types.CodeActionParams{
         .textDocument = .{ .uri = uri },
         .range = .{
             .start = .{ .line = 0, .character = 0 },
             .end = offsets.indexToPosition(before, before.len, ctx.server.offset_encoding),
         },
-        .context = .{ .diagnostics = diagnostics.items },
+        .context = .{ .diagnostics = &.{diagnostic} },
     };
 
     @setEvalBranchQuota(5000);
@@ -622,8 +616,6 @@ fn testDiagnostic(before: []const u8, after: []const u8, diagnostic: types.Diagn
 
     var text_edits: std.ArrayListUnmanaged(types.TextEdit) = .{};
     defer text_edits.deinit(allocator);
-
-    // std.log.err("Response: {any}", .{response});
 
     for (response) |action| {
         const code_action = action.CodeAction;

--- a/tests/lsp_features/code_actions.zig
+++ b/tests/lsp_features/code_actions.zig
@@ -383,7 +383,7 @@ test "organize imports" {
         \\const xyz = @import("xyz.zig");
         \\
         \\
-    , importDiagnostic);
+    );
     // Three different import groups: std, build_options and builtin, but these groups do not have separator
     // Builtin comes before build_options despite alphabetical order (they are different import kinds)
     // Case insensitive, pub is preserved
@@ -412,7 +412,7 @@ test "organize imports" {
         \\const Server = @import("Server.zig");
         \\
         \\
-    , importDiagnostic);
+    );
     // Relative paths are sorted by import path
     try testDiagnostic(
         \\const y = @import("a/file2.zig");
@@ -424,7 +424,7 @@ test "organize imports" {
         \\const x = @import("a/file3.zig");
         \\
         \\
-    , importDiagnostic);
+    );
 }
 
 test "organize imports - bubbles up" {
@@ -439,7 +439,7 @@ test "organize imports - bubbles up" {
         \\
         \\fn main() void {}
         \\
-    , importDiagnostic);
+    );
 }
 
 test "organize imports - scope" {
@@ -463,7 +463,7 @@ test "organize imports - scope" {
         \\  _ = y; // autofix
         \\  _ = x; // autofix
         \\}
-    , importDiagnostic);
+    );
 }
 
 test "organize imports - comments" {
@@ -478,7 +478,7 @@ test "organize imports - comments" {
         \\const xyz = @import("xyz.zig");
         \\
         \\
-    , importDiagnostic);
+    );
     // Respects top-level doc-comment
     try testDiagnostic(
         \\//! A module doc
@@ -493,7 +493,7 @@ test "organize imports - comments" {
         \\const abc = @import("abc.zig");
         \\
         \\
-    , importDiagnostic);
+    );
 }
 
 test "organize imports - field access" {
@@ -506,7 +506,7 @@ test "organize imports - field access" {
         \\const xyz = @import("xyz.zig").a.long.chain;
         \\
         \\
-    , importDiagnostic);
+    );
     // declarations without @import move under other imports for now
     try testDiagnostic(
         \\const xyz = @import("xyz.zig").a.long.chain;
@@ -518,7 +518,7 @@ test "organize imports - field access" {
         \\
         \\const xyz_related = xyz.related;
         \\
-    , importDiagnostic);
+    );
 }
 
 test "organize imports - edge cases" {
@@ -534,7 +534,7 @@ test "organize imports - edge cases" {
         \\const abc = @import("abc.zig");
         \\
         \\
-    , importDiagnostic);
+    );
 }
 
 fn testAutofix(before: []const u8, after: []const u8) !void {
@@ -552,8 +552,7 @@ fn testAutofixOptions(before: []const u8, after: []const u8, want_zir: bool) !vo
     const handle = ctx.server.document_store.getHandle(uri).?;
 
     var diagnostics: std.ArrayListUnmanaged(types.Diagnostic) = .{};
-    // try zls.diagnostics.getAstCheckDiagnostics(ctx.server, ctx.arena.allocator(), handle, &diagnostics);
-    defer diagnostics.deinit(allocator);
+    try zls.diagnostics.getAstCheckDiagnostics(ctx.server, ctx.arena.allocator(), handle, &diagnostics);
 
     const params = types.CodeActionParams{
         .textDocument = .{ .uri = uri },
@@ -591,7 +590,7 @@ fn testAutofixOptions(before: []const u8, after: []const u8, want_zir: bool) !vo
     try std.testing.expectEqualStrings(after, handle.tree.source);
 }
 
-fn testDiagnostic(before: []const u8, after: []const u8, diagnostic: types.Diagnostic) !void {
+fn testDiagnostic(before: []const u8, after: []const u8) !void {
     var ctx = try Context.init();
     defer ctx.deinit();
     ctx.server.config.enable_autofix = true;
@@ -605,7 +604,7 @@ fn testDiagnostic(before: []const u8, after: []const u8, diagnostic: types.Diagn
             .start = .{ .line = 0, .character = 0 },
             .end = offsets.indexToPosition(before, before.len, ctx.server.offset_encoding),
         },
-        .context = .{ .diagnostics = &.{diagnostic} },
+        .context = .{ .diagnostics = &.{} },
     };
 
     @setEvalBranchQuota(5000);

--- a/tests/lsp_features/code_actions.zig
+++ b/tests/lsp_features/code_actions.zig
@@ -544,9 +544,11 @@ test "organize imports - field access" {
         \\const xyz = @import("xyz.zig");
         \\const abc = @import("abc.zig");
         \\const xyz_related = xyz.related;
+        \\/// comment
         \\const abc_related = abc.related;
     ,
         \\const abc = @import("abc.zig");
+        \\/// comment
         \\const abc_related = abc.related;
         \\const xyz = @import("xyz.zig");
         \\const xyz_related = xyz.related;

--- a/tests/lsp_features/code_actions.zig
+++ b/tests/lsp_features/code_actions.zig
@@ -363,17 +363,6 @@ test "ignore autofix comment whitespace" {
     );
 }
 
-const importDiagnostic = types.Diagnostic{
-    .range = .{
-        .start = .{ .line = 1, .character = 0 },
-        .end = .{ .line = 2, .character = 0 },
-    },
-    .severity = .Hint,
-    .code = .{ .string = "unorganized_import" },
-    .source = "zls",
-    .message = "unorganized @import statement",
-};
-
 test "organize imports" {
     try testDiagnostic(
         \\const xyz = @import("xyz.zig");
@@ -482,11 +471,13 @@ test "organize imports - comments" {
     // Respects top-level doc-comment
     try testDiagnostic(
         \\//! A module doc
+        \\//! Another line
         \\
         \\const abc = @import("abc.zig");
         \\const std = @import("std");
     ,
         \\//! A module doc
+        \\//! Another line
         \\
         \\const std = @import("std");
         \\

--- a/tests/lsp_features/code_actions.zig
+++ b/tests/lsp_features/code_actions.zig
@@ -363,6 +363,166 @@ test "ignore autofix comment whitespace" {
     );
 }
 
+const importDiagnostic = types.Diagnostic{
+    .range = .{
+        .start = .{ .line = 1, .character = 0 },
+        .end = .{ .line = 2, .character = 0 },
+    },
+    .severity = .Hint,
+    .code = .{ .string = "unorganized_import" },
+    .source = "zls",
+    .message = "unorganized @import statement",
+};
+
+test "organize imports" {
+    try testDiagnostic(
+        \\const xyz = @import("xyz.zig");
+        \\const abc = @import("abc.zig");
+    ,
+        \\const abc = @import("abc.zig");
+        \\const xyz = @import("xyz.zig");
+        \\
+        \\
+    , importDiagnostic);
+    // Three different import groups: std, build_options and builtin, but these groups do not have separator
+    // Builtin comes before build_options despite alphabetical order (they are different import kinds)
+    // Case insensitive, pub is preserved
+    try testDiagnostic(
+        \\const std = @import("std");
+        \\const abc = @import("abc.zig");
+        \\const build_options = @import("build_options");
+        \\const builtin = @import("builtin");
+        \\const tres = @import("tres");
+        \\
+        \\pub const offsets = @import("offsets.zig");
+        \\const Config = @import("Config.zig");
+        \\const debug = @import("debug.zig");
+        \\const Server = @import("Server.zig");
+    ,
+        \\const std = @import("std");
+        \\const builtin = @import("builtin");
+        \\const build_options = @import("build_options");
+        \\
+        \\const tres = @import("tres");
+        \\
+        \\const abc = @import("abc.zig");
+        \\const Config = @import("Config.zig");
+        \\const debug = @import("debug.zig");
+        \\pub const offsets = @import("offsets.zig");
+        \\const Server = @import("Server.zig");
+        \\
+        \\
+    , importDiagnostic);
+    // Imports bubble up
+    try testDiagnostic(
+        \\const std = @import("std");
+        \\fn main() void {}
+        \\const abc = @import("abc.zig");
+    ,
+        \\const std = @import("std");
+        \\
+        \\const abc = @import("abc.zig");
+        \\
+        \\fn main() void {}
+        \\
+    , importDiagnostic);
+    // Relative paths are sorted by import path
+    try testDiagnostic(
+        \\const y = @import("a/file2.zig");
+        \\const x = @import("a/file3.zig");
+        \\const z = @import("a/file1.zig");
+    ,
+        \\const z = @import("a/file1.zig");
+        \\const y = @import("a/file2.zig");
+        \\const x = @import("a/file3.zig");
+        \\
+        \\
+    , importDiagnostic);
+    // Ignore imports not in root scope
+    // The imports are sorted by import name
+    try testDiagnostic(
+        \\const b = @import("a.zig");
+        \\const a = @import("b.zig");
+        \\fn main() void {
+        \\  const y = @import("y");
+        \\  const x = @import("x");
+        \\  _ = y; // autofix
+        \\  _ = x; // autofix
+        \\}
+    ,
+        \\const a = @import("b.zig");
+        \\const b = @import("a.zig");
+        \\
+        \\fn main() void {
+        \\  const y = @import("y");
+        \\  const x = @import("x");
+        \\  _ = y; // autofix
+        \\  _ = x; // autofix
+        \\}
+    , importDiagnostic);
+    // Doc comments are preserved
+    try testDiagnostic(
+        \\const xyz = @import("xyz.zig");
+        \\/// Do not look inside
+        \\const abc = @import("abc.zig");
+    ,
+        \\/// Do not look inside
+        \\const abc = @import("abc.zig");
+        \\const xyz = @import("xyz.zig");
+        \\
+        \\
+    , importDiagnostic);
+    // field access on import
+    try testDiagnostic(
+        \\const xyz = @import("xyz.zig").a.long.chain;
+        \\const abc = @import("abc.zig");
+    ,
+        \\const abc = @import("abc.zig");
+        \\const xyz = @import("xyz.zig").a.long.chain;
+        \\
+        \\
+    , importDiagnostic);
+    try testDiagnostic(
+        \\const xyz = @import("xyz.zig").a.long.chain;
+        \\const xyz_related = xyz.related;
+        \\const abc = @import("abc.zig");
+    ,
+        \\const abc = @import("abc.zig");
+        \\const xyz = @import("xyz.zig").a.long.chain;
+        \\
+        \\const xyz_related = xyz.related;
+        \\
+    , importDiagnostic);
+    // Withstands non-standard behavior
+    try testDiagnostic(
+        \\const std = @import("std");
+        \\const abc = @import("abc.zig");
+        \\const std = @import("std");
+    ,
+        \\const std = @import("std");
+        \\const std = @import("std");
+        \\
+        \\const abc = @import("abc.zig");
+        \\
+        \\
+    , importDiagnostic);
+    // Respects top-level doc-comment
+    try testDiagnostic(
+        \\//! A module doc
+        \\
+        \\const abc = @import("abc.zig");
+        \\const std = @import("std");
+    ,
+        \\//! A module doc
+        \\
+        \\const std = @import("std");
+        \\
+        \\const abc = @import("abc.zig");
+        \\
+        \\
+    , importDiagnostic);
+}
+
 fn testAutofix(before: []const u8, after: []const u8) !void {
     try testAutofixOptions(before, after, true); // diagnostics come from our AstGen fork
     try testAutofixOptions(before, after, false); // diagnostics come from calling zig ast-check
@@ -378,7 +538,8 @@ fn testAutofixOptions(before: []const u8, after: []const u8, want_zir: bool) !vo
     const handle = ctx.server.document_store.getHandle(uri).?;
 
     var diagnostics: std.ArrayListUnmanaged(types.Diagnostic) = .{};
-    try zls.diagnostics.getAstCheckDiagnostics(ctx.server, ctx.arena.allocator(), handle, &diagnostics);
+    // try zls.diagnostics.getAstCheckDiagnostics(ctx.server, ctx.arena.allocator(), handle, &diagnostics);
+    defer diagnostics.deinit(allocator);
 
     const params = types.CodeActionParams{
         .textDocument = .{ .uri = uri },
@@ -398,9 +559,60 @@ fn testAutofixOptions(before: []const u8, after: []const u8, want_zir: bool) !vo
     var text_edits: std.ArrayListUnmanaged(types.TextEdit) = .{};
     defer text_edits.deinit(allocator);
 
+    // std.log.err("Response: {any}", .{response});
+
     for (response) |action| {
         const code_action = action.CodeAction;
         if (code_action.kind.? != .@"source.fixAll") continue;
+        const workspace_edit = code_action.edit.?;
+        const changes = workspace_edit.changes.?.map;
+        try std.testing.expectEqual(@as(usize, 1), changes.count());
+        try std.testing.expect(changes.contains(uri));
+
+        try text_edits.appendSlice(allocator, changes.get(uri).?);
+    }
+
+    const actual = try zls.diff.applyTextEdits(allocator, before, text_edits.items, ctx.server.offset_encoding);
+    defer allocator.free(actual);
+    try ctx.server.document_store.refreshDocument(uri, try allocator.dupeZ(u8, actual));
+
+    try std.testing.expectEqualStrings(after, handle.tree.source);
+}
+
+fn testDiagnostic(before: []const u8, after: []const u8, diagnostic: types.Diagnostic) !void {
+    var ctx = try Context.init();
+    defer ctx.deinit();
+    ctx.server.config.enable_autofix = true;
+
+    const uri = try ctx.addDocument(before);
+    const handle = ctx.server.document_store.getHandle(uri).?;
+
+    var diagnostics: std.ArrayListUnmanaged(types.Diagnostic) = .{};
+    try diagnostics.append(allocator, diagnostic);
+    defer diagnostics.deinit(allocator);
+
+    const params = types.CodeActionParams{
+        .textDocument = .{ .uri = uri },
+        .range = .{
+            .start = .{ .line = 0, .character = 0 },
+            .end = offsets.indexToPosition(before, before.len, ctx.server.offset_encoding),
+        },
+        .context = .{ .diagnostics = diagnostics.items },
+    };
+
+    @setEvalBranchQuota(5000);
+    const response = try ctx.server.sendRequestSync(ctx.arena.allocator(), "textDocument/codeAction", params) orelse {
+        std.debug.print("Server returned `null` as the result\n", .{});
+        return error.InvalidResponse;
+    };
+
+    var text_edits: std.ArrayListUnmanaged(types.TextEdit) = .{};
+    defer text_edits.deinit(allocator);
+
+    // std.log.err("Response: {any}", .{response});
+
+    for (response) |action| {
+        const code_action = action.CodeAction;
         const workspace_edit = code_action.edit.?;
         const changes = workspace_edit.changes.?.map;
         try std.testing.expectEqual(@as(usize, 1), changes.count());

--- a/tests/lsp_features/code_actions.zig
+++ b/tests/lsp_features/code_actions.zig
@@ -557,6 +557,18 @@ test "organize imports - field access" {
     );
 }
 
+test "organize imports - @embedFile" {
+    try testDiagnostic(
+        \\const foo = @embedFile("foo.zig");
+        \\const abc = @import("abc.zig");
+    ,
+        \\const abc = @import("abc.zig");
+        \\
+        \\const foo = @embedFile("foo.zig");
+        \\
+    );
+}
+
 test "organize imports - edge cases" {
     // Withstands non-standard behavior
     try testDiagnostic(


### PR DESCRIPTION
# Organize Imports Diagnostic and Code Action

This PR adds a diagnostic and a code action to organize imports in the current Zig file. The code action is available in the command palette as `organize @import`.

It is designed to be fairly customizable, so that we can arrive at a acceptable sorting style, like different grouping or case sensitivity.
All decisions, especially those around diagnostics are very much open to critique as I do not have experience with the LSP.

Closes #1637, continues work from #881.

## Design

An import is a top level declaration of a variable that uses the `@import` builtin.
A top level declaration that uses import variables (like `const print = std.debug.print;`) is not considered an import and stays in place.

The sorting splits imports into three separated groups: builtin packages, packages and project files.
The builtin packages are sorted in the order: `std`, `builtin`, `build_options`.
The sorting inside other groups is done by comparing the declaration names (the `x` in `const x = @import("file.zig");`).

The feature is tested both in unit tests and in neovim. The unit tests required a new helper function.

### Diagnostic

The diagnostic is enabled under the `warn_style` zls config option, which is disabled by default.
The diagnostic's range is the entire line of the import which would be moved by organizing imports.
That means one diagnostic per wrongly placed import line.

The diagnostic does not consider the correctness of separators between imports.

### Code Action

The code action is available based on the diagnostic.
This means that users with the `warn_style` option disabled will not be offered the code action.

The code action always sorts. The previous PR had optimization using `isSorted` to avoid sorting when it was not necessary.
This, however, did not work well in some corner cases.

The documentation comments (`///`) are moved with the import they are attached to.
It also respects `Top-Level Doc Comments` (`//!`), which must appear before any expression. This is handled using the commments token location.

This feature required running `generateCodeAction` for each diagnostic provided in request.
Previously, it ran the function only on diagnostics from `getAstCheckDiagnostics`.

## Considerations and notes

- Top-level declarations (that includes imports) are order-independent ([Source](https://ziglang.org/documentation/master/#Values) and tested)
- `zig fmt` and `textDocument/formatting` does not interfere with the sorting.
- Only root declarations are considered for sorting (no import inside functions).
- Will not work with `@import(variable);` (we don't do comptime)
- Resolving one diagnostic will resolve all diagnostics in the file (since all imports are moved).
- I removed the part dealing with intersection with action's range (`builder.range` field which no longer exists). If it was relevant, I can study it further.
- The code action works without `warn_style` as seen in tests. It is just that user cannot call it without the diagnostic.
- `std.sort.sort` does not exist anymore. I picked `std.sort.heap` as a replacement. My understanding is that we do not need a stable sort here, but feel free to correct me and suggest a different sort from the `std` library.

## Unresolved questions

- [x] Allow for `const print = std.debug.print;` to be sorted as well in some way?
- [x] How to treat `@import("root")`? (Currently a package, which does not seem right)
- [x] The `getSortSlice` function ported from previous PR seems weird. I would just do `return self.name` and not look in the import path. Any reasoning behind this?
- [ ] What about grouping by directory for the file imports? Perhaps if there are > 1 file imports from the same directory, they could be in a group of their own.
- [ ] I think `DiagnosticKind` could be parsed from the diagnostic code, which would be cleaner and would easily allow more versions of the diagnostic message. Or use the `data` field of the diagnostic message.
- [ ] What about `@embedFile`?
- [x] How to implement ignoring the diagnostic? `Ast.zig`, for example, imports extra stuff near end of the file for tests.

