### PR TITLE
infer `orelse` on a C-pointer as a C-pointer

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -865,6 +865,10 @@ pub fn resolveOptionalUnwrap(analyser: *Analyser, optional: Type) error{OutOfMem
             std.debug.assert(child_ty.is_type_val);
             return try child_ty.instanceTypeVal(analyser);
         },
+        .pointer => |ptr| {
+            if (ptr.size == .c) return optional;
+            return null;
+        },
         else => return null,
     }
 }

--- a/tests/lsp_features/hover.zig
+++ b/tests/lsp_features/hover.zig
@@ -1164,6 +1164,19 @@ test "optional" {
         \\(i32)
         \\```
     );
+
+    try testHover(
+        \\var value: u32 = 123;
+        \\const ptr: [*c]u32 = &value;
+        \\const f<cursor>oo = ptr orelse unreachable;
+    ,
+        \\```zig
+        \\const foo = ptr orelse unreachable
+        \\```
+        \\```zig
+        \\([*c]u32)
+        \\```
+    );
 }
 
 test "error union" {


### PR DESCRIPTION
A C-pointer `[*c]T` can be `null`, and it is possible to use with `orelse` and `.?` unwrapping.
However, as `[*c]` pointers carry some special semantics, the result is still a `[*c]` pointer.