### PR TITLE
Move `Type.Data.ip_index` and `.either` to `Type`

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -2738,7 +2738,7 @@ pub const Type = union(enum) {
                         .descriptor = entry.descriptor,
                     });
                 }
-                return fromEither(analyser, either.items);
+                return try fromEither(analyser, either.items);
             },
         }
     }
@@ -2756,7 +2756,7 @@ pub const Type = union(enum) {
                 for (entries) |entry| {
                     either.appendAssumeCapacity(.{ .type = try entry.type.typeOf(analyser), .descriptor = entry.descriptor });
                 }
-                return .{ .either = either.items }; // TODO: should this use fromEither?
+                return try fromEither(analyser, either.items) orelse .{ .either = either.items };
             },
         }
     }

--- a/src/features/hover.zig
+++ b/src/features/hover.zig
@@ -134,13 +134,13 @@ fn hoverSymbolRecursive(
 
     var resolved_type_str: []const u8 = "unknown";
     if (try decl_handle.resolveType(analyser)) |resolved_type| {
-        if (try resolved_type.docComments(arena)) |doc|
+        if (try resolved_type.docComments(analyser)) |doc|
             try doc_strings.append(arena, doc);
         try analyser.referencedTypes(
             resolved_type,
             &reference_collector,
         );
-        resolved_type_str = try std.fmt.allocPrint(arena, "{}", .{resolved_type.fmt(analyser, .{ .truncate_container_decls = false })});
+        resolved_type_str = try std.fmt.allocPrint(arena, "{}", .{try resolved_type.fmt(analyser, .{ .truncate_container_decls = false })});
     }
     const referenced_types: []const Analyser.ReferencedType = type_references.keys();
 

--- a/src/features/inlay_hints.zig
+++ b/src/features/inlay_hints.zig
@@ -238,7 +238,7 @@ fn writeCallHint(
 
     const ty = try builder.analyser.resolveTypeOfNode(.{ .node = call.ast.fn_expr, .handle = handle }) orelse return;
     const fn_ty = try builder.analyser.resolveFuncProtoOfCallable(ty) orelse return;
-    const fn_node = fn_ty.data.other; // this assumes that function types can only be Ast nodes
+    const fn_node = fn_ty.dynamic.data.other; // this assumes that function types can only be Ast nodes
 
     var buffer: [1]Ast.Node.Index = undefined;
     const fn_proto = fn_node.handle.tree.fullFnProto(&buffer, fn_node.node).?;
@@ -345,7 +345,7 @@ fn typeStrOfNode(builder: *Builder, node: Ast.Node.Index) !?[]const u8 {
     const type_str: []const u8 = try std.fmt.allocPrint(
         builder.arena,
         "{}",
-        .{resolved_type.fmt(builder.analyser, .{ .truncate_container_decls = true })},
+        .{try resolved_type.fmt(builder.analyser, .{ .truncate_container_decls = true })},
     );
     if (type_str.len == 0) return null;
 
@@ -363,7 +363,7 @@ fn typeStrOfToken(builder: *Builder, token: Ast.TokenIndex) !?[]const u8 {
     const type_str: []const u8 = try std.fmt.allocPrint(
         builder.arena,
         "{}",
-        .{resolved_type.fmt(builder.analyser, .{ .truncate_container_decls = true })},
+        .{try resolved_type.fmt(builder.analyser, .{ .truncate_container_decls = true })},
     );
     if (type_str.len == 0) return null;
 
@@ -568,7 +568,7 @@ fn writeNodeInlayHint(
                 const type_str: []const u8 = try std.fmt.allocPrint(
                     builder.arena,
                     "{}",
-                    .{ty.fmt(builder.analyser, .{ .truncate_container_decls = true })},
+                    .{try ty.fmt(builder.analyser, .{ .truncate_container_decls = true })},
                 );
                 if (type_str.len == 0) continue;
                 try appendTypeHintString(

--- a/src/features/semantic_tokens.zig
+++ b/src/features/semantic_tokens.zig
@@ -583,8 +583,11 @@ fn writeNodeTokens(builder: *Builder, node: Ast.Node.Index) error{OutOfMemory}!v
 
                 field_token_type = if (try builder.analyser.resolveTypeOfNode(
                     .{ .node = struct_init.ast.type_expr, .handle = handle },
-                )) |struct_type| if (struct_type != .dynamic) null else switch (struct_type.dynamic.data) {
-                    .container => |scope_handle| fieldTokenType(scope_handle.toNode(), scope_handle.handle, false),
+                )) |struct_type| switch (struct_type) {
+                    .dynamic => |payload| switch (payload.data) {
+                        .container => |scope_handle| fieldTokenType(scope_handle.toNode(), scope_handle.handle, false),
+                        else => null,
+                    },
                     else => null,
                 } else null;
             }

--- a/src/features/signature_help.zig
+++ b/src/features/signature_help.zig
@@ -20,7 +20,7 @@ fn fnProtoToSignatureInfo(
     func_type: Analyser.Type,
     markup_kind: types.MarkupKind,
 ) !types.SignatureInformation {
-    const fn_node_handle = func_type.data.other; // this assumes that function types can only be Ast nodes
+    const fn_node_handle = func_type.dynamic.data.other; // this assumes that function types can only be Ast nodes
     const fn_node = fn_node_handle.node;
     const fn_handle = fn_node_handle.handle;
     const tree = fn_handle.tree;
@@ -271,7 +271,7 @@ pub fn getSignatureInfo(
                 };
                 const name = offsets.locToSlice(handle.tree.source, name_loc);
 
-                const skip_self_param = !ty.is_type_val;
+                const skip_self_param = !ty.isTypeVal(analyser);
                 ty = try analyser.resolveFieldAccess(ty, name) orelse {
                     try symbol_stack.append(arena, .l_paren);
                     continue;


### PR DESCRIPTION
The `is_type_val` field is redundant for `ip_index` and `either`, so let's turn `Type` into a tagged union with those and the original struct as the possible variants. Currently, I've named the new variant as `dynamic`, but I'm open to suggestions!

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>

```zig
pub const Type = struct {
    data: Data,
    is_type_val: bool,

    pub const Data = union(enum) {
        // ...

        compile_error: NodeWithHandle,

        either: []const EitherEntry,

        ip_index: struct {
            node: ?NodeWithHandle = null,
            index: InternPool.Index,
        },

        pub const EitherEntry = struct {
            type_data: Data,
            descriptor: []const u8,
        };
    };

    // ...

    pub const TypeWithDescriptor = struct {
        type: Type,
        descriptor: []const u8,
    };

    // ...
};
```

</td>
<td>

```zig
pub const Type = union(enum) {
    dynamic: struct {
        data: Data,
        is_type_val: bool,
    },

    ip_index: struct {
        node: ?NodeWithHandle = null,
        index: InternPool.Index,
    },

    either: []const TypeWithDescriptor,

    pub const Data = union(enum) {
        // ...

        compile_error: NodeWithHandle,
    };

    // ...

    pub const TypeWithDescriptor = struct {
        type: Type,
        descriptor: []const u8,
    };

    // ...
};
```

</td>
</tr>
</table>
