### PR TITLE
Fix activeParameter of signature help when there is no closing paren

### DIFF
--- a/src/features/signature_help.zig
+++ b/src/features/signature_help.zig
@@ -80,8 +80,11 @@ pub fn getSignatureInfo(
     // We start by finding the token that includes the current cursor position
     const last_token = blk: {
         const last_token = offsets.sourceIndexToTokenIndex(tree, absolute_index);
+        // Determine whether index is after the token
+        const passed = tree.tokens.items(.start)[last_token] < absolute_index;
         switch (token_tags[last_token]) {
             .l_brace, .l_paren, .l_bracket => break :blk last_token,
+            .comma => break :blk if (passed) last_token else last_token -| 1,
             else => break :blk last_token -| 1,
         }
     };

--- a/tests/lsp_features/signature_help.zig
+++ b/tests/lsp_features/signature_help.zig
@@ -47,6 +47,97 @@ test "simple" {
         \\    foo(0,55<cursor>)
         \\}
     , "fn foo(a: u32, b: u32) void", 1);
+    try testSignatureHelp(
+        \\fn foo(a: u32, b: u32, c: u32) void {
+        \\    foo(0, 1, <cursor>)
+        \\}
+    , "fn foo(a: u32, b: u32, c: u32) void", 2);
+}
+
+test "no right paren" {
+    try testSignatureHelp(
+        \\fn foo(a: u32, b: u32) void {
+        \\    foo(<cursor>
+        \\}
+    , "fn foo(a: u32, b: u32) void", 0);
+    try testSignatureHelp(
+        \\fn foo(a: u32, b: u32) void {
+        \\    foo(<cursor>,0
+        \\}
+    , "fn foo(a: u32, b: u32) void", 0);
+    try testSignatureHelp(
+        \\fn foo(a: u32, b: u32) void {
+        \\    foo(0,<cursor>
+        \\}
+    , "fn foo(a: u32, b: u32) void", 1);
+    try testSignatureHelp(
+        \\fn foo(a: u32, b: u32) void {
+        \\    foo(0,<cursor>55
+        \\}
+    , "fn foo(a: u32, b: u32) void", 1);
+    try testSignatureHelp(
+        \\fn foo(a: u32, b: u32) void {
+        \\    foo(0,5<cursor>5
+        \\}
+    , "fn foo(a: u32, b: u32) void", 1);
+    try testSignatureHelp(
+        \\fn foo(a: u32, b: u32) void {
+        \\    foo(0,55<cursor>
+        \\}
+    , "fn foo(a: u32, b: u32) void", 1);
+    try testSignatureHelp(
+        \\fn foo(a: u32, b: u32, c: u32) void {
+        \\    foo(0, 1, <cursor>
+        \\}
+    , "fn foo(a: u32, b: u32, c: u32) void", 2);
+}
+
+test "multiline" {
+    try testSignatureHelp(
+        \\fn foo(
+        \\    /// a is important
+        \\    a: u32,
+        \\    b: u32,
+        \\) void {
+        \\    foo(<cursor>)
+        \\}
+    ,
+        \\fn foo(
+        \\    /// a is important
+        \\    a: u32,
+        \\    b: u32,
+        \\) void
+    , 0);
+    try testSignatureHelp(
+        \\fn foo(
+        \\    /// a is important
+        \\    a: u32,
+        \\    b: u32,
+        \\) void {
+        \\    foo(<cursor>,0)
+        \\}
+    ,
+        \\fn foo(
+        \\    /// a is important
+        \\    a: u32,
+        \\    b: u32,
+        \\) void
+    , 0);
+    try testSignatureHelp(
+        \\fn foo(
+        \\    /// a is important
+        \\    a: u32,
+        \\    b: u32,
+        \\) void {
+        \\    foo(0,<cursor>)
+        \\}
+    ,
+        \\fn foo(
+        \\    /// a is important
+        \\    a: u32,
+        \\    b: u32,
+        \\) void
+    , 1);
 }
 
 test "syntax error resistance" {


### PR DESCRIPTION
In 0.13.0, ~I believe that~ `activeParameter` of signature help is following an incorrect pattern of `0, 0, 1, 2...` when the closing right paren is missing. This PR adds tests which cover that case and others and provides a fix.