### PR TITLE
Resolve array `**` and `++` operators

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -2257,7 +2257,23 @@ fn resolveTypeOfNodeUncached(analyser: *Analyser, node_handle: NodeWithHandle) e
 
         .array_mult,
         .array_cat,
-        => {},
+        => {
+            const elem_idx = datas[node].lhs;
+            var elem_ty = try analyser.resolveTypeOfNode(.{ .node = elem_idx, .handle = handle }) orelse return null;
+
+            switch (elem_ty.data) {
+                .array => |*a| a.elem_count = null,
+                .pointer => |*p| {
+                    switch (p.elem_ty.data) {
+                        .array => |*a| a.elem_count = null,
+                        else => return null,
+                    }
+                },
+                else => return null,
+            }
+
+            return elem_ty;
+        },
 
         .assign_mul,
         .assign_div,

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -2259,7 +2259,7 @@ fn resolveTypeOfNodeUncached(analyser: *Analyser, node_handle: NodeWithHandle) e
         .array_cat,
         => {
             const elem_idx = datas[node].lhs;
-            var elem_ty = try analyser.resolveTypeOfNode(.{ .node = elem_idx, .handle = handle }) orelse return null;
+            var elem_ty = try analyser.resolveTypeOfNodeInternal(.{ .node = elem_idx, .handle = handle }) orelse return null;
 
             switch (elem_ty.data) {
                 .array => |*a| a.elem_count = null,

--- a/tests/lsp_features/hover.zig
+++ b/tests/lsp_features/hover.zig
@@ -563,6 +563,89 @@ test "union" {
     );
 }
 
+test "array cat and mult" {
+    try testHover(
+        \\const <cursor>a = [_]u8{0} ++ [_]u8{1};
+    ,
+        \\```zig
+        \\const a = [_]u8{0} ++ [_]u8{1}
+        \\```
+        \\```zig
+        \\([?]u8)
+        \\```
+    );
+    try testHover(
+        \\const <cursor>a = [1]u8{0} ++ [_]u8{1};
+    ,
+        \\```zig
+        \\const a = [1]u8{0} ++ [_]u8{1}
+        \\```
+        \\```zig
+        \\([?]u8)
+        \\```
+    );
+    try testHover(
+        \\const <cursor>a = [_]u8{0} ++ [1]u8{1};
+    ,
+        \\```zig
+        \\const a = [_]u8{0} ++ [1]u8{1}
+        \\```
+        \\```zig
+        \\([?]u8)
+        \\```
+    );
+    try testHover(
+        \\const <cursor>a = [1]u8{0} ++ [1]u8{1};
+    ,
+        \\```zig
+        \\const a = [1]u8{0} ++ [1]u8{1}
+        \\```
+        \\```zig
+        \\([2]u8)
+        \\```
+    );
+    try testHover(
+        \\const <cursor>a = &[2]u8{ 0, 1 } ++ &[3]u8{ 2, 3, 4 };
+    ,
+        \\```zig
+        \\const a = &[2]u8{ 0, 1 } ++ &[3]u8{ 2, 3, 4 }
+        \\```
+        \\```zig
+        \\(*[5]u8)
+        \\```
+    );
+    try testHover(
+        \\const <cursor>a = [_]u8{0} ** 2;
+    ,
+        \\```zig
+        \\const a = [_]u8{0} ** 2
+        \\```
+        \\```zig
+        \\([?]u8)
+        \\```
+    );
+    try testHover(
+        \\const <cursor>a = [1]u8{0} ** 2;
+    ,
+        \\```zig
+        \\const a = [1]u8{0} ** 2
+        \\```
+        \\```zig
+        \\([2]u8)
+        \\```
+    );
+    try testHover(
+        \\const <cursor>a = &[3]u8{ 0, 1, 2 } ** 2;
+    ,
+        \\```zig
+        \\const a = &[3]u8{ 0, 1, 2 } ** 2
+        \\```
+        \\```zig
+        \\(*[6]u8)
+        \\```
+    );
+}
+
 test "sentinel values" {
     try testHover(
         \\const <cursor>a: [:0] i1 = undefined;


### PR DESCRIPTION
Resolves the mult and cat operators for arrays and single pointers to arrays.
I could look more into the other cases (string literals, tuples and comptime known slices), but would take more time.

(partly) fixes #2105 