### PR TITLE
fix padding for very small numbers in number hover

### DIFF
--- a/src/features/hover.zig
+++ b/src/features/hover.zig
@@ -401,8 +401,8 @@ fn hoverNumberLiteral(
             .dash = "-",
             .value = "Value",
             .number = number,
-            .count = @bitSizeOf(@TypeOf(number)) - @clz(number) + "0x".len + @intFromBool(is_negative),
-            .len = @bitSizeOf(@TypeOf(number)) - @clz(number),
+            .count = @max(@bitSizeOf(@TypeOf(number)) - @clz(number) + "0x".len + @intFromBool(is_negative), "Value".len),
+            .len = @max(@bitSizeOf(@TypeOf(number)) - @clz(number), "Value".len - "0x".len),
         }),
         .plaintext, .unknown_value => return try std.fmt.allocPrint(
             arena,

--- a/tests/lsp_features/hover.zig
+++ b/tests/lsp_features/hover.zig
@@ -186,6 +186,16 @@ test "integer literal" {
         \\| DEC  | -42       |
         \\| HEX  | -0x2A     |
     );
+    try testHover(
+        \\const foo = 0x<cursor>0;
+    ,
+        \\| Base | Value |
+        \\| ---- | ----- |
+        \\| BIN  | 0b0   |
+        \\| OCT  | 0o0   |
+        \\| DEC  | 0     |
+        \\| HEX  | 0x0   |
+    );
     try testHoverWithOptions(
         \\const foo = 4<cursor>2;
     ,


### PR DESCRIPTION
before
```
| Base | Value |
| ---- | -- |
| BIN  | 0b0 |
| OCT  | 0o0 |
| DEC  | 0   |
| HEX  | 0x0 |
```
after
```
| Base | Value |
| ---- | ----- |
| BIN  | 0b0   |
| OCT  | 0o0   |
| DEC  | 0     |
| HEX  | 0x0   |
```
side note, i believe 80e9245f299e93adb14515b919f41f06bb78f30e broke hover on single digit int literals