### PR TITLE
fix: use tag type for calling convention

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -6,7 +6,7 @@ const builtin = @import("builtin");
 const zls_version = std.SemanticVersion{ .major = 0, .minor = 14, .patch = 0, .pre = "dev" };
 
 /// Specify the minimum Zig version that is required to compile and test ZLS:
-/// std.zig.tokenizer: simplify line-based tokens
+/// Replace `std.builtin.CallingConvention` with a tagged union, eliminating `@setAlignStack`
 ///
 /// If you do not use Nix, a ZLS maintainer can take care of this.
 /// Whenever this version is increased, run the following command:
@@ -15,7 +15,7 @@ const zls_version = std.SemanticVersion{ .major = 0, .minor = 14, .patch = 0, .p
 /// ```
 ///
 /// Must match the `minimum_zig_version` in `build.zig.zon`.
-const minimum_build_zig_version = "0.14.0-dev.1517+900753455";
+const minimum_build_zig_version = "0.14.0-dev.1983+6bf52b050";
 
 /// Specify the minimum Zig version that is required to run ZLS:
 /// Release 0.12.0

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,7 +3,7 @@
     // Must match the `zls_version` in `build.zig`
     .version = "0.14.0-dev",
     // Must match the `minimum_build_zig_version` in `build.zig`
-    .minimum_zig_version = "0.14.0-dev.1517+900753455",
+    .minimum_zig_version = "0.14.0-dev.1983+6bf52b050",
     // If you do not use Nix, a ZLS maintainer can take care of this.
     // Whenever the dependencies are updated, run the following command:
     // ```bash

--- a/flake.lock
+++ b/flake.lock
@@ -74,11 +74,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1729181673,
-        "narHash": "sha256-LDiPhQ3l+fBjRATNtnuDZsBS7hqoBtPkKBkhpoBHv3I=",
+        "lastModified": 1729691686,
+        "narHash": "sha256-BAuPWW+9fa1moZTU+jFh+1cUtmsuF8asgzFwejM4wac=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4eb33fe664af7b41a4c446f87d20c9a0a6321fa3",
+        "rev": "32e940c7c420600ef0d1ef396dc63b04ee9cad37",
         "type": "github"
       },
       "original": {
@@ -135,11 +135,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729339835,
-        "narHash": "sha256-E7BK/IY4j9aLcWyo290ya5MmfBhFWgBBkHg69AqRcJw=",
+        "lastModified": 1729771896,
+        "narHash": "sha256-4QjqSgcLvoiTCJ8gWleGAA/vpEzOlYg/TqHTDRHXmZ8=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "5aa48f75dcfd6a4f46bd6e0a1cb263652e25e4ec",
+        "rev": "0a4db4fe638db7838fb065680ebc92b7621b7990",
         "type": "github"
       },
       "original": {

--- a/src/features/inlay_hints.zig
+++ b/src/features/inlay_hints.zig
@@ -63,9 +63,9 @@ const excluded_builtins_set = blk: {
         .{"errorCast"},
         // .{"export"},
         // .{"extern"},
-        // .{"fence"},
         // .{"field"},
         // .{"fieldParentPtr"},
+        // .{"FieldType"},
         .{"floatCast"},
         .{"floatFromInt"},
         .{"frameAddress"}, // no parameters
@@ -95,7 +95,6 @@ const excluded_builtins_set = blk: {
         .{"rem"},
         .{"returnAddress"}, // no parameters
         // .{"select"},
-        // .{"setAlignStack"},
         .{"setEvalBranchQuota"},
         .{"setFloatMode"},
         .{"setRuntimeSafety"},

--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -2731,9 +2731,9 @@ test "builtin fns taking an enum arg" {
     });
     try testCompletionTextEdit(.{
         .source = "fn foo() callconv(.<cursor>",
-        .label = "AAPCS",
-        .expected_insert_line = "fn foo() callconv(.AAPCS",
-        .expected_replace_line = "fn foo() callconv(.AAPCS",
+        .label = "arm_aapcs",
+        .expected_insert_line = "fn foo() callconv(.{ .arm_aapcs = ",
+        .expected_replace_line = "fn foo() callconv(.{ .arm_aapcs = ",
     });
 }
 


### PR DESCRIPTION
Fix for `0.14.0-dev.1983+6bf52b050`

`std.builtin.CallingConvention` was recently changed to `union(enum(u8))`, with some deprecated names as well. This swaps the field to be `CallingConvention.Tag` type instead and replaces the deprecated names with their equivalent 
