### PR TITLE
Code action to convert string literal

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -1660,6 +1660,7 @@ fn codeActionHandler(server: *Server, arena: std.mem.Allocator, request: types.C
 
     var actions: std.ArrayListUnmanaged(types.CodeAction) = .{};
     try builder.generateCodeAction(error_bundle, &actions);
+    try builder.generateCodeActionsInRange(request.range, &actions);
 
     const Result = lsp.types.getRequestMetadata("textDocument/codeAction").?.Result;
     const result = try arena.alloc(std.meta.Child(std.meta.Child(Result)), actions.items.len);

--- a/src/features/code_actions.zig
+++ b/src/features/code_actions.zig
@@ -149,7 +149,7 @@ pub fn generateStringLiteralCodeActions(
     };
     // Check for disallowed characters and utf-8 validity
     for (parsed) |c| {
-        if (c == '\n' or c == '\r') continue;
+        if (c == '\n') continue;
         if (std.ascii.isControl(c)) return;
     }
     if (!std.unicode.utf8ValidateSlice(parsed)) return;

--- a/src/features/code_actions.zig
+++ b/src/features/code_actions.zig
@@ -129,6 +129,8 @@ pub fn generateStringLiteralCodeActions(
     const tracy_zone = tracy.trace(@src());
     defer tracy_zone.end();
 
+    if (!builder.wantKind(.refactor)) return;
+
     const tags = builder.handle.tree.tokens.items(.tag);
     switch (tags[token -| 1]) {
         // Not covered by position context
@@ -157,7 +159,7 @@ pub fn generateStringLiteralCodeActions(
     const loc = offsets.tokenToLoc(builder.handle.tree, token);
     try actions.append(builder.arena, .{
         .title = "convert to a multiline string literal",
-        .kind = .{ .custom_value = "refactor.convertStringLiteral" },
+        .kind = .refactor,
         .isPreferred = false,
         .edit = try builder.createWorkspaceEdit(&.{builder.createTextEditLoc(loc, result.items)}),
     });
@@ -170,6 +172,8 @@ pub fn generateMultilineStringCodeActions(
 ) !void {
     const tracy_zone = tracy.trace(@src());
     defer tracy_zone.end();
+
+    if (!builder.wantKind(.refactor)) return;
 
     const token_tags = builder.handle.tree.tokens.items(.tag);
     std.debug.assert(.multiline_string_literal_line == token_tags[token]);
@@ -214,7 +218,7 @@ pub fn generateMultilineStringCodeActions(
 
     try actions.append(builder.arena, .{
         .title = "convert to a string literal",
-        .kind = .{ .custom_value = "refactor.convertStringLiteral" },
+        .kind = .refactor,
         .isPreferred = false,
         .edit = try builder.createWorkspaceEdit(&.{builder.createTextEditLoc(remove_loc, str_escaped.items)}),
     });

--- a/src/features/code_actions.zig
+++ b/src/features/code_actions.zig
@@ -135,13 +135,12 @@ pub fn generateStringLiteralCodeActions(
         error.InvalidLiteral => return,
         else => |other| return other,
     };
-    // Check for disallowed characters
+    // Check for disallowed characters and utf-8 validity
     for (parsed) |c| {
-        switch (c) {
-            0x01...0x09, 0x0b...0x0c, 0x0e...0x1f, 0x7f => return,
-            else => {},
-        }
+        if (c == '\n' or c == '\r') continue;
+        if (std.ascii.isControl(c)) return;
     }
+    if (!std.unicode.utf8ValidateSlice(parsed)) return;
     const with_slashes = try std.mem.replaceOwned(u8, builder.arena, parsed, "\n", "\n    \\\\"); // Hardcoded 4 spaces
 
     var result = try std.ArrayListUnmanaged(u8).initCapacity(builder.arena, with_slashes.len + 3);

--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -697,7 +697,7 @@ fn completeFileSystemStringLiteral(builder: *Builder, pos_context: Analyser.Posi
     const store = &builder.server.document_store;
     const source = builder.orig_handle.tree.source;
 
-    var string_content_loc = pos_context.loc().?;
+    var string_content_loc = pos_context.content_loc(source).?;
 
     // the position context is without lookahead so we have to do it ourself
     while (string_content_loc.end < source.len) : (string_content_loc.end += 1) {

--- a/tests/lsp_features/code_actions.zig
+++ b/tests/lsp_features/code_actions.zig
@@ -811,7 +811,7 @@ fn testOrganizeImports(before: []const u8, after: []const u8) !void {
 }
 
 fn testConvertString(before: []const u8, after: []const u8) !void {
-    try testDiagnostic(before, after, .{ .filter_kind = types.CodeActionKind{ .custom_value = "refactor.convertStringLiteral" } });
+    try testDiagnostic(before, after, .{ .filter_kind = types.CodeActionKind.refactor });
 }
 
 fn testDiagnostic(

--- a/tests/lsp_features/code_actions.zig
+++ b/tests/lsp_features/code_actions.zig
@@ -763,6 +763,12 @@ test "convert string literal to multiline - invalid" {
     ,
         \\const foo = "Smile: \u{1F9131}";
     );
+    // Invalid utf-8
+    try testConvertString(
+        \\const foo = "<cursor>\xaa";
+    ,
+        \\const foo = "\xaa";
+    );
     // Hex escaped unprintable character
     try testConvertString(
         \\const foo = "<cursor>\x7f";

--- a/tests/lsp_features/code_actions.zig
+++ b/tests/lsp_features/code_actions.zig
@@ -715,6 +715,32 @@ test "convert string literal to multiline" {
     );
 }
 
+test "convert string literal to multiline - cursor outside of string literal" {
+    try testConvertString(
+        \\const foo = <cursor> "hello";
+    ,
+        \\const foo =  "hello";
+    );
+    try testConvertString(
+        \\const foo = <cursor>"hello";
+    ,
+        \\const foo = \\hello
+        \\;
+    );
+    try testConvertString(
+        \\const foo = "hello"<cursor>;
+    ,
+        \\const foo = \\hello
+        \\;
+    );
+    // TODO
+    // try testConvertString(
+    //     \\const foo = "hello" <cursor>;
+    // ,
+    //     \\const foo = "hello" <cursor>;
+    // );
+}
+
 test "convert string literal to multiline - escapes" {
     // Hex escapes
     try testConvertString(

--- a/tests/lsp_features/code_actions.zig
+++ b/tests/lsp_features/code_actions.zig
@@ -807,6 +807,12 @@ test "convert string literal to multiline - invalid" {
     ,
         \\const foo = "\tWe use tabs";
     );
+    // A Multi-Line String Literals can't contain carriage returns
+    try testConvertString(
+        \\const foo = "<cursor>\r";
+    ,
+        \\const foo = "\r";
+    );
     // Not in @import
     try testConvertString(
         \\const std = @import("<cursor>std");

--- a/tests/lsp_features/code_actions.zig
+++ b/tests/lsp_features/code_actions.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const zls = @import("zls");
 
 const Context = @import("../context.zig").Context;
+const helper = @import("../helper.zig");
 
 const types = zls.types;
 const offsets = zls.offsets;
@@ -643,6 +644,157 @@ test "organize imports - edge cases" {
     );
 }
 
+test "convert multiline string literal" {
+    try testConvertString(
+        \\const foo = \\Hell<cursor>o
+        \\            \\World
+        \\;
+    ,
+        \\const foo = "Hello\nWorld";
+    );
+    // Empty
+    try testConvertString(
+        \\const foo = \\<cursor>
+        \\;
+    ,
+        \\const foo = "";
+    );
+    // Multi-byte characters
+    try testConvertString(
+        \\const foo = \\He😂ll<cursor>o
+        \\            \\Wo🤓rld
+        \\;
+    ,
+        \\const foo = "He😂llo\nWo🤓rld";
+    );
+    // Quotes
+    try testConvertString(
+        \\const foo = \\The<cursor> "cure"
+        \\;
+    ,
+        \\const foo = "The \"cure\"";
+    );
+    try testConvertString(
+        \\const foo = \\<cursor>\x49 \u{0033}
+        \\            \\\n'
+        \\            \\
+        \\;
+    ,
+        \\const foo = "\\x49 \\u{0033}\n\\n'\n";
+    );
+    // The control characters TAB and CR are rejected by the grammar inside multi-line string literals,
+    // except if CR is directly before NL.
+    try testConvertString( // (force format)
+        "const foo = \\\\<cursor>Hello\r\n;",
+        \\const foo = "Hello";
+    );
+}
+
+test "convert string literal to multiline" {
+    try testConvertString(
+        \\const foo = "He<cursor>llo\nWorld";
+    ,
+        \\const foo = \\Hello
+        \\    \\World
+        \\;
+    );
+    // Empty
+    try testConvertString(
+        \\const foo = "<cursor>";
+    ,
+        \\const foo = \\
+        \\;
+    );
+    // In function
+    try testConvertString(
+        \\const x = foo("<cursor>bar\nbaz");
+    ,
+        \\const x = foo(\\bar
+        \\    \\baz
+        \\);
+    );
+}
+
+test "convert string literal to multiline - escapes" {
+    // Hex escapes
+    try testConvertString(
+        \\const foo = "<cursor>\x41\x42\x43";
+    ,
+        \\const foo = \\ABC
+        \\;
+    );
+    // Hex escapes that form a unicode character in utf-8
+    try testConvertString(
+        \\const foo = "<cursor>\xE2\x9C\x85";
+    ,
+        \\const foo = \\✅
+        \\;
+    );
+    // Newlines
+    try testConvertString(
+        \\const foo = "<cursor>\nhello\n\n";
+    ,
+        \\const foo = \\
+        \\    \\hello
+        \\    \\
+        \\    \\
+        \\;
+    );
+    // Quotes and slashes
+    try testConvertString(
+        \\const foo = "<cursor>A slash: \'\\\'";
+    ,
+        \\const foo = \\A slash: '\'
+        \\;
+    );
+    // Unicode
+    try testConvertString(
+        \\const foo = "<cursor>Smile: \u{1F913}";
+    ,
+        \\const foo = \\Smile: 🤓
+        \\;
+    );
+}
+
+test "convert string literal to multiline - invalid" {
+    // Invalid unicode
+    try testConvertString(
+        \\const foo = "<cursor>Smile: \u{1F9131}";
+    ,
+        \\const foo = "Smile: \u{1F9131}";
+    );
+    // Hex escaped unprintable character
+    try testConvertString(
+        \\const foo = "<cursor>\x7f";
+    ,
+        \\const foo = "\x7f";
+    );
+    // Tabs are invalid too
+    try testConvertString(
+        \\const foo = "<cursor>\tWe use tabs";
+    ,
+        \\const foo = "\tWe use tabs";
+    );
+    // Not in @import
+    try testConvertString(
+        \\const std = @import("<cursor>std");
+    ,
+        \\const std = @import("std");
+    );
+    // Not in test
+    try testConvertString(
+        \\test "<cursor>addition" { }
+    ,
+        \\test "addition" { }
+    );
+    // Not in extern
+    try testConvertString(
+        \\pub extern "<cursor>c" fn printf(format: [*:0]const u8) c_int;
+    ,
+        \\pub extern "c" fn printf(format: [*:0]const u8) c_int;
+    );
+}
+
 fn testAutofix(before: []const u8, after: []const u8) !void {
     try testDiagnostic(before, after, .{ .filter_kind = .@"source.fixAll", .want_zir = true }); // diagnostics come from our AstGen fork
     try testDiagnostic(before, after, .{ .filter_kind = .@"source.fixAll", .want_zir = false }); // diagnostics come from calling zig ast-check
@@ -650,6 +802,10 @@ fn testAutofix(before: []const u8, after: []const u8) !void {
 
 fn testOrganizeImports(before: []const u8, after: []const u8) !void {
     try testDiagnostic(before, after, .{ .filter_kind = .@"source.organizeImports" });
+}
+
+fn testConvertString(before: []const u8, after: []const u8) !void {
+    try testDiagnostic(before, after, .{ .filter_kind = types.CodeActionKind{ .custom_value = "refactor.convertStringLiteral" } });
 }
 
 fn testDiagnostic(
@@ -665,7 +821,23 @@ fn testDiagnostic(
     defer ctx.deinit();
     ctx.server.config.prefer_ast_check_as_child_process = !options.want_zir;
 
-    const uri = try ctx.addDocument(.{ .source = before });
+    const placeholders = try helper.collectPlaceholderLocs(allocator, before);
+    defer allocator.free(placeholders);
+    const range: types.Range = switch (placeholders.len) {
+        0 => .{
+            .start = .{ .line = 0, .character = 0 },
+            .end = offsets.indexToPosition(before, before.len, ctx.server.offset_encoding),
+        },
+        1 => blk: {
+            const point = offsets.indexToPosition(before, placeholders[0].start, ctx.server.offset_encoding);
+            break :blk .{ .start = point, .end = point };
+        },
+        else => unreachable,
+    };
+    const source = try helper.clearPlaceholders(allocator, before);
+    defer allocator.free(source);
+
+    const uri = try ctx.addDocument(.{ .source = source });
     const handle = ctx.server.document_store.getHandle(uri).?;
 
     var error_bundle = try zls.diagnostics.getAstCheckDiagnostics(ctx.server, handle);
@@ -681,10 +853,7 @@ fn testDiagnostic(
 
     const params: types.CodeActionParams = .{
         .textDocument = .{ .uri = uri },
-        .range = .{
-            .start = .{ .line = 0, .character = 0 },
-            .end = offsets.indexToPosition(before, before.len, ctx.server.offset_encoding),
-        },
+        .range = range,
         .context = .{
             .diagnostics = diagnostics,
             .only = if (options.filter_kind) |kind| &.{kind} else null,
@@ -719,7 +888,7 @@ fn testDiagnostic(
         try text_edits.appendSlice(allocator, changes.get(uri).?);
     }
 
-    const actual = try zls.diff.applyTextEdits(allocator, before, text_edits.items, ctx.server.offset_encoding);
+    const actual = try zls.diff.applyTextEdits(allocator, source, text_edits.items, ctx.server.offset_encoding);
     defer allocator.free(actual);
     try ctx.server.document_store.refreshDocument(uri, try allocator.dupeZ(u8, actual));
 

--- a/tests/utility/position_context.zig
+++ b/tests/utility/position_context.zig
@@ -281,76 +281,91 @@ test "comment" {
 
 test "import/embedfile string literal" {
     try testContext(
-        \\const std = @import("<loc>s</loc><cursor>t");
+        \\const std = @import(<loc>"s</loc><cursor>t");
     , .import_string_literal, .{ .lookahead = false });
     try testContext(
-        \\const std = @import("<loc>st</loc><cursor>");
+        \\const std = @import(<loc>"st</loc><cursor>");
     , .import_string_literal, .{ .lookahead = false });
     try testContext(
-        \\const std = @embedFile("<loc>file</loc><cursor>.");
+        \\const std = @embedFile(<loc>"file</loc><cursor>.");
     , .embedfile_string_literal, .{ .lookahead = false });
     try testContext(
-        \\const std = @embedFile("<loc>file.</loc><cursor>");
+        \\const std = @embedFile(<loc>"file.</loc><cursor>");
     , .embedfile_string_literal, .{ .lookahead = false });
 
     try testContext(
         \\const std = @import("std"<cursor>);
-    , .empty, .{});
+    , .empty, .{ .lookahead = true });
+    // TODO
+    // try testContext(
+    //     \\const std = @import("std"<cursor>);
+    // , .empty, .{ .lookahead = false });
     try testContext(
-        \\const std = @import(<cursor>"std");
-    , .empty, .{});
+        \\const std = @import(<cursor><loc>"std"</loc>);
+    , .import_string_literal, .{ .lookahead = true });
 }
 
 test "string literal" {
     try testContext(
-        \\var foo = <cursor>"hello world!";
-    , .empty, .{});
+        \\var foo = <cursor><loc>"hello world!"</loc>;
+    , .string_literal, .{ .lookahead = true });
+    try testContext(
+        \\var foo = <loc>"hello world!<cursor>"</loc>;
+    , .string_literal, .{ .lookahead = true });
+    try testContext(
+        \\var foo = <loc>"hello world!</loc><cursor>";
+    , .string_literal, .{ .lookahead = false });
+    // TODO
+    // try testContext(
+    //     \\var foo = "hello world!"<cursor>;
+    // , .empty, .{ .lookahead = false });
     try testContext(
         \\var foo = "hello world!"<cursor>;
-    , .empty, .{});
+    , .empty, .{ .lookahead = true });
 
     try testContext(
-        \\var foo = "<loc></loc><cursor>";
-    , .string_literal, .{});
+        \\var foo = <loc>"<cursor></loc>";
+    , .string_literal, .{ .lookahead = false });
+    try testContext(
+        \\var foo = <loc>"<cursor>"</loc>;
+    , .string_literal, .{ .lookahead = true });
     // TODO
     // try testContext(
     //     \\var foo = "<loc>\"</loc><cursor>";
     // , .string_literal, .{});
 
     try testContext(
-        \\var foo = "<loc>hello</loc><cursor> world!";
+        \\var foo = <loc>"hello</loc><cursor> world!";
     , .string_literal, .{ .lookahead = false });
     try testContext(
-        \\var foo = "<loc>hello<cursor> world!</loc>";
+        \\var foo = <loc>"hello<cursor> world!"</loc>;
     , .string_literal, .{ .lookahead = true });
-
-    // TODO
-    // try testContext(
-    //     \\var foo = "hello world!"<cursor>;
-    // , .empty, .{});
 }
 
 test "multi-line string literal" {
     try testContext(
         \\var foo = <cursor>\\hello;
-    , .empty, .{});
-
+    , .empty, .{ .lookahead = false });
     try testContext(
-        \\var foo = \\<loc></loc><cursor>
-    , .string_literal, .{});
-    try testContext(
-        \\var foo = \\<loc>\"</loc><cursor>
-    , .string_literal, .{});
-
-    try testContext(
-        \\var foo = \\<loc>hello</loc><cursor> world!
-    , .string_literal, .{ .lookahead = false });
-    try testContext(
-        \\var foo = \\<loc>hello<cursor> world!</loc>
+        \\var foo = <cursor><loc>\\hello;</loc>
     , .string_literal, .{ .lookahead = true });
 
     try testContext(
-        \\var foo = \\<loc>hello;</loc><cursor>
+        \\var foo = <loc>\\</loc><cursor>
+    , .string_literal, .{});
+    try testContext(
+        \\var foo = <loc>\\\"</loc><cursor>
+    , .string_literal, .{});
+
+    try testContext(
+        \\var foo = <loc>\\hello</loc><cursor> world!
+    , .string_literal, .{ .lookahead = false });
+    try testContext(
+        \\var foo = <loc>\\hello<cursor> world!</loc>
+    , .string_literal, .{ .lookahead = true });
+
+    try testContext(
+        \\var foo = <loc>\\hello;</loc><cursor>
     , .string_literal, .{});
 }
 

--- a/tests/utility/position_context.zig
+++ b/tests/utility/position_context.zig
@@ -294,34 +294,24 @@ test "import/embedfile string literal" {
     , .embedfile_string_literal, .{ .lookahead = false });
 
     try testContext(
-        \\const std = @import("std"<cursor>);
-    , .empty, .{ .lookahead = true });
-    // TODO
-    // try testContext(
-    //     \\const std = @import("std"<cursor>);
-    // , .empty, .{ .lookahead = false });
+        \\const std = @import(<loc>"std"</loc><cursor>);
+    , .string_literal, .{});
     try testContext(
         \\const std = @import(<cursor><loc>"std"</loc>);
-    , .import_string_literal, .{ .lookahead = true });
+    , .string_literal, .{ .lookahead = true });
 }
 
 test "string literal" {
     try testContext(
+        \\var foo = <cursor>"hello world!";
+    , .empty, .{ .lookahead = false });
+    try testContext(
         \\var foo = <cursor><loc>"hello world!"</loc>;
     , .string_literal, .{ .lookahead = true });
+
     try testContext(
-        \\var foo = <loc>"hello world!<cursor>"</loc>;
-    , .string_literal, .{ .lookahead = true });
-    try testContext(
-        \\var foo = <loc>"hello world!</loc><cursor>";
-    , .string_literal, .{ .lookahead = false });
-    // TODO
-    // try testContext(
-    //     \\var foo = "hello world!"<cursor>;
-    // , .empty, .{ .lookahead = false });
-    try testContext(
-        \\var foo = "hello world!"<cursor>;
-    , .empty, .{ .lookahead = true });
+        \\var foo = <loc>"hello world!"</loc><cursor>;
+    , .string_literal, .{});
 
     try testContext(
         \\var foo = <loc>"<cursor></loc>";
@@ -331,8 +321,8 @@ test "string literal" {
     , .string_literal, .{ .lookahead = true });
     // TODO
     // try testContext(
-    //     \\var foo = "<loc>\"</loc><cursor>";
-    // , .string_literal, .{});
+    //     \\var foo = <loc>"\"<cursor>"</loc>;
+    // , .string_literal, .{ .lookahead = true });
 
     try testContext(
         \\var foo = <loc>"hello</loc><cursor> world!";
@@ -344,10 +334,10 @@ test "string literal" {
 
 test "multi-line string literal" {
     try testContext(
-        \\var foo = <cursor>\\hello;
+        \\var foo = <cursor>\\hello
     , .empty, .{ .lookahead = false });
     try testContext(
-        \\var foo = <cursor><loc>\\hello;</loc>
+        \\var foo = <cursor><loc>\\hello</loc>
     , .string_literal, .{ .lookahead = true });
 
     try testContext(


### PR DESCRIPTION

# Code action to rewrite string literal <-> multiline string

The code action will be available if the cursor is _inside_ the string literal and if it is convertible.

Code action name in both directions: `refactor.convertStringLiteral`.

Tested in: Neovim, VS Code

## Converting string literal -> multiline string

Multiline string literals have no escapes, so strings with some escapes cannot be converted:

| Escape Sequence |                                Name                               | Convertible to multiline |
|:---------------:|:-----------------------------------------------------------------:|--------------------------|
| `\n`            | Newline                                                           |                        ✅|
| `\r`            | Carriage Return                                                   |                        ❎|
| `\t`            | Tab                                                               |                        ❎|
| `\\`            | Backslash                                                         |                        ✅|
| `\'`            | Single Quote                                                      |                        ✅|
| `\"`            | Double Quote                                                      |                        ✅|
| `\xNN`          | hexadecimal 8-bit byte value (2 digits)                           |                        ❓|
| `\u{NNNNNN}`    | hexadecimal Unicode scalar value UTF-8 encoded (1 or more digits) |                        ❓|

It is possible to convert at least some of the hex values to the utf-8 codes.

<details>
<summary>string literal -> multiline string example</summary>

```zig
const foo = "Hello\nWorld";
```

```zig
const foo = 
\\Hello
\\World
;
```

</details>

## Converting multiline string -> string literal

Escapes must be added in some cases.
Newline `\n` must be added for every line of the multiline string except for the last one.

From ascii select characters can be found in the string, which makes things easier.
Quoting the tokenizer for multiline string:
```zig
    0x01...0x09, 0x0b...0x0c, 0x0e...0x1f, 0x7f => continue :state .invalid,
```

<details>
    <summary>multiline string -> string literal</summary>


```zig
const foo = 
\\1. Eggs
\\2. "Bacon"
\\
;
```

```zig
const foo = "1. Eggs\n2. \"Bacon\"\n";
```

</details>

## Discussion

The code action does not appear when cursor is on the markup (`\\` or `"`).
I would like to fix this because this way it is not possible to use the action on empty strings.
It is also less convenient for the user.
The position context might be updated to not exclude the markup, but there might be some consequences.

Other notes:
- test names, `@import` arguments, `pub extern "something"` cannot be multiline strings (`test "addition" { ... }`)
- Invalid escape (like `" \ "`) is not a concern because such source code cannot be tokenized, therefore code actions are not generated
- It doesn't interact with chars (`'q'`) - it is a different type
- `std.zig.stringEscape` could not be used because it escapes unicode (emojis etc.) as hexcodes, which I do not like
- Relevant PR: [https://github.com/ziglang/zig/issues/19299](https://github.com/ziglang/zig/issues/19299)
- Replaces #1931

Questions:
- Did I understand `\r` correctly?
- Should indentation be part of the produced edit, or does fmt take care of it afterwards? Right now there is a hardcoded 4 space indent
- Performance-wise, there might be a lot of `appendSlice` calls in a loop. An upper bound of the final string's length could be determined and preallocated.

