### PR TITLE
escape identifiers when renaming

### DIFF
--- a/src/features/references.zig
+++ b/src/features/references.zig
@@ -497,13 +497,14 @@ pub fn referencesHandler(server: *Server, arena: std.mem.Allocator, request: Gen
 
     switch (request) {
         .rename => |rename| {
+            const escaped_rename = try std.fmt.allocPrint(arena, "{}", .{std.zig.fmtId(rename.newName)});
             var changes = std.StringArrayHashMapUnmanaged(std.ArrayListUnmanaged(types.TextEdit)){};
 
             for (locations.items) |loc| {
                 const gop = try changes.getOrPutValue(arena, loc.uri, .{});
                 try gop.value_ptr.append(arena, .{
                     .range = loc.range,
-                    .newText = rename.newName,
+                    .newText = escaped_rename,
                 });
             }
 


### PR DESCRIPTION
closes #2124
this isnt completely ideal since it always escapes primitives despite those being valid field names but `zig fmt` automatically canonicalizes those so... its fine i suppose?