### PR TITLE
Add `aarch64-windows` and `arm-linux` to `release_targets`.

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -33,8 +33,10 @@ const release_targets = [_]std.Target.Query{
     .{ .cpu_arch = .x86_64, .os_tag = .macos },
     .{ .cpu_arch = .x86, .os_tag = .windows },
     .{ .cpu_arch = .x86, .os_tag = .linux },
+    .{ .cpu_arch = .aarch64, .os_tag = .windows },
     .{ .cpu_arch = .aarch64, .os_tag = .linux },
     .{ .cpu_arch = .aarch64, .os_tag = .macos },
+    .{ .cpu_arch = .arm, .os_tag = .linux },
     .{ .cpu_arch = .wasm32, .os_tag = .wasi },
 };
 


### PR DESCRIPTION
With this, ZLS will provide binaries for the ~same set of targets that rust-analyzer [does](https://github.com/rust-lang/rust-analyzer/releases/tag/nightly).

Closes #2059.