### PR TITLE
Put param hint on previous line for multiline string arg

### DIFF
--- a/tests/lsp_features/inlay_hints.zig
+++ b/tests/lsp_features/inlay_hints.zig
@@ -37,6 +37,16 @@ test "function call" {
     , .{ .kind = .Parameter });
 }
 
+test "function call with multiline string literal" {
+    try testInlayHints(
+        \\fn foo(bar: []const u8) void {}
+        \\const _ = foo(<bar>
+        \\    \\alpha
+        \\    \\beta
+        \\);
+    , .{ .kind = .Parameter });
+}
+
 test "extern function call" {
     try testInlayHints(
         \\extern fn foo(u32, beta: bool, []const u8) void;
@@ -128,6 +138,15 @@ test "builtin call" {
         .kind = .Parameter,
         .show_builtin = false,
     });
+}
+
+test "builtin call with multiline string literal" {
+    try testInlayHints(
+        \\const _ = @compileError(<msg>
+        \\    \\foo
+        \\    \\bar
+        \\);
+    , .{ .kind = .Parameter });
 }
 
 test "exclude single argument" {


### PR DESCRIPTION
Before:

<img width="357" alt="Screenshot 2025-02-08 at 9 53 58 PM" src="https://github.com/user-attachments/assets/67e99b36-d097-422f-9673-090662adb046" />

After:

<img width="358" alt="Screenshot 2025-02-08 at 9 54 12 PM" src="https://github.com/user-attachments/assets/3034c7b7-2086-49b8-b3b7-bf2ff1f3f6ec" />
