### PR TITLE
wrap number hover in code block

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -1558,7 +1558,15 @@ fn hoverHandler(server: *Server, arena: std.mem.Allocator, request: types.HoverP
     var analyser = server.initAnalyser(handle);
     defer analyser.deinit();
 
-    return hover_handler.hover(&analyser, arena, handle, source_index, markup_kind, server.offset_encoding);
+    return hover_handler.hover(
+        &analyser,
+        arena,
+        handle,
+        source_index,
+        markup_kind,
+        server.offset_encoding,
+        server.client_capabilities.client_name,
+    );
 }
 
 fn documentSymbolsHandler(server: *Server, arena: std.mem.Allocator, request: types.DocumentSymbolParams) Error!lsp.ResultType("textDocument/documentSymbol") {


### PR DESCRIPTION
without this zed would put everything on 1 line, arguably this is probably something they should fix but the `md` also gives the numbers highlighting :man_shrugging:. didnt notice this make anything worse on nvim or helix
![image](https://github.com/user-attachments/assets/834b5637-9ed2-466f-98d6-ce32db8c82f6)

![image](https://github.com/user-attachments/assets/9e4a838d-162c-4de7-8072-3b350d0ca057)
