### PR TITLE
Update for breaking Zig Allocator API change

### DIFF
--- a/.github/workflows/build_runner.yml
+++ b/.github/workflows/build_runner.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         include:
           - zig-version: mach-latest
-            build-runner-file: master.zig
+            build-runner-file: mach-latest.zig
           # Zig master is handled by 'zig build test' in the main CI
     runs-on: ubuntu-22.04
 

--- a/build.zig
+++ b/build.zig
@@ -6,7 +6,7 @@ const builtin = @import("builtin");
 const zls_version: std.SemanticVersion = .{ .major = 0, .minor = 14, .patch = 0, .pre = "dev" };
 
 /// Specify the minimum Zig version that is required to compile and test ZLS:
-/// compiler,std: implement ZON support
+/// std.ArrayList: popOrNull() -> pop() [v2]
 ///
 /// If you do not use Nix, a ZLS maintainer can take care of this.
 /// Whenever this version is increased, run the following command:
@@ -15,7 +15,7 @@ const zls_version: std.SemanticVersion = .{ .major = 0, .minor = 14, .patch = 0,
 /// ```
 ///
 /// Also update the `minimum_zig_version` in `build.zig.zon`.
-const minimum_build_zig_version = "0.14.0-dev.3042+317722b37";
+const minimum_build_zig_version = "0.14.0-dev.3181+914248237";
 
 /// Specify the minimum Zig version that is required to run ZLS:
 /// std.Build: add new functions to create artifacts/Step.Compile from existing module

--- a/build.zig
+++ b/build.zig
@@ -18,14 +18,14 @@ const zls_version: std.SemanticVersion = .{ .major = 0, .minor = 14, .patch = 0,
 const minimum_build_zig_version = "0.14.0-dev.3181+914248237";
 
 /// Specify the minimum Zig version that is required to run ZLS:
-/// std.Build: add new functions to create artifacts/Step.Compile from existing module
+/// std.ArrayList: popOrNull() -> pop() [v2]
 ///
 /// Examples of reasons that would cause the minimum runtime version to be bumped are:
 ///   - breaking change to the Zig Syntax
 ///   - breaking change to AstGen (i.e `zig ast-check`)
 ///
 /// A breaking change to the Zig Build System should be handled by updating ZLS's build runner (see src\build_runner)
-const minimum_runtime_zig_version = "0.14.0-dev.2534+12d64c456";
+const minimum_runtime_zig_version = "0.14.0-dev.3181+914248237";
 
 const release_targets = [_]std.Target.Query{
     .{ .cpu_arch = .x86_64, .os_tag = .windows },

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,7 +4,7 @@
     .version = "0.14.0-dev",
     // Must be kept in line with the `minimum_build_zig_version` in `build.zig`.
     // Should be a Zig version that is downloadable from https://ziglang.org/download/ or a mirror.
-    .minimum_zig_version = "0.14.0-dev.3046+08d661fcf",
+    .minimum_zig_version = "0.14.0-dev.3181+914248237",
     // If you do not use Nix, a ZLS maintainer can take care of this.
     // Whenever the dependencies are updated, run the following command:
     // ```bash

--- a/src/DiagnosticsCollection.zig
+++ b/src/DiagnosticsCollection.zig
@@ -234,7 +234,7 @@ pub fn publishDiagnostics(collection: *DiagnosticsCollection) (std.mem.Allocator
             collection.mutex.lock();
             defer collection.mutex.unlock();
 
-            const entry = collection.outdated_files.popOrNull() orelse break;
+            const entry = collection.outdated_files.pop() orelse break;
             defer collection.allocator.free(entry.key);
             const document_uri = entry.key;
 

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -3737,7 +3737,7 @@ pub fn getPositionContext(
         }
     }
 
-    if (stack.popOrNull()) |state| {
+    if (stack.pop()) |state| {
         switch (state.ctx) {
             .parens_expr => |loc| return .{ .var_access = loc },
             .var_access => |loc| {

--- a/src/binned_allocator.zig
+++ b/src/binned_allocator.zig
@@ -108,10 +108,9 @@ pub fn BinnedAllocator(comptime config: Config) type {
         ) bool {
             const self: *Self = @ptrCast(@alignCast(ctx));
 
-            const align_ = alignment.toByteUnits();
             comptime var prev_size: usize = 0;
             inline for (&self.bins) |*bin| {
-                if (buf.len <= bin.size and align_ <= bin.size) {
+                if (buf.len <= bin.size and alignment.toByteUnits() <= bin.size) {
                     // Check it still fits
                     return new_len > prev_size and new_len <= bin.size;
                 }
@@ -126,9 +125,8 @@ pub fn BinnedAllocator(comptime config: Config) type {
         fn free(ctx: *anyopaque, buf: []u8, alignment: std.mem.Alignment, ret_addr: usize) void {
             const self: *Self = @ptrCast(@alignCast(ctx));
 
-            const align_ = alignment.toByteUnits();
             inline for (&self.bins) |*bin| {
-                if (buf.len <= bin.size and align_ <= bin.size) {
+                if (buf.len <= bin.size and alignment.toByteUnits() <= bin.size) {
                     bin.free(buf.ptr);
                     return;
                 }

--- a/src/binned_allocator.zig
+++ b/src/binned_allocator.zig
@@ -82,8 +82,7 @@ pub fn BinnedAllocator(comptime config: Config) type {
         ) ?[*]u8 {
             const self: *Self = @ptrCast(@alignCast(ctx));
 
-            const align_ = @as(usize, 1) << @intFromEnum(log2_align);
-            const size = @max(len, align_);
+            const size = @max(len, log2_align.toByteUnits());
             inline for (&self.bins) |*bin| {
                 if (size <= bin.size) {
                     return bin.alloc(self.backing_allocator);
@@ -109,7 +108,7 @@ pub fn BinnedAllocator(comptime config: Config) type {
         ) bool {
             const self: *Self = @ptrCast(@alignCast(ctx));
 
-            const align_ = @as(usize, 1) << @intFromEnum(log2_align);
+            const align_ = log2_align.toByteUnits();
             comptime var prev_size: usize = 0;
             inline for (&self.bins) |*bin| {
                 if (buf.len <= bin.size and align_ <= bin.size) {
@@ -127,7 +126,7 @@ pub fn BinnedAllocator(comptime config: Config) type {
         fn free(ctx: *anyopaque, buf: []u8, log2_align: std.mem.Alignment, ret_addr: usize) void {
             const self: *Self = @ptrCast(@alignCast(ctx));
 
-            const align_ = @as(usize, 1) << @intFromEnum(log2_align);
+            const align_ = log2_align.toByteUnits();
             inline for (&self.bins) |*bin| {
                 if (buf.len <= bin.size and align_ <= bin.size) {
                     bin.free(buf.ptr);

--- a/src/build_runner/mach-latest.zig
+++ b/src/build_runner/mach-latest.zig
@@ -1,7 +1,7 @@
 //! PLEASE READ THE FOLLOWING MESSAGE BEFORE EDITING THIS FILE:
 //!
 //! This build runner is targeting compatibility with the following Zig versions:
-//!   - master (0.14.0-dev.3181+914248237 and later)
+//!   - master (0.14.0-dev.2046+b8795b4d0 and later)
 //!
 //! Handling multiple Zig versions can be achieved by branching on the `builtin.zig_version` at comptime.
 //!
@@ -1024,7 +1024,7 @@ fn extractBuildInformation(
             stack.appendAssumeCapacity(&tls.step);
         }
 
-        while (stack.pop()) |step| {
+        while (stack.popOrNull()) |step| {
             const gop = try steps.getOrPut(gpa, step);
             if (gop.found_existing) continue;
 

--- a/src/build_runner/master.zig
+++ b/src/build_runner/master.zig
@@ -1024,7 +1024,7 @@ fn extractBuildInformation(
             stack.appendAssumeCapacity(&tls.step);
         }
 
-        while (stack.popOrNull()) |step| {
+        while (stack.pop()) |step| {
             const gop = try steps.getOrPut(gpa, step);
             if (gop.found_existing) continue;
 

--- a/src/debug.zig
+++ b/src/debug.zig
@@ -106,23 +106,23 @@ pub const FailingAllocator = struct {
     fn alloc(
         ctx: *anyopaque,
         len: usize,
-        log2_ptr_align: std.mem.Alignment,
+        ptr_alignment: std.mem.Alignment,
         return_address: usize,
     ) ?[*]u8 {
         const self: *FailingAllocator = @ptrCast(@alignCast(ctx));
         if (shouldFail(self)) return null;
-        return self.internal_allocator.rawAlloc(len, log2_ptr_align, return_address);
+        return self.internal_allocator.rawAlloc(len, ptr_alignment, return_address);
     }
 
     fn resize(
         ctx: *anyopaque,
         old_mem: []u8,
-        log2_old_align: std.mem.Alignment,
+        old_alignment: std.mem.Alignment,
         new_len: usize,
         ra: usize,
     ) bool {
         const self: *FailingAllocator = @ptrCast(@alignCast(ctx));
-        if (!self.internal_allocator.rawResize(old_mem, log2_old_align, new_len, ra))
+        if (!self.internal_allocator.rawResize(old_mem, old_alignment, new_len, ra))
             return false;
         return true;
     }
@@ -130,11 +130,11 @@ pub const FailingAllocator = struct {
     fn free(
         ctx: *anyopaque,
         old_mem: []u8,
-        log2_old_align: std.mem.Alignment,
+        old_alignment: std.mem.Alignment,
         ra: usize,
     ) void {
         const self: *FailingAllocator = @ptrCast(@alignCast(ctx));
-        self.internal_allocator.rawFree(old_mem, log2_old_align, ra);
+        self.internal_allocator.rawFree(old_mem, old_alignment, ra);
     }
 
     fn remap(

--- a/src/features/folding_range.zig
+++ b/src/features/folding_range.zig
@@ -304,7 +304,7 @@ pub fn generateFoldingRanges(allocator: std.mem.Allocator, tree: Ast, encoding: 
         if (std.mem.startsWith(u8, tree.source[possible_region..], "//#region")) {
             try stack.append(allocator, possible_region);
         } else if (std.mem.startsWith(u8, tree.source[possible_region..], "//#endregion")) {
-            const start_index = stack.popOrNull() orelse break; // null means there are more endregions than regions
+            const start_index = stack.pop() orelse break; // null means there are more endregions than regions
             const end_index = offsets.lineLocAtIndex(tree.source, possible_region).end;
             const is_same_line = std.mem.indexOfScalar(u8, tree.source[start_index..end_index], '\n') == null;
             if (is_same_line) continue;

--- a/src/features/signature_help.zig
+++ b/src/features/signature_help.zig
@@ -123,7 +123,7 @@ pub fn getSignatureInfo(
         switch (token_tags[curr_token]) {
             .comma => curr_commas += 1,
             .l_brace => {
-                curr_commas = comma_stack.popOrNull() orelse 0;
+                curr_commas = comma_stack.pop() orelse 0;
                 if (symbol_stack.items.len != 0) {
                     const peek_sym = symbol_stack.items[symbol_stack.items.len - 1];
                     switch (peek_sym) {
@@ -140,7 +140,7 @@ pub fn getSignatureInfo(
                 try symbol_stack.append(arena, .l_brace);
             },
             .l_bracket => {
-                curr_commas = comma_stack.popOrNull() orelse 0;
+                curr_commas = comma_stack.pop() orelse 0;
                 if (symbol_stack.items.len != 0) {
                     const peek_sym = symbol_stack.items[symbol_stack.items.len - 1];
                     switch (peek_sym) {
@@ -158,7 +158,7 @@ pub fn getSignatureInfo(
             },
             .l_paren => {
                 const paren_commas = curr_commas;
-                curr_commas = comma_stack.popOrNull() orelse 0;
+                curr_commas = comma_stack.pop() orelse 0;
                 if (symbol_stack.items.len != 0) {
                     const peek_sym = symbol_stack.items[symbol_stack.items.len - 1];
                     switch (peek_sym) {

--- a/tests/lsp_features/document_symbol.zig
+++ b/tests/lsp_features/document_symbol.zig
@@ -129,7 +129,7 @@ fn testDocumentSymbol(source: []const u8, want: []const u8) !void {
             _ = stack.pop();
         }
     }
-    _ = got.popOrNull(); // Final \n
+    _ = got.pop(); // Final \n
 
     try std.testing.expectEqualStrings(want, got.items);
 }

--- a/tests/lsp_features/selection_range.zig
+++ b/tests/lsp_features/selection_range.zig
@@ -61,7 +61,8 @@ fn testSelectionRange(source: []const u8, want: []const []const u8) !void {
         it = r.parent;
     }
     const last = got.pop();
-    try std.testing.expectEqualStrings(phr.new_source, last);
+    try std.testing.expect(last != null);
+    try std.testing.expectEqualStrings(phr.new_source, last.?);
     try std.testing.expectEqual(want.len, got.items.len);
     for (want, got.items) |expected, actual| {
         try std.testing.expectEqualStrings(expected, actual);


### PR DESCRIPTION
Updates ZLS to compile and pass tests with the https://github.com/ziglang/zig/pull/20511/ PR merged in Zig master. 

Of note is the new `remap` function in the binned allocator; it simply calls `resize` internally  à la `remap` functions introduced for several allocators in the Zig standard library (see e.g. `FixedBufferAllocator`), in the aforementioned PR.

This can also be replaced with a naive implementation that copies `resize`, but internally calling the underlying allocator's `remap`. I can make this change upon request, or this can be left for a followup PR (potentially leaving room for an entirely different implementation to make use of `remap`'s looser guarantees).

Also includes the minor `popOrNull` -> `pop` change in https://github.com/ziglang/zig/pull/22721