### PR TITLE
Make `Type.Data.ip_index.index` optional

### DIFF
--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -143,7 +143,7 @@ fn typeToCompletion(builder: *Builder, ty: Analyser.Type) error{OutOfMemory}!voi
             builder.arena,
             &builder.completions,
             builder.analyser.ip,
-            payload.index,
+            payload.index orelse try builder.analyser.ip.getUnknown(builder.analyser.gpa, payload.type),
         ),
         .either => |either_entries| {
             for (either_entries) |entry| {
@@ -265,7 +265,7 @@ fn declToCompletion(builder: *Builder, decl_handle: Analyser.DeclWithHandle, opt
             }
 
             const detail = if (maybe_resolved_ty) |ty| blk: {
-                if (ty.is_type_val and ty.data == .ip_index and !builder.analyser.ip.isUnknown(ty.data.ip_index.index)) {
+                if (ty.is_type_val and ty.data == .ip_index and ty.data.ip_index.index != null and !builder.analyser.ip.isUnknown(ty.data.ip_index.index.?)) {
                     break :blk try std.fmt.allocPrint(builder.arena, "{}", .{ty.fmtTypeVal(builder.analyser, .{ .truncate_container_decls = false })});
                 } else {
                     break :blk try std.fmt.allocPrint(builder.arena, "{}", .{ty.fmt(builder.analyser, .{ .truncate_container_decls = false })});

--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -257,7 +257,7 @@ fn declToCompletion(builder: *Builder, decl_handle: Analyser.DeclWithHandle, opt
                     kind = .Struct;
                 } else if (decl_handle.decl == .function_parameter and ty.isMetaType()) {
                     kind = .TypeParameter;
-                } else if (ty.isEnumLiteral(builder.analyser)) {
+                } else if (ty.isEnumLiteral()) {
                     kind = .EnumMember;
                 } else if (ty.data == .compile_error) {
                     is_deprecated = true;
@@ -1645,7 +1645,7 @@ fn collectEnumLiteralContainerNodes(
         el_dot_context,
     );
     for (containers) |container| {
-        const container_instance = try container.instanceTypeVal(analyser) orelse container;
+        const container_instance = container.instanceTypeVal(analyser) orelse container;
         const member_decl = try container_instance.lookupSymbol(analyser, alleged_field_name) orelse continue;
         var member_type = try member_decl.resolveType(analyser) orelse continue;
         // Unwrap `x{ .fld_w_opt_type =`


### PR DESCRIPTION
```diff
         ip_index: struct {
-            node: ?NodeWithHandle = null,
-            index: InternPool.Index,
+            type: InternPool.Index,
+            index: ?InternPool.Index,
         },
```

Closes #2186