### PR TITLE
Fix StringPool test with latest Zig

### DIFF
--- a/src/analyser/string_pool.zig
+++ b/src/analyser/string_pool.zig
@@ -272,6 +272,7 @@ test "StringPool - getOrPut on existing string without allocation" {
     var pool: StringPool(.{}) = .empty;
     defer pool.deinit(gpa);
 
+    try pool.bytes.ensureTotalCapacityPrecise(gpa, "hello".len + 1);
     const hello_string = try pool.getOrPutString(gpa, "hello");
 
     try std.testing.expectError(error.OutOfMemory, pool.getOrPutString(failing_gpa.allocator(), "world"));


### PR DESCRIPTION
Likely culprit: [std.ArrayList: initial capacity based on cache line size](https://github.com/ziglang/zig/commit/d12123a)

Output from [relevant zls CI run](https://github.com/zigtools/zls/actions/runs/13333681045/job/37243800894?pr=2189):

```
error: 'analyser.string_pool.test.StringPool - getOrPut on existing string without allocation' failed: expected error.OutOfMemory, found analyser.string_pool.StringPool(.{ .thread_safe = true, .MutexType = null }).String(6)
zig/lib/std/testing.zig:50:9: 0x12ec551 in expectError__anon_93308 (src test)
        return error.TestExpectedError;
        ^
zls/src/analyser/string_pool.zig:277:5: 0x12ec7d8 in test.StringPool - getOrPut on existing string without allocation (src test)
    try std.testing.expectError(error.OutOfMemory, pool.getOrPutString(failing_gpa.allocator(), "world"));
    ^
```