### PR TITLE
Pass `--zig-lib-dir` config option to the build runner

### DIFF
--- a/src/DocumentStore.zig
+++ b/src/DocumentStore.zig
@@ -814,6 +814,7 @@ pub fn invalidateBuildFile(self: *DocumentStore, build_file_uri: Uri) void {
     if (self.config.zig_exe_path == null) return;
     if (self.config.build_runner_path == null) return;
     if (self.config.global_cache_path == null) return;
+    if (self.config.zig_lib_path == null) return;
 
     if (builtin.single_threaded) {
         self.invalidateBuildFileWorker(build_file_uri, false);
@@ -1039,6 +1040,7 @@ fn loadBuildConfiguration(self: *DocumentStore, build_file_uri: Uri) !std.json.P
     std.debug.assert(self.config.zig_exe_path != null);
     std.debug.assert(self.config.build_runner_path != null);
     std.debug.assert(self.config.global_cache_path != null);
+    std.debug.assert(self.config.zig_lib_path != null);
 
     const build_file_path = try URI.parse(self.allocator, build_file_uri);
     defer self.allocator.free(build_file_path);

--- a/src/DocumentStore.zig
+++ b/src/DocumentStore.zig
@@ -1005,7 +1005,7 @@ fn prepareBuildRunnerArgs(self: *DocumentStore, build_file_uri: []const u8) ![][
     defer tracy_zone.end();
 
     const base_args = &[_][]const u8{
-        self.config.zig_exe_path.?, "build", "--build-runner", self.config.build_runner_path.?,
+        self.config.zig_exe_path.?, "build", "--build-runner", self.config.build_runner_path.?, "--zig-lib-dir", self.config.zig_lib_path.?,
     };
 
     var args: std.ArrayListUnmanaged([]const u8) = try .initCapacity(self.allocator, base_args.len);


### PR DESCRIPTION
Without this patch, the build runner fails to run if build scripts depend on a modified zig library directory even if the config file specifies a different library directory, for example if the project depends on patches to the Zig build system.

I tested this change on a project of mine with a blank config file and with a config file that sets zig_lib_path; it seems to work correctly in both scenarios.
