### PR TITLE
make autofix configurable through in-editor configuration

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -27,11 +27,6 @@
             },
             "default": []
         },
-        "enable_autofix": {
-            "description": "Whether to automatically fix errors on save. Currently supports adding and removing discards.",
-            "type": "boolean",
-            "default": false
-        },
         "semantic_tokens": {
             "description": "Set level of semantic tokens. `partial` only includes information that requires semantic analysis.",
             "type": "string",
@@ -74,6 +69,11 @@
         },
         "inlay_hints_hide_redundant_param_names_last_token": {
             "description": "Hides inlay hints when parameter name matches the last token of a parameter node (e.g. foo: bar.foo, foo: &foo)",
+            "type": "boolean",
+            "default": false
+        },
+        "force_autofix": {
+            "description": "Work around editors that do not support 'source.fixall' code actions on save. This option may delivered a substandard user experience. Please refer to the installation guide to see which editors natively support code actions on save.",
             "type": "boolean",
             "default": false
         },

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -18,9 +18,6 @@ enable_build_on_save: ?bool = null,
 /// If the `build.zig` has declared a 'check' step, it will be preferred over the default 'install' step.
 build_on_save_args: []const []const u8 = &.{},
 
-/// Whether to automatically fix errors on save. Currently supports adding and removing discards.
-enable_autofix: bool = false,
-
 /// Set level of semantic tokens. `partial` only includes information that requires semantic analysis.
 semantic_tokens: enum {
     none,
@@ -48,6 +45,9 @@ inlay_hints_hide_redundant_param_names: bool = false,
 
 /// Hides inlay hints when parameter name matches the last token of a parameter node (e.g. foo: bar.foo, foo: &foo)
 inlay_hints_hide_redundant_param_names_last_token: bool = false,
+
+/// Work around editors that do not support 'source.fixall' code actions on save. This option may delivered a substandard user experience. Please refer to the installation guide to see which editors natively support code actions on save.
+force_autofix: bool = false,
 
 /// Enables warnings for style guideline mismatches
 warn_style: bool = false,

--- a/src/features/diagnostics.zig
+++ b/src/features/diagnostics.zig
@@ -53,7 +53,7 @@ pub fn generateDiagnostics(server: *Server, arena: std.mem.Allocator, handle: *D
         }
     }
 
-    if (server.config.enable_autofix and tree.mode == .zig) {
+    if (server.getAutofixMode() != .none and tree.mode == .zig) {
         try code_actions.collectAutoDiscardDiagnostics(tree, arena, &diagnostics, server.offset_encoding);
     }
 

--- a/src/tools/config.json
+++ b/src/tools/config.json
@@ -25,12 +25,6 @@
             "default": []
         },
         {
-            "name": "enable_autofix",
-            "description": "Whether to automatically fix errors on save. Currently supports adding and removing discards.",
-            "type": "bool",
-            "default": false
-        },
-        {
             "name": "semantic_tokens",
             "description": "Set level of semantic tokens. `partial` only includes information that requires semantic analysis.",
             "type": "enum",
@@ -80,6 +74,12 @@
         {
             "name": "inlay_hints_hide_redundant_param_names_last_token",
             "description": "Hides inlay hints when parameter name matches the last token of a parameter node (e.g. foo: bar.foo, foo: &foo)",
+            "type": "bool",
+            "default": false
+        },
+        {
+            "name": "force_autofix",
+            "description": "Work around editors that do not support 'source.fixall' code actions on save. This option may delivered a substandard user experience. Please refer to the installation guide to see which editors natively support code actions on save.",
             "type": "bool",
             "default": false
         },

--- a/src/tools/config_gen.zig
+++ b/src/tools/config_gen.zig
@@ -261,7 +261,8 @@ fn generateVSCodeConfigFile(allocator: std.mem.Allocator, config: Config, path: 
     });
 
     for (config.options) |option| {
-        if (std.mem.eql(u8, option.name, "zig_exe_path")) continue;
+        if (std.mem.eql(u8, option.name, "zig_exe_path")) continue; // vscode-zig has its own option for this
+        if (std.mem.eql(u8, option.name, "force_autofix")) continue; // VS Code supports code actions on save without a workaround
 
         const snake_case_name = try std.fmt.allocPrint(allocator, "zig.zls.{s}", .{option.name});
         defer allocator.free(snake_case_name);

--- a/tests/lsp_features/code_actions.zig
+++ b/tests/lsp_features/code_actions.zig
@@ -663,7 +663,6 @@ fn testDiagnostic(
 ) !void {
     var ctx = try Context.init();
     defer ctx.deinit();
-    ctx.server.config.enable_autofix = true;
     ctx.server.config.prefer_ast_check_as_child_process = !options.want_zir;
 
     const uri = try ctx.addDocument(.{ .source = before });


### PR DESCRIPTION
Some editors like VS Code and Sublime Text offer their own setting to configure code actions on save, `editor.codeActionsOnSave` and `lsp_code_actions_on_save` respectively. These options should be preferred over `enable_autofix` if possible. The `enable_autofix` gets renamed to `force_autofix` to reflect that it should only be used on editors that don't support code actions on save. 
fixes #1093

List of editors that should be checked for the best way to implement autofix (code action on save or force_autofix):
- [x] VS Code ❎ with `editor.codeActionsOnSave`
- [x] Sublime Text LSP ❎ with `lsp_code_actions_on_save`
- [x] Zed Editor ❎ with `code_actions_on_format` (haven't checked whether it actually works)
- [x] ZigBrains ❌ (further research required)
- [x] Helix ❌ (possible with `force_autofix` but the ux is too bad)
- [x] nvim-lspconfig ❎ with `vim.lsp.buf.code_action`
- [x] CoC ❎ with `CocAction`
- [x] YouCompleteMe ❌ (wtf is this LSP client?)
- [x] Emacs eglot ❎ with `eglot-code-action`
- [x] Emacs lsp-mode ❌ (possible with `force_autofix`)
- [x] Kate ❌

## How To Upgrade

Please checkout the [Installation Guide](https://zigtools.org/zls/install/) and go to the documentation of your editor. Do not blindly change `enable_autofix` to `force_autofix`!