### PR TITLE
add analysis tests

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Run Tests with kcov
         run: |
           kcov --version
-          zig build coverage --summary all
+          zig build test -Dcoverage --summary all
 
       - name: Upload to Codecov
         uses: codecov/codecov-action@v5

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -2879,7 +2879,7 @@ pub const Type = struct {
     }
 
     pub fn fmtTypeVal(ty: Type, analyser: *Analyser, options: FormatOptions) std.fmt.Formatter(format) {
-        std.debug.assert(ty.is_type_val);
+        std.debug.assert(ty.data == .ip_index or ty.is_type_val);
         return .{ .data = .{ .ty = ty, .analyser = analyser, .options = options } };
     }
 

--- a/src/zls.zig
+++ b/src/zls.zig
@@ -19,6 +19,7 @@ pub const analyser = @import("analyser/analyser.zig");
 pub const configuration = @import("configuration.zig");
 pub const DocumentScope = @import("DocumentScope.zig");
 pub const BuildRunnerVersion = @import("build_runner/BuildRunnerVersion.zig");
+pub const DiagnosticsCollection = @import("DiagnosticsCollection.zig");
 
 pub const signature_help = @import("features/signature_help.zig");
 pub const references = @import("features/references.zig");

--- a/tests/add_analysis_cases.zig
+++ b/tests/add_analysis_cases.zig
@@ -1,0 +1,51 @@
+const std = @import("std");
+
+pub fn addCases(
+    b: *std.Build,
+    test_filters: []const []const u8,
+    steps1: *std.ArrayListUnmanaged(*std.Build.Step.Run),
+    steps2: *std.ArrayListUnmanaged(*std.Build.Step.Run),
+) void {
+    const cases_dir = b.path("tests/analysis");
+    const cases_path_from_root = b.pathFromRoot("tests/analysis");
+
+    const check_exe = b.addExecutable(.{
+        .name = "analysis_check",
+        .root_source_file = b.path("tests/analysis_check.zig"),
+        .target = b.graph.host,
+    });
+    check_exe.root_module.addImport("zls", b.modules.get("zls").?);
+
+    // https://github.com/ziglang/zig/issues/20605
+    var dir = std.fs.openDirAbsolute(b.pathFromRoot(cases_path_from_root), .{ .iterate = true }) catch |err|
+        std.debug.panic("failed to open '{s}': {}", .{ cases_path_from_root, err });
+    defer dir.close();
+
+    var it = dir.iterate();
+
+    while (true) {
+        const entry = it.next() catch |err|
+            std.debug.panic("failed to walk directory '{s}': {}", .{ cases_path_from_root, err }) orelse break;
+
+        if (entry.kind != .file) continue;
+        if (!std.mem.eql(u8, std.fs.path.extension(entry.name), ".zig")) continue;
+
+        for (test_filters) |test_filter| {
+            if (std.mem.indexOf(u8, entry.name, test_filter) != null) break;
+        } else if (test_filters.len > 0) continue;
+
+        // We create two runs steps, one for `zig build test` and another for `zig build coverage`
+        for ([_]*std.ArrayListUnmanaged(*std.Build.Step.Run){ steps1, steps2 }) |steps| {
+            const run_check = std.Build.Step.Run.create(b, b.fmt("run analysis on {s}", .{entry.name}));
+            run_check.producer = check_exe;
+            run_check.addArtifactArg(check_exe);
+            run_check.addArg("--zig-exe-path");
+            run_check.addFileArg(.{ .cwd_relative = b.graph.zig_exe });
+            run_check.addArg("--zig-lib-path");
+            run_check.addDirectoryArg(.{ .cwd_relative = b.fmt("{}", .{b.graph.zig_lib_directory}) });
+            run_check.addFileArg(cases_dir.path(b, entry.name));
+
+            steps.append(b.allocator, run_check) catch @panic("OOM");
+        }
+    }
+}

--- a/tests/analysis/array.zig
+++ b/tests/analysis/array.zig
@@ -1,0 +1,81 @@
+const ArrayType = [3]u8;
+//    ^^^^^^^^^ (type)([3]u8)
+const ArrayTypeWithSentinel = [3:0]u8;
+//    ^^^^^^^^^^^^^^^^^^^^^ (type)([3:0]u8)
+
+const empty_array: [0]u8 = undefined;
+//    ^^^^^^^^^^^ ([0]u8)()
+const empty_array_len = empty_array.len;
+//    ^^^^^^^^^^^^^^^ (usize)()
+
+const length = 3;
+const unknown_length: usize = undefined;
+var runtime_index: usize = 5;
+
+const some_array: [length]u8 = undefined;
+//    ^^^^^^^^^^ ([3]u8)()
+
+const some_unsized_array: [unknown_length]u8 = undefined;
+//    ^^^^^^^^^^^^^^^^^^ ([?]u8)()
+
+const some_array_len = some_array.len;
+//    ^^^^^^^^^^^^^^ (usize)()
+
+const some_unsized_array_len = some_unsized_array.len;
+//    ^^^^^^^^^^^^^^^^^^^^^^ (usize)()
+
+const array_indexing = some_array[0];
+//    ^^^^^^^^^^^^^^ (u8)()
+
+// TODO this should be `*const [2]u8`
+const array_slice_open_1 = some_array[1..];
+//    ^^^^^^^^^^^^^^^^^^ ([]u8)()
+
+// TODO this should be `*const [0]u8`
+const array_slice_open_3 = some_array[3..];
+//    ^^^^^^^^^^^^^^^^^^ ([]u8)()
+
+// TODO this should be `*const [?]u8`
+const array_slice_open_4 = some_array[4..];
+//    ^^^^^^^^^^^^^^^^^^ ([]u8)()
+
+const array_slice_open_runtime = some_array[runtime_index..];
+//    ^^^^^^^^^^^^^^^^^^^^^^^^ ([]u8)()
+
+// TODO this should be `*const [2]u8`
+const array_slice_0_2 = some_array[0..2];
+//    ^^^^^^^^^^^^^^^ ([]u8)()
+
+// TODO this should be `*const [2 :0]u8`
+const array_slice_0_2_sentinel = some_array[0..2 :0];
+// TODO   ^^^^^^^^^^^^^^^ ([:0]u8)()
+
+// TODO this should be `*const [?]u8`
+const array_slice_0_5 = some_array[0..5];
+//    ^^^^^^^^^^^^^^^ ([]u8)()
+
+// TODO this should be `*const [?]u8`
+const array_slice_3_2 = some_array[3..2];
+//    ^^^^^^^^^^^^^^^ ([]u8)()
+
+const array_slice_0_runtime = some_array[0..runtime_index];
+//    ^^^^^^^^^^^^^^^^^^^^^ ([]u8)()
+
+const array_slice_with_sentinel = some_array[0..runtime_index :0];
+// TODO   ^^^^^^^^^^^^^^^^^^^^^^^^^ ([:0]u8)()
+
+//
+// Array init
+//
+
+const array_init = [length]u8{};
+//    ^^^^^^^^^^ ([3]u8)()
+const array_init_inferred_len_0 = [_]u8{};
+// TODO   ^^^^^^^^^^^^^^^^^^^^^^^^^ ([0]u8)()
+const array_init_inferred_len_3 = [_]u8{ 1, 2, 3 };
+// TODO   ^^^^^^^^^^^^^^^^^^^^^^^^^ ([0]u8)()
+
+comptime {
+    // Use @compileLog to verify the expected type with the compiler:
+    // @compileLog(some_array);
+}

--- a/tests/analysis/basic.zig
+++ b/tests/analysis/basic.zig
@@ -1,0 +1,48 @@
+const alpha: bool = true;
+//    ^^^^^ (bool)()
+const beta: bool = false;
+//    ^^^^ (bool)()
+const gamma: type = bool;
+//    ^^^^^ (type)(bool)
+const delta: comptime_int = 4;
+//    ^^^^^ (comptime_int)()
+const epsilon = null;
+//    ^^^^^^^ (@TypeOf(null))(null)
+const zeta: type = u32;
+//    ^^^^ (type)(u32)
+const eta: type = isize;
+//    ^^^ (type)(isize)
+const theta = true;
+//    ^^^^^ (bool)(true)
+const iota = false;
+//    ^^^^ (bool)(false)
+const kappa = bool;
+//    ^^^^^ (type)(bool)
+const lambda = 4;
+//    ^^^^^^ (comptime_int)()
+const mu = undefined;
+//    ^^ (@TypeOf(undefined))(undefined)
+const nu: type = i1;
+//    ^^ (type)(i1)
+const xi: type = usize;
+//    ^^ (type)(usize)
+const omicron = 0;
+//    ^^^^^^^ ()()
+const pi = 3.14159;
+//    ^^ (comptime_float)()
+const rho: type = anyopaque;
+//    ^^^ (type)(anyopaque)
+const sigma = noreturn;
+//    ^^^^^ (type)(noreturn)
+const tau = anyerror;
+//    ^^^ (type)(anyerror)
+const upsilon = 0;
+//    ^^^^^^^ ()()
+const phi = 0;
+//    ^^^ ()()
+const chi = 0;
+//    ^^^ ()()
+const psi = 0;
+//    ^^^ ()()
+const omega = 0;
+//    ^^^^^ ()()

--- a/tests/analysis/optional.zig
+++ b/tests/analysis/optional.zig
@@ -1,0 +1,20 @@
+const alpha: ?u32 = undefined;
+//    ^^^^^ (?u32)()
+
+const beta = alpha.?;
+//    ^^^^ (u32)()
+
+const gamma = if (alpha) |value| value else null;
+//                        ^^^^^ (u32)()
+
+const delta = alpha orelse unreachable;
+//    ^^^^^ (u32)()
+
+const epsilon = alpha.?;
+//    ^^^^^^^ (u32)()
+
+const zeta = alpha orelse null;
+// TODO   ^^^^ (?u32)()
+
+const eta = alpha orelse 5;
+//    ^^^ (u32)()

--- a/tests/analysis/pointer.zig
+++ b/tests/analysis/pointer.zig
@@ -1,0 +1,128 @@
+//
+// single item pointer *T
+//
+
+const one_u32: *const u32 = &@as(u32, 5);
+//    ^^^^^^^ (*const u32)()
+
+const one_u32_deref = one_u32.*;
+//    ^^^^^^^^^^^^^ (u32)()
+
+const one_u32_indexing = one_u32[0];
+//    ^^^^^^^^^^^^^^^^ (unknown)()
+
+const one_u32_slice_len_0_5 = one_u32[0..5];
+//    ^^^^^^^^^^^^^^^^^^^^^ (unknown)()
+
+const one_u32_slice_len_0_0 = one_u32[0..0];
+// TODO   ^^^^^^^^^^^^^^^^^^^^^ (*const [0]u32)()
+
+const one_u32_slice_len_0_1 = one_u32[0..1];
+// TODO   ^^^^^^^^^^^^^^^^^^^^^ (*const [1]u32)()
+
+const one_u32_slice_len_1_1 = one_u32[1..1];
+// TODO   ^^^^^^^^^^^^^^^^^^^^^ (*const [0]u32)()
+
+const one_u32_slice_open = one_u32[1..];
+//    ^^^^^^^^^^^^^^^^^^ (unknown)()
+
+const one_u32_orelse = one_u32 orelse unreachable;
+//    ^^^^^^^^^^^^^^ (unknown)()
+
+const one_u32_unwrap = one_u32.?;
+//    ^^^^^^^^^^^^^^ (unknown)()
+
+//
+// many item pointer [*]T
+//
+
+const many_u32: [*]const u32 = &[_]u32{ 1, 2 };
+//    ^^^^^^^^ ([*]const u32)()
+
+const many_u32_deref = many_u32.*;
+//    ^^^^^^^^^^^^^^ (unknown)()
+
+const many_u32_indexing = many_u32[0];
+//    ^^^^^^^^^^^^^^^^^ (u32)()
+
+// TODO this should be `*const [2]u32`
+const many_u32_slice_len_comptime = many_u32[0..2];
+//    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ ([]const u32)()
+
+const many_u32_slice_len_runtime = many_u32[0..runtime_index];
+//    ^^^^^^^^^^^^^^^^^^^^^^^^^^ ([]const u32)()
+
+const many_u32_slice_open = many_u32[1..];
+//    ^^^^^^^^^^^^^^^^^^^ ([*]const u32)()
+
+const many_u32_orelse = many_u32 orelse unreachable;
+//    ^^^^^^^^^^^^^^^ (unknown)()
+
+const many_u32_unwrap = many_u32.?;
+//    ^^^^^^^^^^^^^^^ (unknown)()
+
+//
+// slice []T
+//
+
+const slice_u32: []const u32 = &.{ 1, 2 };
+//    ^^^^^^^^^ ([]const u32)()
+
+const slice_u32_deref = slice_u32.*;
+//    ^^^^^^^^^^^^^^^ (unknown)()
+
+const slice_u32_indexing = slice_u32[0];
+//    ^^^^^^^^^^^^^^^^^^ (u32)()
+
+// TODO this should be `*const [2]u32`
+const slice_u32_slice_len_comptime = slice_u32[0..2];
+//    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ([]const u32)()
+
+const slice_u32_slice_len_runtime = slice_u32[0..runtime_index];
+//    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ ([]const u32)()
+
+// TODO this should be `*const [1]u32`
+const slice_u32_slice_open = slice_u32[1..];
+//    ^^^^^^^^^^^^^^^^^^^^ ([]const u32)()
+
+const slice_u32_orelse = slice_u32 orelse unreachable;
+//    ^^^^^^^^^^^^^^^^ (unknown)()
+
+const slice_u32_unwrap = slice_u32.?;
+//    ^^^^^^^^^^^^^^^^ (unknown)()
+
+//
+// C pointer [*c]T
+//
+
+const c_u32: [*c]const u32 = &[_]u32{ 1, 2 };
+//    ^^^^^ ([*c]const u32)()
+
+const c_u32_deref = c_u32.*;
+//    ^^^^^^^^^^^ (u32)()
+
+const c_u32_indexing = c_u32[0];
+//    ^^^^^^^^^^^^^^ (u32)()
+
+// TODO this should be `*const [2]u32`
+const c_u32_slice_len_comptime = c_u32[0..2];
+//    ^^^^^^^^^^^^^^^^^^^^^^^^ ([]const u32)()
+
+const c_u32_slice_len_runtime = c_u32[0..runtime_index];
+//    ^^^^^^^^^^^^^^^^^^^^^^^ ([]const u32)()
+
+const c_u32_slice_open = c_u32[1..];
+//    ^^^^^^^^^^^^^^^^ ([*c]const u32)()
+
+const c_u32_orelse = c_u32 orelse unreachable;
+//    ^^^^^^^^^^^^ ([*c]const u32)()
+
+const c_u32_unwrap = c_u32.?;
+//    ^^^^^^^^^^^^ ([*c]const u32)()
+
+var runtime_index: usize = 5;
+
+comptime {
+    // Use @compileLog to verify the expected type with the compiler:
+    // @compileLog(many_u32_slice_len_comptime);
+}

--- a/tests/analysis_check.zig
+++ b/tests/analysis_check.zig
@@ -1,0 +1,270 @@
+const std = @import("std");
+const zls = @import("zls");
+const builtin = @import("builtin");
+
+const helper = @import("helper.zig");
+const ErrorBuilder = @import("ErrorBuilder.zig");
+
+const InternPool = zls.analyser.InternPool;
+const Index = InternPool.Index;
+const Key = InternPool.Key;
+const Analyser = zls.Analyser;
+const offsets = zls.offsets;
+
+pub const std_options: std.Options = .{
+    .log_level = .warn,
+};
+
+const Error = error{
+    OutOfMemory,
+    InvalidTestItem,
+
+    IdentifierNotFound,
+    ResolveTypeFailed,
+    WrongType,
+    WrongValue,
+};
+
+pub fn main() Error!void {
+    var general_purpose_allocator: std.heap.GeneralPurposeAllocator(.{}) = .init;
+    defer _ = general_purpose_allocator.deinit();
+    const gpa = general_purpose_allocator.allocator();
+
+    var arg_it = std.process.argsWithAllocator(gpa) catch |err| std.debug.panic("failed to collect args: {}", .{err});
+    defer arg_it.deinit();
+
+    _ = arg_it.skip();
+
+    var arena_allocator: std.heap.ArenaAllocator = .init(gpa);
+    defer arena_allocator.deinit();
+
+    const arena = arena_allocator.allocator();
+
+    var config: zls.Config = .{};
+
+    var opt_file_path: ?[]const u8 = null;
+
+    while (arg_it.next()) |arg| {
+        if (!std.mem.startsWith(u8, arg, "--")) {
+            if (opt_file_path != null) {
+                std.log.err("duplicate source file argument", .{});
+                std.process.exit(1);
+            } else {
+                opt_file_path = try arena.dupe(u8, arg);
+            }
+        } else if (std.mem.eql(u8, arg, "--zig-exe-path")) {
+            const zig_exe_path = arg_it.next() orelse {
+                std.log.err("expected argument after '--zig-exe-path'.", .{});
+                std.process.exit(1);
+            };
+            config.zig_exe_path = try arena.dupe(u8, zig_exe_path);
+        } else if (std.mem.eql(u8, arg, "--zig-lib-path")) {
+            const zig_lib_path = arg_it.next() orelse {
+                std.log.err("expected argument after '--zig-lib-path'.", .{});
+                std.process.exit(1);
+            };
+            config.zig_lib_path = try arena.dupe(u8, zig_lib_path);
+        } else {
+            std.log.err("Unrecognized argument '{s}'.", .{arg});
+            std.process.exit(1);
+        }
+    }
+
+    var thread_pool: if (builtin.single_threaded) void else std.Thread.Pool = undefined;
+    if (builtin.single_threaded) {
+        thread_pool = {};
+    } else {
+        thread_pool.init(.{
+            .allocator = gpa,
+        }) catch std.debug.panic("failed to initalize thread pool", .{});
+    }
+    defer if (!builtin.single_threaded) thread_pool.deinit();
+
+    var ip: InternPool = try .init(gpa);
+    defer ip.deinit(gpa);
+
+    var diagnostics_collection: zls.DiagnosticsCollection = .{ .allocator = gpa };
+    defer diagnostics_collection.deinit();
+
+    var document_store: zls.DocumentStore = .{
+        .allocator = gpa,
+        .config = .fromMainConfig(config),
+        .thread_pool = &thread_pool,
+        .diagnostics_collection = &diagnostics_collection,
+    };
+    defer document_store.deinit();
+
+    const file_path = opt_file_path orelse {
+        std.log.err("Missing source file path argument", .{});
+        std.process.exit(1);
+    };
+
+    const file = std.fs.openFileAbsolute(file_path, .{}) catch |err| std.debug.panic("failed to open {s}: {}", .{ file_path, err });
+    defer file.close();
+
+    const source = file.readToEndAllocOptions(gpa, std.math.maxInt(usize), null, @alignOf(u8), 0) catch |err|
+        std.debug.panic("failed to read from {s}: {}", .{ file_path, err });
+    defer gpa.free(source);
+
+    const handle_uri = try zls.URI.fromPath(arena, file_path);
+    try document_store.openDocument(handle_uri, source);
+    const handle: *zls.DocumentStore.Handle = document_store.handles.get(handle_uri).?;
+
+    var error_builder: ErrorBuilder = .init(gpa);
+    defer error_builder.deinit();
+    errdefer error_builder.writeDebug();
+    error_builder.file_name_visibility = .always;
+
+    try error_builder.addFile(file_path, handle.tree.source);
+
+    const annotations = helper.collectAnnotatedSourceLocations(gpa, handle.tree.source) catch |err| switch (err) {
+        error.InvalidSourceLoc => std.debug.panic("{s} contains invalid annotated source locations: {}", .{ file_path, err }),
+        error.OutOfMemory => |e| return e,
+    };
+    defer gpa.free(annotations);
+
+    var analyser = zls.Analyser.init(gpa, &document_store, &ip, handle);
+    defer analyser.deinit();
+
+    for (annotations) |annotation| {
+        const identifier_loc = annotation.loc;
+        const identifier = offsets.locToSlice(handle.tree.source, identifier_loc);
+
+        const test_item = parseAnnotatedSourceLoc(annotation) catch |err| {
+            try error_builder.msgAtLoc("invalid annotated source location '{s}'", file_path, annotation.loc, .err, .{
+                annotation.content,
+            });
+            return err;
+        };
+
+        const decl = try analyser.lookupSymbolGlobal(handle, identifier, identifier_loc.start) orelse {
+            try error_builder.msgAtLoc("failed to find identifier '{s}' here", file_path, annotation.loc, .err, .{
+                annotation.content,
+            });
+            return error.IdentifierNotFound;
+        };
+
+        const expect_unknown = (if (test_item.expected_type) |expected_type| std.mem.eql(u8, expected_type, "unknown") else false) and
+            (if (test_item.expected_value) |expected_value| std.mem.eql(u8, expected_value, "unknown") else true) and
+            test_item.expected_error == null;
+
+        const ty = try decl.resolveType(&analyser) orelse {
+            if (expect_unknown) continue;
+            try error_builder.msgAtLoc("failed to resolve type of '{s}'", file_path, annotation.loc, .err, .{
+                identifier,
+            });
+            return error.ResolveTypeFailed;
+        };
+
+        if (expect_unknown) {
+            const actual_type = try std.fmt.allocPrint(gpa, "{}", .{ty.fmt(&analyser, .{
+                .truncate_container_decls = false,
+            })});
+            defer gpa.free(actual_type);
+
+            try error_builder.msgAtLoc("expected unknown but got `{s}`", file_path, identifier_loc, .err, .{
+                actual_type,
+            });
+            return error.WrongType;
+        }
+
+        if (test_item.expected_error) |_| {
+            @panic("unsupported");
+        }
+
+        if (test_item.expected_type) |expected_type| {
+            const actual_type = try std.fmt.allocPrint(gpa, "{}", .{ty.fmt(&analyser, .{
+                .truncate_container_decls = false,
+            })});
+            defer gpa.free(actual_type);
+
+            if (!std.mem.eql(u8, expected_type, actual_type)) {
+                try error_builder.msgAtLoc("expected type `{s}` but got `{s}`", file_path, identifier_loc, .err, .{
+                    expected_type,
+                    actual_type,
+                });
+                return error.WrongType;
+            }
+        }
+
+        if (test_item.expected_value) |expected_value| {
+            if (ty.data != .ip_index and !ty.is_type_val) {
+                try error_builder.msgAtLoc("unsupported value check `{s}`", file_path, identifier_loc, .err, .{
+                    expected_value,
+                });
+                return error.WrongValue;
+            }
+
+            const actual_value = try std.fmt.allocPrint(gpa, "{}", .{ty.fmtTypeVal(&analyser, .{
+                .truncate_container_decls = false,
+            })});
+            defer gpa.free(actual_value);
+
+            if (!std.mem.eql(u8, expected_value, actual_value)) {
+                try error_builder.msgAtLoc("expected value `{s}` but got `{s}`", file_path, identifier_loc, .err, .{
+                    expected_value,
+                    actual_value,
+                });
+                return error.WrongValue;
+            }
+        }
+    }
+}
+
+const TestItem = struct {
+    loc: offsets.Loc,
+    expected_type: ?[]const u8 = null,
+    expected_value: ?[]const u8 = null,
+    expected_error: ?[]const u8 = null,
+};
+
+fn parseAnnotatedSourceLoc(annotation: helper.AnnotatedSourceLoc) error{InvalidTestItem}!TestItem {
+    const str = annotation.content;
+
+    if (std.mem.startsWith(u8, str, "error:")) {
+        return .{
+            .loc = annotation.loc,
+            .expected_error = std.mem.trim(u8, str["error:".len..], &std.ascii.whitespace),
+        };
+    }
+
+    if (!std.mem.startsWith(u8, str, "(")) return error.InvalidTestItem;
+    const expected_type_start = 1;
+    const expected_type_end = expected_type_start + (findClosingBrace(str[expected_type_start..]) orelse return error.InvalidTestItem);
+
+    if (!std.mem.startsWith(u8, str[expected_type_end + 1 ..], "(")) return error.InvalidTestItem;
+    const expected_value_start = expected_type_end + 2;
+    const expected_value_end = expected_value_start + (findClosingBrace(str[expected_value_start..]) orelse return error.InvalidTestItem);
+
+    const expected_type = std.mem.trim(
+        u8,
+        offsets.locToSlice(str, .{ .start = expected_type_start, .end = expected_type_end }),
+        &std.ascii.whitespace,
+    );
+    const expected_value = std.mem.trim(
+        u8,
+        offsets.locToSlice(str, .{ .start = expected_value_start, .end = expected_value_end }),
+        &std.ascii.whitespace,
+    );
+
+    return .{
+        .loc = annotation.loc,
+        .expected_type = if (expected_type.len != 0) expected_type else null,
+        .expected_value = if (expected_value.len != 0) expected_value else null,
+    };
+}
+
+fn findClosingBrace(source: []const u8) ?usize {
+    var depth: usize = 0;
+    for (source, 0..) |c, i| {
+        switch (c) {
+            '(' => depth += 1,
+            ')' => {
+                if (depth == 0) return i;
+                depth -= 1;
+            },
+            else => continue,
+        }
+    }
+    return null;
+}

--- a/tests/helper.zig
+++ b/tests/helper.zig
@@ -159,3 +159,187 @@ test collectReplacePlaceholders {
         .{ .start = 3, .end = 6 },
     });
 }
+
+pub const AnnotatedSourceLoc = struct {
+    loc: offsets.Loc,
+    content: []const u8,
+};
+
+/// extract a list of special comment from a source file
+/// **Example**
+/// ```
+/// Some text where we want to highlight some locations
+/// //   ^^^^ some content
+/// in the text file.
+/// //          ^^^^ something else here
+/// ```
+/// passing the above content to this function will yield the following:
+/// ```zig
+/// [2]AnnotatedSourceLoc{
+///     .{
+///         .loc = .{ .start = 5, .end = 9 }, // this is the location of `text` in the source
+///         .content = "some content",
+///     },
+///     .{
+///         .loc = .{ .start = 87, .end = 91 }, // this is the location of `file` in the source
+///         .content = "something else here",
+///     },
+/// },
+/// ```
+pub fn collectAnnotatedSourceLocations(
+    allocator: std.mem.Allocator,
+    source: []const u8,
+) error{ OutOfMemory, InvalidSourceLoc }![]AnnotatedSourceLoc {
+    var items: std.ArrayListUnmanaged(AnnotatedSourceLoc) = .empty;
+    errdefer items.deinit(allocator);
+
+    var i: usize = 0;
+    while (i < source.len) {
+        defer i = std.mem.indexOfScalarPos(u8, source, i, '\n') orelse source.len;
+
+        i = skipWhitespace(source, i);
+        if (!std.mem.startsWith(u8, source[i..], "//")) continue;
+        i += 2;
+
+        i = skipWhitespace(source, i);
+        if (!std.mem.startsWith(u8, source[i..], "^")) continue;
+        var loc: offsets.Loc = .{ .start = i, .end = undefined };
+        i += 1;
+        while (i < source.len) : (i += 1) {
+            if (source[i] != '^') break;
+        }
+        loc.end = i;
+
+        const content_start = i;
+        const content_end = std.mem.indexOfScalarPos(u8, source, i, '\n') orelse source.len;
+        const content = source[content_start..content_end];
+
+        const loc_length = offsets.locLength(source, loc, .@"utf-8");
+        const start_pos = offsets.indexToPosition(source, loc.start, .@"utf-8");
+
+        const content_line_start_index = blk: {
+            var content_line_start_pos = start_pos;
+            while (content_line_start_pos.line > 0) {
+                content_line_start_pos.line -= 1;
+                var previous_line_index = offsets.positionToIndex(
+                    source,
+                    .{ .line = content_line_start_pos.line, .character = 0 },
+                    .@"utf-8",
+                );
+
+                previous_line_index = skipWhitespace(source, previous_line_index);
+                if (!std.mem.startsWith(u8, source[previous_line_index..], "//"))
+                    break :blk offsets.positionToIndex(source, content_line_start_pos, .@"utf-8");
+                previous_line_index += 2;
+                previous_line_index = skipWhitespace(source, previous_line_index);
+                if (!std.mem.startsWith(u8, source[previous_line_index..], "^"))
+                    break :blk offsets.positionToIndex(source, content_line_start_pos, .@"utf-8");
+
+                // the previous line is also a annotated comment, go to the previous line again
+            }
+            return error.InvalidSourceLoc; // there is no previous line
+        };
+
+        const source_line_loc: offsets.Loc = .{
+            .start = content_line_start_index,
+            .end = content_line_start_index + loc_length,
+        };
+
+        if (source_line_loc.end >= source.len) return error.InvalidSourceLoc;
+        if (std.mem.indexOfScalar(u8, offsets.locToSlice(source, source_line_loc), '\n') != null) return error.InvalidSourceLoc;
+
+        try items.append(allocator, .{
+            .loc = source_line_loc,
+            .content = std.mem.trim(u8, content, &std.ascii.whitespace),
+        });
+    }
+    return items.toOwnedSlice(allocator);
+}
+
+fn testCollectAnnotatedSourceLocations(
+    source: []const u8,
+    expected: []const AnnotatedSourceLoc,
+) !void {
+    const allocator = std.testing.allocator;
+    const actual = try collectAnnotatedSourceLocations(allocator, source);
+    defer allocator.free(actual);
+
+    if (expected.len == actual.len) failed: {
+        for (expected, actual) |expected_item, actual_item| {
+            if (!std.meta.eql(expected_item.loc, actual_item.loc)) break :failed;
+            if (!std.mem.eql(u8, expected_item.content, actual_item.content)) break :failed;
+        }
+        return;
+    }
+    try std.testing.expectEqualSlices(AnnotatedSourceLoc, expected, actual);
+    unreachable; // expectEqualSlices is supposed to fail
+}
+
+test "helper - collectAnnotatedSourceLocations" {
+    const allocator = std.testing.allocator;
+
+    try testCollectAnnotatedSourceLocations("", &.{});
+    try testCollectAnnotatedSourceLocations("hello", &.{});
+    try testCollectAnnotatedSourceLocations(
+        \\ hello
+        \\^^^^ world
+        \\// and goodbye
+    , &.{});
+    try testCollectAnnotatedSourceLocations(
+        \\Hello World
+        \\// 
+    , &.{});
+    try testCollectAnnotatedSourceLocations(
+        \\hello world
+        \\//    ^^^^^ here
+    , &.{
+        .{ .loc = .{ .start = 6, .end = 11 }, .content = "here" },
+    });
+    try testCollectAnnotatedSourceLocations(
+        \\
+        \\hello   rld
+        \\//    ^^^^^ here 
+        \\
+    , &.{
+        .{ .loc = .{ .start = 7, .end = 12 }, .content = "here" },
+    });
+    try testCollectAnnotatedSourceLocations(
+        \\Some text where we want to highlight some locations
+        \\//   ^^^^ some content
+        \\in the text file.
+        \\//          ^^^^ something else here
+    , &.{
+        .{ .loc = .{ .start = 5, .end = 9 }, .content = "some content" },
+        .{ .loc = .{ .start = 87, .end = 91 }, .content = "something else here" },
+    });
+    try testCollectAnnotatedSourceLocations(
+        \\    Hansel and Gretel
+        \\//  ^^^^^^ First
+        \\//             ^^^^^^ Second
+    , &.{
+        .{ .loc = .{ .start = 4, .end = 10 }, .content = "First" },
+        .{ .loc = .{ .start = 15, .end = 21 }, .content = "Second" },
+    });
+
+    try std.testing.expectError(
+        error.InvalidSourceLoc,
+        collectAnnotatedSourceLocations(allocator,
+            \\hello worl
+            \\//    ^^^^^
+        ),
+    );
+    try std.testing.expectError(
+        error.InvalidSourceLoc,
+        collectAnnotatedSourceLocations(allocator,
+            \\//    ^^^^^
+        ),
+    );
+}
+
+fn skipWhitespace(source: []const u8, pos: usize) usize {
+    var i = pos;
+    while (i < source.len) : (i += 1) {
+        if (std.mem.indexOfScalar(u8, " \n", source[i]) == null) break;
+    }
+    return i;
+}


### PR DESCRIPTION
These new tests make easier to directly test the analysis backend without going through one of the LSP requests. Some of the existing tests should also be ported to this new system.

They can be executed with `zig build test-analysis` which will also compile faster than `zig build test`.