### PR TITLE
Update build.zig.zon for new package hash format

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,5 @@
 .{
-    .name = "zls",
+    .name = .zls,
     // Must match the `zls_version` in `build.zig`
     .version = "0.14.0-dev",
     // Must be kept in line with the `minimum_build_zig_version` in `build.zig`.
@@ -13,16 +13,16 @@
     // ```
     .dependencies = .{
         .known_folders = .{
-            .url = "https://github.com/ziglibs/known-folders/archive/1cceeb70e77dec941a4178160ff6c8d05a74de6f.tar.gz",
-            .hash = "12205f5e7505c96573f6fc5144592ec38942fb0a326d692f9cddc0c7dd38f9028f29",
+            .url = "https://github.com/llogick/known-folders/archive/38e02c8309577cc530e0a245722f0e670a7cfc83.tar.gz",
+            .hash = "known_folders-0.0.0-oAywZozDAADe2QIdEUirRpV-DBsHR3p80F4dIqvZ_aGk",
         },
         .diffz = .{
             .url = "https://github.com/ziglibs/diffz/archive/ef45c00d655e5e40faf35afbbde81a1fa5ed7ffb.tar.gz",
             .hash = "1220102cb2c669d82184fb1dc5380193d37d68b54e8d75b76b2d155b9af7d7e2e76d",
         },
         .@"lsp-codegen" = .{
-            .url = "https://github.com/zigtools/zig-lsp-codegen/archive/e1f281f67ac2cb8c19d3cabe9cfae46fde691c56.tar.gz",
-            .hash = "12208e12a10e78de19f140acae65e6edc20189459dd208d5f6b7afdf0aa894113d1b",
+            .url = "https://github.com/llogick/zig-lsp-codegen/archive/7689f90f73a27564daebb51d04b15f9ce7de22b2.tar.gz",
+            .hash = "lsp_codegen-0.1.0-kj8TWTpWCQCanqipptdrn8Fu41aPgRW-CCpJPDfMap2M",
         },
         .tracy = .{
             .url = "https://github.com/wolfpld/tracy/archive/refs/tags/v0.11.1.tar.gz",
@@ -31,4 +31,5 @@
         },
     },
     .paths = .{""},
+    .fingerprint = 0xa66330b9e5caa855,
 }


### PR DESCRIPTION
This depends on PRs in known-folders and lsp-codegen. I will update it once these are merged.