### PR TITLE
Detect declarations deprecated with a doc comment

### DIFF
--- a/src/features/semantic_tokens.zig
+++ b/src/features/semantic_tokens.zig
@@ -224,6 +224,10 @@ fn colorIdentifierBasedOnType(
     is_parameter: bool,
     tok_mod: TokenModifiers,
 ) !void {
+    var new_tok_mod = tok_mod;
+    if (type_node.deprecated_comment) {
+        new_tok_mod.deprecated = true;
+    }
     if (type_node.is_type_val) {
         const token_type: TokenType =
             if (type_node.isNamespace())
@@ -241,11 +245,10 @@ fn colorIdentifierBasedOnType(
         else
             .type;
 
-        try writeTokenMod(builder, target_tok, token_type, tok_mod);
+        try writeTokenMod(builder, target_tok, token_type, new_tok_mod);
     } else if (type_node.isTypeFunc()) {
-        try writeTokenMod(builder, target_tok, .type, tok_mod);
+        try writeTokenMod(builder, target_tok, .type, new_tok_mod);
     } else if (type_node.isFunc()) {
-        var new_tok_mod = tok_mod;
         if (type_node.isGenericFunc()) {
             new_tok_mod.generic = true;
         }
@@ -254,7 +257,6 @@ fn colorIdentifierBasedOnType(
 
         try writeTokenMod(builder, target_tok, if (has_self_param) .method else .function, new_tok_mod);
     } else {
-        var new_tok_mod = tok_mod;
         if (type_node.data == .compile_error) {
             new_tok_mod.deprecated = true;
         }

--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -2347,6 +2347,68 @@ test "deprecated " {
     });
 }
 
+test "deprecated with doc comment " {
+    try testCompletion(
+        \\/// Deprecated; some message
+        \\const foo = 123;
+        \\const bar = <cursor>
+    , &.{
+        .{
+            .label = "foo",
+            .kind = .Constant,
+            .documentation = " Deprecated; some message",
+            .deprecated = true,
+        },
+    });
+    try testCompletion(
+        \\///Deprecated
+        \\fn bar() void {}
+        \\const baz = <cursor>
+    , &.{
+        .{
+            .label = "bar",
+            .kind = .Function,
+            .documentation = "Deprecated",
+            .deprecated = true,
+        },
+    });
+    try testCompletion(
+        \\fn bar() void {}
+        \\///Deprecated, use bar
+        \\const foo = bar;
+        \\const baz = <cursor>
+    , &.{
+        .{
+            .label = "bar",
+            .kind = .Function,
+        },
+        .{
+            .label = "foo",
+            .kind = .Function,
+            .documentation = "Deprecated, use bar",
+            .deprecated = true,
+        },
+    });
+    try testCompletion(
+        \\const S = struct {
+        \\    /// Deprecated
+        \\    foo: u32,
+        \\};
+        \\comptime {
+        \\    var s: S = undefined;
+        \\    s.<cursor>
+        \\}
+    , &.{
+        .{
+            .label = "foo",
+            .kind = .Field,
+            .documentation = " Deprecated",
+            .deprecated = true,
+            .detail = "u32",
+        },
+    });
+}
+
 test "declarations" {
     try testCompletion(
         \\const S = struct {

--- a/tests/lsp_features/semantic_tokens.zig
+++ b/tests/lsp_features/semantic_tokens.zig
@@ -1798,6 +1798,59 @@ test "deprecated" {
     });
 }
 
+test "deprecated with doc comment" {
+    try testSemanticTokens(
+        \\/// Deprecated: use bar
+        \\const foo = 123;
+    , &.{
+        .{ "/// Deprecated: use bar", .comment, .{ .documentation = true } },
+        .{ "const", .keyword, .{} },
+        .{ "foo", .variable, .{ .declaration = true, .deprecated = true } },
+        .{ "=", .operator, .{} },
+        .{ "123", .number, .{} },
+    });
+    try testSemanticTokens(
+        \\/// DEPRECATED use bar
+        \\const foo = 123;
+        \\const bar = foo;
+    , &.{
+        .{ "/// DEPRECATED use bar", .comment, .{ .documentation = true } },
+        .{ "const", .keyword, .{} },
+        .{ "foo", .variable, .{ .declaration = true, .deprecated = true } },
+        .{ "=", .operator, .{} },
+        .{ "123", .number, .{} },
+
+        .{ "const", .keyword, .{} },
+        .{ "bar", .variable, .{ .declaration = true, .deprecated = true } },
+        .{ "=", .operator, .{} },
+        .{ "foo", .variable, .{ .deprecated = true } },
+    });
+    try testSemanticTokens(
+        \\const S = struct {
+        \\  /// deprecated, use bar
+        \\  const foo = 123;
+        \\};
+        \\const bar = S.foo;
+    , &.{
+        .{ "const", .keyword, .{} },
+        .{ "S", .namespace, .{ .declaration = true } },
+        .{ "=", .operator, .{} },
+        .{ "struct", .keyword, .{} },
+
+        .{ "/// deprecated, use bar", .comment, .{ .documentation = true } },
+        .{ "const", .keyword, .{} },
+        .{ "foo", .variable, .{ .declaration = true, .deprecated = true } },
+        .{ "=", .operator, .{} },
+        .{ "123", .number, .{} },
+
+        .{ "const", .keyword, .{} },
+        .{ "bar", .variable, .{ .declaration = true, .deprecated = true } },
+        .{ "=", .operator, .{} },
+        .{ "S", .namespace, .{} },
+        .{ "foo", .variable, .{ .deprecated = true } },
+    });
+}
+
 test "zon file" {
     try testSemanticTokensOptions(
         \\.{


### PR DESCRIPTION
I already get a compile error when using declarations deprecated with `@compileError`, seeing the ones only deprecated with doc comments is much more useful.

On a related note, why aren't the deprecated identifiers rendered with a strikethrough?

```zig
/// Deprecated
const foo = 123;
const bar = @compileError("foo");
comptime {
    foo;
    bar;
}
```
vs
```js
/**
 * @deprecated test
 */
const foo = 1;
foo
```
![image](https://github.com/user-attachments/assets/7e6cc2f3-34cf-4680-ba06-dea8ea2da612)
