### PR TITLE
Represent error sets through InternPool

### DIFF
--- a/src/DocumentScope.zig
+++ b/src/DocumentScope.zig
@@ -115,7 +115,6 @@ fn getDeclNameToken(tree: Ast, node: Ast.Node.Index) ?Ast.TokenIndex {
         .tagged_union_two_trailing,
         .tagged_union_enum_tag,
         .tagged_union_enum_tag_trailing,
-        .error_set_decl,
         .block,
         .block_semicolon,
         .block_two,
@@ -137,7 +136,6 @@ pub const Declaration = union(enum) {
     ///   - `.root`
     ///   - `.container_decl`
     ///   - `.tagged_union`
-    ///   - `.error_set_decl`
     ///   - `.container_field`
     ///   - `.fn_proto`
     ///   - `.fn_decl`

--- a/src/analyser/InternPool.zig
+++ b/src/analyser/InternPool.zig
@@ -3779,6 +3779,8 @@ const FormatContext = struct {
 // TODO add options for controlling how types show be formatted
 pub const FormatOptions = struct {
     debug: bool = false,
+    // TODO: truncate structs, unions, enums
+    truncate_container: bool = false,
 };
 
 fn format(
@@ -3926,6 +3928,10 @@ fn printInternal(ip: *InternPool, ty: Index, writer: anytype, options: FormatOpt
             if (error_set_info.owner_decl.unwrap()) |decl_index| {
                 const decl = ip.getDecl(decl_index);
                 try writer.print("{}", .{ip.fmtId(decl.name)});
+                return null;
+            }
+            if (options.truncate_container and error_set_info.names.len > 2) {
+                try writer.writeAll("error{...}");
                 return null;
             }
             try writer.writeAll("error{");

--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -141,18 +141,6 @@ fn typeToCompletion(builder: *Builder, ty: Analyser.Type) error{OutOfMemory}!voi
                 });
             }
         },
-        .other => |node_handle| switch (node_handle.handle.tree.nodeTag(node_handle.node)) {
-            .merge_error_sets => {
-                const lhs, const rhs = node_handle.handle.tree.nodeData(node_handle.node).node_and_node;
-                if (try builder.analyser.resolveTypeOfNode(.{ .node = lhs, .handle = node_handle.handle })) |lhs_ty| {
-                    try typeToCompletion(builder, lhs_ty);
-                }
-                if (try builder.analyser.resolveTypeOfNode(.{ .node = rhs, .handle = node_handle.handle })) |rhs_ty| {
-                    try typeToCompletion(builder, rhs_ty);
-                }
-            },
-            else => {},
-        },
         .ip_index => |payload| try analyser_completions.dotCompletions(
             builder.arena,
             &builder.completions,
@@ -167,6 +155,7 @@ fn typeToCompletion(builder: *Builder, ty: Analyser.Type) error{OutOfMemory}!voi
         },
         .error_union,
         .union_tag,
+        .other,
         .compile_error,
         => {},
     }

--- a/src/features/semantic_tokens.zig
+++ b/src/features/semantic_tokens.zig
@@ -917,6 +917,10 @@ fn writeNodeTokens(builder: *Builder, node: Ast.Node.Index) error{OutOfMemory}!v
                 return;
             };
             const lhs_type = try builder.analyser.resolveDerefType(lhs) orelse lhs;
+            if (lhs_type.isErrorSetType(builder.analyser)) {
+                try writeToken(builder, field_name_token, .errorTag);
+                return;
+            }
             if (try lhs_type.lookupSymbol(builder.analyser, symbol_name)) |decl_type| {
                 switch (decl_type.decl) {
                     .ast_node => |decl_node| {
@@ -931,10 +935,6 @@ fn writeNodeTokens(builder: *Builder, node: Ast.Node.Index) error{OutOfMemory}!v
                                 return;
                             }
                         }
-                    },
-                    .error_token => {
-                        try writeToken(builder, field_name_token, .errorTag);
-                        return;
                     },
                     else => {},
                 }

--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -1904,7 +1904,7 @@ test "error set" {
         \\const baz = E2.<cursor>
     , &.{
         .{ .label = "baz", .kind = .Constant, .detail = "error.baz" },
-        .{ .label = "qux", .kind = .Constant, .detail = "error.qux", .documentation = "hello" },
+        .{ .label = "qux", .kind = .Constant, .detail = "error.qux" },
     });
 }
 
@@ -1994,7 +1994,7 @@ test "merged error sets" {
         \\const Error = error{Foo} || error{Bar};
         \\const E = <cursor>
     , &.{
-        .{ .label = "Error", .kind = .Constant, .detail = "type" },
+        .{ .label = "Error", .kind = .Constant, .detail = "error{Foo,Bar}" },
     });
 }
 

--- a/tests/lsp_features/hover.zig
+++ b/tests/lsp_features/hover.zig
@@ -1044,7 +1044,7 @@ test "function" {
         \\fn foo(a: A, b: B) E!C
         \\```
         \\
-        \\Go to [A](file:///test.zig#L1) | [B](file:///test.zig#L2) | [E](file:///test.zig#L4) | [C](file:///test.zig#L3)
+        \\Go to [A](file:///test.zig#L1) | [B](file:///test.zig#L2) | [C](file:///test.zig#L3)
     );
     try testHover(
         \\const S = struct { a: i32 };
@@ -1055,7 +1055,7 @@ test "function" {
         \\fn foo(a: S, b: S) E!S
         \\```
         \\
-        \\Go to [S](file:///test.zig#L1) | [E](file:///test.zig#L2)
+        \\Go to [S](file:///test.zig#L1)
     );
     try testHover(
         \\fn foo(b<cursor>ar: enum { fizz, buzz }) void {}
@@ -1212,10 +1212,10 @@ test "error union" {
         \\const foo: E!S = undefined
         \\```
         \\```zig
-        \\(E!S)
+        \\(error{A,B}!S)
         \\```
         \\
-        \\Go to [E](file:///test.zig#L2) | [S](file:///test.zig#L1)
+        \\Go to [S](file:///test.zig#L1)
     );
 }
 

--- a/tests/lsp_features/inlay_hints.zig
+++ b/tests/lsp_features/inlay_hints.zig
@@ -256,7 +256,7 @@ test "var decl" {
         \\    const baz: ?Foo = Foo{ .bar<u32> = 42 };
         \\    if (baz) |b<Foo>| {
         \\        const d: Error!?Foo = b;
-        \\        const e<*Error!?Foo> = &d;
+        \\        const e<*error{e}!?Foo> = &d;
         \\        const f<Foo> = (try e.*).?;
         \\        _ = f;
         \\    }
@@ -370,7 +370,7 @@ test "function with error union" {
         \\const Error<type> = error{OutOfMemory};
         \\fn foo() Error!u32 {}
         \\test {
-        \\    const val<Error!u32> = foo();
+        \\    const val<error{OutOfMemory}!u32> = foo();
         \\}
     , .{ .kind = .Type });
     try testInlayHints(
@@ -424,7 +424,7 @@ test "capture values with if" {
         \\               _ = c;
         \\            }
         \\        }
-        \\    } else |e<FooError>| {
+        \\    } else |e<error{Err1}>| {
         \\        _ = e;
         \\    }
         \\}
@@ -484,7 +484,7 @@ test "capture values with while loop" {
         \\    var it: Iterator = .{};
         \\    while (it.next()) |val<?usize>| {
         \\        if (val) |v<usize>| { _ = v; }
-        \\    } else |e<Error>| { _ = e; }
+        \\    } else |e<error{Err1}>| { _ = e; }
         \\}
     , .{ .kind = .Type });
 }
@@ -515,7 +515,7 @@ test "capture value with catch" {
         \\const Error<type> = error{OutOfMemory};
         \\fn foo() Error!u32 {}
         \\test {
-        \\    foo() catch |err<Error>| {}
+        \\    foo() catch |err<error{OutOfMemory}>| {}
         \\}
     , .{ .kind = .Type });
     try testInlayHints(
@@ -546,7 +546,7 @@ test "truncate anonymous error sets" {
 
 test "truncate merged error sets" {
     try testInlayHints(
-        \\const A<error{...}> =  @as(error{ Foo } || error{ Bar }, undefined);
+        \\const A<error{Foo,Bar}> =  @as(error{ Foo } || error{ Bar }, undefined);
     , .{ .kind = .Type });
 }
 


### PR DESCRIPTION
Preparatory work for peer type resolution with error unions

Regression 1: link to error set is no longer included in "Go to ..." when hovering.

Regression 2: given error set `E = error{A,B}` and struct `S`, `E!S` is printed as `error{A,B}!S`. However, this is consistent with how Zig would normally print `E!S` in e.g. `std.debug.print`.

```zig
const std = @import("std");
const E = error{A,B};
const S = struct{};
pub fn main() !void {
    std.debug.print("{}", .{E!S}); // => error{A,B}!S
}
```