### PR TITLE
nix: add meta.mainProgram to silence nix warning

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,7 @@
         packages.zls = pkgs.stdenvNoCC.mkDerivation {
           name = "zls";
           version = "master";
+          meta.mainProgram = "zls";
           src = gitignoreSource ./.;
           nativeBuildInputs = [ zig ];
           dontConfigure = true;


### PR DESCRIPTION
Nix now warn users if a package does not have `meta.mainProgram` set.

This is because of https://github.com/NixOS/nixpkgs/pull/246386.

This PR simply adds `meta.mainProgram = "zls";` to the `flake.nix`.