### PR TITLE
Release 0.14.0

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: mlugg/setup-zig@v1
         with:
-          version: master
+          version: 0.14.0
 
       - name: Install APT packages
         run: |

--- a/.github/workflows/build_runner.yml
+++ b/.github/workflows/build_runner.yml
@@ -19,8 +19,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - zig-version: mach-latest
-            build-runner-file: master.zig
+          - zig-version: 0.14.0
+            build-runner-file: 0.14.0.zig
           # Zig master is handled by 'zig build test' in the main CI
     runs-on: ubuntu-22.04
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: mlugg/setup-zig@v1
         with:
-          version: master
+          version: 0.14.0
 
       - run: zig env
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: mlugg/setup-zig@v1
         with:
-          version: master
+          version: 0.14.0
 
       - name: Run zig fmt
         if: matrix.os == 'ubuntu-latest'

--- a/build.zig
+++ b/build.zig
@@ -3,7 +3,7 @@ const builtin = @import("builtin");
 
 /// Must match the `version` in `build.zig.zon`.
 /// Remove `.pre` when tagging a new ZLS release and add it back on the next development cycle.
-const zls_version: std.SemanticVersion = .{ .major = 0, .minor = 14, .patch = 0, .pre = "dev" };
+const zls_version: std.SemanticVersion = .{ .major = 0, .minor = 14, .patch = 0 };
 
 /// Specify the minimum Zig version that is required to compile and test ZLS:
 /// implement new package hash format: `$name-$semver-$hash`
@@ -15,7 +15,7 @@ const zls_version: std.SemanticVersion = .{ .major = 0, .minor = 14, .patch = 0,
 /// ```
 ///
 /// Also update the `minimum_zig_version` in `build.zig.zon`.
-const minimum_build_zig_version = "0.14.0-dev.3445+6c3cbb0c8";
+const minimum_build_zig_version = "0.14.0";
 
 /// Specify the minimum Zig version that is required to run ZLS:
 /// std.Build: add new functions to create artifacts/Step.Compile from existing module
@@ -25,7 +25,7 @@ const minimum_build_zig_version = "0.14.0-dev.3445+6c3cbb0c8";
 ///   - breaking change to AstGen (i.e `zig ast-check`)
 ///
 /// A breaking change to the Zig Build System should be handled by updating ZLS's build runner (see src\build_runner)
-const minimum_runtime_zig_version = "0.14.0-dev.2534+12d64c456";
+const minimum_runtime_zig_version = "0.14.0";
 
 const release_targets = [_]std.Target.Query{
     .{ .cpu_arch = .x86_64, .os_tag = .windows },

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,10 +1,10 @@
 .{
     .name = .zls,
     // Must match the `zls_version` in `build.zig`
-    .version = "0.14.0-dev",
+    .version = "0.14.0",
     // Must be kept in line with the `minimum_build_zig_version` in `build.zig`.
     // Should be a Zig version that is downloadable from https://ziglang.org/download/ or a mirror.
-    .minimum_zig_version = "0.14.0-dev.3445+6c3cbb0c8",
+    .minimum_zig_version = "0.14.0",
     // If you do not use Nix, a ZLS maintainer can take care of this.
     // Whenever the dependencies are updated, run the following command:
     // ```bash

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
       (
         system: let
           pkgs = nixpkgs.legacyPackages.${system};
-          zig = zig-overlay.packages.${system}.master;
+          zig = zig-overlay.packages.${system}."0.14.0";
           gitignoreSource = gitignore.lib.gitignoreSource;
           target = builtins.replaceStrings ["darwin"] ["macos"] system;
           revision = self;
@@ -30,7 +30,7 @@
             default = zls;
             zls = pkgs.stdenvNoCC.mkDerivation {
               name = "zls";
-              version = "master";
+              version = "0.14.0";
               meta.mainProgram = "zls";
               src = gitignoreSource ./.;
               nativeBuildInputs = [zig];

--- a/src/build_runner/0.14.0.zig
+++ b/src/build_runner/0.14.0.zig
@@ -1,0 +1,1469 @@
+//! PLEASE READ THE FOLLOWING MESSAGE BEFORE EDITING THIS FILE:
+//!
+//! This build runner is targeting compatibility with the following Zig versions:
+//!   - master (0.14.0-dev.2046+b8795b4d0 and later)
+//!
+//! Handling multiple Zig versions can be achieved by branching on the `builtin.zig_version` at comptime.
+//!
+//! You can test out the build runner on ZLS's `build.zig` with the following command:
+//! `zig build --build-runner src/build_runner/master.zig`
+//!
+//! You can also test the build runner on any other `build.zig` with the following command:
+//! `zig build --build-file /path/to/build.zig --build-runner /path/to/zls/src/build_runner/master.zig`
+//! `zig build --build-runner /path/to/zls/src/build_runner/master.zig` (if the cwd contains build.zig)
+//!
+
+const root = @import("@build");
+const std = @import("std");
+const builtin = @import("builtin");
+const assert = std.debug.assert;
+const mem = std.mem;
+const process = std.process;
+const ArrayList = std.ArrayList;
+const Step = std.Build.Step;
+const Allocator = std.mem.Allocator;
+
+pub const dependencies = @import("@dependencies");
+
+// ----------- List of Zig versions that introduced breaking changes -----------
+
+const replace_pop_or_null_version = std.SemanticVersion.parse("0.14.0-dev.3181+914248237") catch unreachable;
+
+// -----------------------------------------------------------------------------
+
+///! This is a modified build runner to extract information out of build.zig
+///! Modified version of lib/build_runner.zig
+pub fn main() !void {
+    // Here we use an ArenaAllocator backed by a DirectAllocator because a build is a short-lived,
+    // one shot program. We don't need to waste time freeing memory and finding places to squish
+    // bytes into. So we free everything all at once at the very end.
+    var single_threaded_arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer single_threaded_arena.deinit();
+
+    var thread_safe_arena: std.heap.ThreadSafeAllocator = .{
+        .child_allocator = single_threaded_arena.allocator(),
+    };
+    const arena = thread_safe_arena.allocator();
+
+    const args = try process.argsAlloc(arena);
+
+    // skip my own exe name
+    var arg_idx: usize = 1;
+
+    const zig_exe = nextArg(args, &arg_idx) orelse fatal("missing zig compiler path", .{});
+    const zig_lib_dir = nextArg(args, &arg_idx) orelse fatal("missing zig lib directory path", .{});
+    const build_root = nextArg(args, &arg_idx) orelse fatal("missing build root directory path", .{});
+    const cache_root = nextArg(args, &arg_idx) orelse fatal("missing cache root directory path", .{});
+    const global_cache_root = nextArg(args, &arg_idx) orelse fatal("missing global cache root directory path", .{});
+
+    const zig_lib_directory: std.Build.Cache.Directory = .{
+        .path = zig_lib_dir,
+        .handle = try std.fs.cwd().openDir(zig_lib_dir, .{}),
+    };
+
+    const build_root_directory: std.Build.Cache.Directory = .{
+        .path = build_root,
+        .handle = try std.fs.cwd().openDir(build_root, .{}),
+    };
+
+    const local_cache_directory: std.Build.Cache.Directory = .{
+        .path = cache_root,
+        .handle = try std.fs.cwd().makeOpenPath(cache_root, .{}),
+    };
+
+    const global_cache_directory: std.Build.Cache.Directory = .{
+        .path = global_cache_root,
+        .handle = try std.fs.cwd().makeOpenPath(global_cache_root, .{}),
+    };
+
+    var graph: std.Build.Graph = .{
+        .arena = arena,
+        .cache = .{
+            .gpa = arena,
+            .manifest_dir = try local_cache_directory.handle.makeOpenPath("h", .{}),
+        },
+        .zig_exe = zig_exe,
+        .env_map = try process.getEnvMap(arena),
+        .global_cache_root = global_cache_directory,
+        .zig_lib_directory = zig_lib_directory,
+        .host = .{
+            .query = .{},
+            .result = try std.zig.system.resolveTargetQuery(.{}),
+        },
+    };
+
+    graph.cache.addPrefix(.{ .path = null, .handle = std.fs.cwd() });
+    graph.cache.addPrefix(build_root_directory);
+    graph.cache.addPrefix(local_cache_directory);
+    graph.cache.addPrefix(global_cache_directory);
+    graph.cache.hash.addBytes(builtin.zig_version_string);
+
+    const builder = try std.Build.create(
+        &graph,
+        build_root_directory,
+        local_cache_directory,
+        dependencies.root_deps,
+    );
+
+    var targets = ArrayList([]const u8).init(arena);
+    var debug_log_scopes = ArrayList([]const u8).init(arena);
+    var thread_pool_options: std.Thread.Pool.Options = .{ .allocator = arena };
+
+    var install_prefix: ?[]const u8 = null;
+    var dir_list: std.Build.DirList = .{};
+    var max_rss: u64 = 0;
+    var skip_oom_steps = false;
+    var seed: u32 = 0;
+    var output_tmp_nonce: ?[16]u8 = null;
+    var debounce_interval_ms: u16 = 50;
+    var watch = false;
+    var check_step_only = false;
+
+    while (nextArg(args, &arg_idx)) |arg| {
+        if (mem.startsWith(u8, arg, "-Z")) {
+            if (arg.len != 18) fatal("bad argument: '{s}'", .{arg});
+            output_tmp_nonce = arg[2..18].*;
+        } else if (mem.startsWith(u8, arg, "-D")) {
+            const option_contents = arg[2..];
+            if (option_contents.len == 0)
+                fatal("expected option name after '-D'", .{});
+            if (mem.indexOfScalar(u8, option_contents, '=')) |name_end| {
+                const option_name = option_contents[0..name_end];
+                const option_value = option_contents[name_end + 1 ..];
+                if (try builder.addUserInputOption(option_name, option_value))
+                    fatal("  access the help menu with 'zig build -h'", .{});
+            } else {
+                if (try builder.addUserInputFlag(option_contents))
+                    fatal("  access the help menu with 'zig build -h'", .{});
+            }
+        } else if (mem.startsWith(u8, arg, "-")) {
+            if (mem.eql(u8, arg, "--verbose")) {
+                builder.verbose = true;
+            } else if (mem.eql(u8, arg, "-h") or mem.eql(u8, arg, "--help")) {
+                fatal("argument '{s}' is not available", .{arg});
+            } else if (mem.eql(u8, arg, "-p") or mem.eql(u8, arg, "--prefix")) {
+                install_prefix = nextArgOrFatal(args, &arg_idx);
+            } else if (mem.eql(u8, arg, "-l") or mem.eql(u8, arg, "--list-steps")) {
+                fatal("argument '{s}' is not available", .{arg});
+            } else if (mem.startsWith(u8, arg, "-fsys=")) {
+                const name = arg["-fsys=".len..];
+                graph.system_library_options.put(arena, name, .user_enabled) catch @panic("OOM");
+            } else if (mem.startsWith(u8, arg, "-fno-sys=")) {
+                const name = arg["-fno-sys=".len..];
+                graph.system_library_options.put(arena, name, .user_disabled) catch @panic("OOM");
+            } else if (mem.eql(u8, arg, "--release")) {
+                builder.release_mode = .any;
+            } else if (mem.startsWith(u8, arg, "--release=")) {
+                const text = arg["--release=".len..];
+                builder.release_mode = std.meta.stringToEnum(std.Build.ReleaseMode, text) orelse {
+                    fatal("expected [off|any|fast|safe|small] in '{s}', found '{s}'", .{
+                        arg, text,
+                    });
+                };
+            } else if (mem.eql(u8, arg, "--prefix-lib-dir")) {
+                dir_list.lib_dir = nextArgOrFatal(args, &arg_idx);
+            } else if (mem.eql(u8, arg, "--prefix-exe-dir")) {
+                dir_list.exe_dir = nextArgOrFatal(args, &arg_idx);
+            } else if (mem.eql(u8, arg, "--prefix-include-dir")) {
+                dir_list.include_dir = nextArgOrFatal(args, &arg_idx);
+            } else if (mem.eql(u8, arg, "--sysroot")) {
+                builder.sysroot = nextArgOrFatal(args, &arg_idx);
+            } else if (mem.eql(u8, arg, "--maxrss")) {
+                const max_rss_text = nextArgOrFatal(args, &arg_idx);
+                max_rss = std.fmt.parseIntSizeSuffix(max_rss_text, 10) catch |err| {
+                    std.debug.print("invalid byte size: '{s}': {s}\n", .{
+                        max_rss_text, @errorName(err),
+                    });
+                    process.exit(1);
+                };
+            } else if (mem.eql(u8, arg, "--skip-oom-steps")) {
+                skip_oom_steps = true;
+            } else if (mem.eql(u8, arg, "--search-prefix")) {
+                const search_prefix = nextArgOrFatal(args, &arg_idx);
+                builder.addSearchPrefix(search_prefix);
+            } else if (mem.eql(u8, arg, "--libc")) {
+                builder.libc_file = nextArgOrFatal(args, &arg_idx);
+            } else if (mem.eql(u8, arg, "--color")) {
+                const next_arg = nextArg(args, &arg_idx) orelse
+                    fatal("expected [auto|on|off] after '{s}'", .{arg});
+                _ = next_arg;
+            } else if (mem.eql(u8, arg, "--summary")) {
+                const next_arg = nextArg(args, &arg_idx) orelse
+                    fatal("expected [all|new|failures|none] after '{s}'", .{arg});
+                _ = next_arg;
+            } else if (mem.eql(u8, arg, "--seed")) {
+                const next_arg = nextArg(args, &arg_idx) orelse
+                    fatal("expected u32 after '{s}'", .{arg});
+                seed = std.fmt.parseUnsigned(u32, next_arg, 0) catch |err| {
+                    fatal("unable to parse seed '{s}' as unsigned 32-bit integer: {s}\n", .{
+                        next_arg, @errorName(err),
+                    });
+                };
+            } else if (mem.eql(u8, arg, "--debounce")) {
+                const next_arg = nextArg(args, &arg_idx) orelse
+                    fatal("expected u16 after '{s}'", .{arg});
+                debounce_interval_ms = std.fmt.parseUnsigned(u16, next_arg, 0) catch |err| {
+                    fatal("unable to parse debounce interval '{s}' as unsigned 16-bit integer: {s}\n", .{
+                        next_arg, @errorName(err),
+                    });
+                };
+            } else if (mem.eql(u8, arg, "--debug-log")) {
+                const next_arg = nextArgOrFatal(args, &arg_idx);
+                try debug_log_scopes.append(next_arg);
+            } else if (mem.eql(u8, arg, "--debug-pkg-config")) {
+                builder.debug_pkg_config = true;
+            } else if (mem.eql(u8, arg, "--debug-compile-errors")) {
+                builder.debug_compile_errors = true;
+            } else if (mem.eql(u8, arg, "--system")) {
+                // The usage text shows another argument after this parameter
+                // but it is handled by the parent process. The build runner
+                // only sees this flag.
+                graph.system_package_mode = true;
+            } else if (mem.eql(u8, arg, "--glibc-runtimes")) {
+                builder.glibc_runtimes_dir = nextArgOrFatal(args, &arg_idx);
+            } else if (mem.eql(u8, arg, "--verbose-link")) {
+                builder.verbose_link = true;
+            } else if (mem.eql(u8, arg, "--verbose-air")) {
+                builder.verbose_air = true;
+            } else if (mem.eql(u8, arg, "--verbose-llvm-ir")) {
+                builder.verbose_llvm_ir = "-";
+            } else if (mem.startsWith(u8, arg, "--verbose-llvm-ir=")) {
+                builder.verbose_llvm_ir = arg["--verbose-llvm-ir=".len..];
+            } else if (mem.eql(u8, arg, "--verbose-llvm-bc=")) {
+                builder.verbose_llvm_bc = arg["--verbose-llvm-bc=".len..];
+            } else if (mem.eql(u8, arg, "--verbose-cimport")) {
+                builder.verbose_cimport = true;
+            } else if (mem.eql(u8, arg, "--verbose-cc")) {
+                builder.verbose_cc = true;
+            } else if (mem.eql(u8, arg, "--verbose-llvm-cpu-features")) {
+                builder.verbose_llvm_cpu_features = true;
+            } else if (mem.eql(u8, arg, "--prominent-compile-errors")) {
+                // prominent_compile_errors = true;
+            } else if (mem.eql(u8, arg, "--watch")) {
+                watch = true;
+            } else if (mem.eql(u8, arg, "--check-only")) { // ZLS only
+                check_step_only = true;
+            } else if (mem.eql(u8, arg, "-fincremental")) {
+                graph.incremental = true;
+            } else if (mem.eql(u8, arg, "-fno-incremental")) {
+                graph.incremental = false;
+            } else if (mem.eql(u8, arg, "-fwine")) {
+                builder.enable_wine = true;
+            } else if (mem.eql(u8, arg, "-fno-wine")) {
+                builder.enable_wine = false;
+            } else if (mem.eql(u8, arg, "-fqemu")) {
+                builder.enable_qemu = true;
+            } else if (mem.eql(u8, arg, "-fno-qemu")) {
+                builder.enable_qemu = false;
+            } else if (mem.eql(u8, arg, "-fwasmtime")) {
+                builder.enable_wasmtime = true;
+            } else if (mem.eql(u8, arg, "-fno-wasmtime")) {
+                builder.enable_wasmtime = false;
+            } else if (mem.eql(u8, arg, "-frosetta")) {
+                builder.enable_rosetta = true;
+            } else if (mem.eql(u8, arg, "-fno-rosetta")) {
+                builder.enable_rosetta = false;
+            } else if (mem.eql(u8, arg, "-fdarling")) {
+                builder.enable_darling = true;
+            } else if (mem.eql(u8, arg, "-fno-darling")) {
+                builder.enable_darling = false;
+            } else if (mem.eql(u8, arg, "-freference-trace")) {
+                builder.reference_trace = 256;
+            } else if (mem.startsWith(u8, arg, "-freference-trace=")) {
+                const num = arg["-freference-trace=".len..];
+                builder.reference_trace = std.fmt.parseUnsigned(u32, num, 10) catch |err| {
+                    std.debug.print("unable to parse reference_trace count '{s}': {s}", .{ num, @errorName(err) });
+                    process.exit(1);
+                };
+            } else if (mem.eql(u8, arg, "-fno-reference-trace")) {
+                builder.reference_trace = null;
+            } else if (mem.startsWith(u8, arg, "-j")) {
+                const num = arg["-j".len..];
+                const n_jobs = std.fmt.parseUnsigned(u32, num, 10) catch |err| {
+                    std.debug.print("unable to parse jobs count '{s}': {s}", .{
+                        num, @errorName(err),
+                    });
+                    process.exit(1);
+                };
+                if (n_jobs < 1) {
+                    std.debug.print("number of jobs must be at least 1\n", .{});
+                    process.exit(1);
+                }
+                thread_pool_options.n_jobs = n_jobs;
+            } else if (mem.eql(u8, arg, "--")) {
+                builder.args = argsRest(args, arg_idx);
+                break;
+            } else {
+                fatal("unrecognized argument: '{s}'", .{arg});
+            }
+        } else {
+            try targets.append(arg);
+        }
+    }
+
+    const main_progress_node = std.Progress.start(.{
+        .disable_printing = true,
+    });
+    defer main_progress_node.end();
+
+    builder.debug_log_scopes = debug_log_scopes.items;
+    builder.resolveInstallPrefix(install_prefix, dir_list);
+    {
+        var prog_node = main_progress_node.start("Configure", 0);
+        defer prog_node.end();
+        try builder.runBuild(root);
+        createModuleDependencies(builder) catch @panic("OOM");
+    }
+
+    if (graph.needed_lazy_dependencies.entries.len != 0) {
+        var buffer: std.ArrayListUnmanaged(u8) = .{};
+        for (graph.needed_lazy_dependencies.keys()) |k| {
+            try buffer.appendSlice(arena, k);
+            try buffer.append(arena, '\n');
+        }
+        const s = std.fs.path.sep_str;
+        const tmp_sub_path = "tmp" ++ s ++ (output_tmp_nonce orelse fatal("missing -Z arg", .{}));
+
+        std.fs.Dir.writeFile(local_cache_directory.handle, .{
+            .sub_path = tmp_sub_path,
+            .data = buffer.items,
+            .flags = .{ .exclusive = true },
+        }) catch |err| {
+            fatal("unable to write configuration results to '{}{s}': {s}", .{
+                local_cache_directory, tmp_sub_path, @errorName(err),
+            });
+        };
+
+        process.exit(3); // Indicate configure phase failed with meaningful stdout.
+    }
+
+    if (builder.validateUserInputDidItFail()) {
+        fatal("  access the help menu with 'zig build -h'", .{});
+    }
+
+    validateSystemLibraryOptions(builder);
+
+    var run: Run = .{
+        .max_rss = max_rss,
+        .max_rss_is_default = false,
+        .max_rss_mutex = .{},
+        .skip_oom_steps = skip_oom_steps,
+        .memory_blocked_steps = std.ArrayList(*Step).init(arena),
+        .thread_pool = undefined, // set below
+
+        .claimed_rss = 0,
+
+        .transport = null,
+        .cycle = 0,
+    };
+
+    if (run.max_rss == 0) {
+        run.max_rss = process.totalSystemMemory() catch std.math.maxInt(u64);
+        run.max_rss_is_default = true;
+    }
+
+    try run.thread_pool.init(thread_pool_options);
+    defer run.thread_pool.deinit();
+
+    if (!watch) {
+        try extractBuildInformation(
+            arena,
+            builder,
+            arena,
+            main_progress_node,
+            &run,
+            seed,
+        );
+        return;
+    }
+
+    var w = try Watch.init();
+
+    const message_thread = try std.Thread.spawn(.{}, struct {
+        fn do(ww: *Watch) void {
+            while (std.io.getStdIn().reader().readByte()) |tag| {
+                switch (tag) {
+                    '\x00' => ww.trigger(),
+                    else => process.exit(1),
+                }
+            } else |err| switch (err) {
+                error.EndOfStream => process.exit(0),
+                else => process.exit(1),
+            }
+        }
+    }.do, .{&w});
+    message_thread.detach();
+
+    const gpa = arena;
+    var transport = Transport.init(.{
+        .gpa = gpa,
+        .in = std.io.getStdIn(),
+        .out = std.io.getStdOut(),
+    });
+    defer transport.deinit();
+
+    run.transport = &transport;
+
+    var step_stack = try stepNamesToStepStack(gpa, builder, targets.items, check_step_only);
+    if (step_stack.count() == 0) {
+        // This means that `enable_build_on_save == null` and the project contains no "check" step.
+        return;
+    }
+
+    prepare(gpa, builder, &step_stack, &run, seed) catch |err| switch (err) {
+        error.UncleanExit => process.exit(1),
+        else => return err,
+    };
+
+    rebuild: while (true) : (run.cycle += 1) {
+        runSteps(
+            builder,
+            &step_stack,
+            main_progress_node,
+            &run,
+        ) catch |err| switch (err) {
+            error.UncleanExit => process.exit(1),
+            else => return err,
+        };
+
+        try w.update(gpa, step_stack.keys());
+
+        // Wait until a file system notification arrives. Read all such events
+        // until the buffer is empty. Then wait for a debounce interval, resetting
+        // if any more events come in. After the debounce interval has passed,
+        // trigger a rebuild on all steps with modified inputs, as well as their
+        // recursive dependants.
+        var debounce_timeout: std.Build.Watch.Timeout = .none;
+        while (true) switch (try w.wait(gpa, debounce_timeout)) {
+            .timeout => {
+                markFailedStepsDirty(gpa, step_stack.keys());
+                continue :rebuild;
+            },
+            .dirty => if (debounce_timeout == .none) {
+                debounce_timeout = .{ .ms = debounce_interval_ms };
+            },
+            .clean => {},
+        };
+    }
+}
+
+fn markFailedStepsDirty(gpa: Allocator, all_steps: []const *Step) void {
+    for (all_steps) |step| switch (step.state) {
+        .dependency_failure, .failure, .skipped => step.recursiveReset(gpa),
+        else => continue,
+    };
+    // Now that all dirty steps have been found, the remaining steps that
+    // succeeded from last run shall be marked "cached".
+    for (all_steps) |step| switch (step.state) {
+        .success => step.result_cached = true,
+        else => continue,
+    };
+}
+
+/// A wrapper around `std.Build.Watch` that supports manually triggering recompilations.
+const Watch = struct {
+    fs_watch: std.Build.Watch,
+    supports_fs_watch: bool,
+    manual_event: std.Thread.ResetEvent,
+    steps: []const *Step,
+
+    fn init() !Watch {
+        return .{
+            .fs_watch = if (@TypeOf(std.Build.Watch) != void) try std.Build.Watch.init() else {},
+            .supports_fs_watch = @TypeOf(std.Build.Watch) != void and shared.BuildOnSaveSupport.isSupportedRuntime(builtin.zig_version) == .supported,
+            .manual_event = .{},
+            .steps = &.{},
+        };
+    }
+
+    fn update(w: *Watch, gpa: Allocator, steps: []const *Step) !void {
+        if (@TypeOf(std.Build.Watch) != void and w.supports_fs_watch) {
+            return try w.fs_watch.update(gpa, steps);
+        }
+        w.steps = steps;
+    }
+
+    fn trigger(w: *Watch) void {
+        if (w.supports_fs_watch) {
+            @panic("received manualy filesystem event even though std.Build.Watch is supported");
+        }
+        w.manual_event.set();
+    }
+
+    fn wait(w: *Watch, gpa: Allocator, timeout: std.Build.Watch.Timeout) !std.Build.Watch.WaitResult {
+        if (@TypeOf(std.Build.Watch) != void and w.supports_fs_watch) {
+            return try w.fs_watch.wait(gpa, timeout);
+        }
+        switch (timeout) {
+            .none => w.manual_event.wait(),
+            .ms => |ms| w.manual_event.timedWait(@as(u64, ms) * std.time.ns_per_ms) catch return .timeout,
+        }
+        w.manual_event.reset();
+        markStepsDirty(gpa, w.steps);
+        return .dirty;
+    }
+
+    fn markStepsDirty(gpa: Allocator, all_steps: []const *Step) void {
+        for (all_steps) |step| switch (step.state) {
+            .precheck_done => continue,
+            else => step.recursiveReset(gpa),
+        };
+    }
+};
+
+const Run = struct {
+    max_rss: u64,
+    max_rss_is_default: bool,
+    max_rss_mutex: std.Thread.Mutex,
+    skip_oom_steps: bool,
+    memory_blocked_steps: std.ArrayList(*Step),
+    thread_pool: std.Thread.Pool,
+
+    claimed_rss: usize,
+
+    transport: ?*Transport,
+    cycle: u32,
+};
+
+fn stepNamesToStepStack(
+    gpa: Allocator,
+    b: *std.Build,
+    step_names: []const []const u8,
+    check_step_only: bool,
+) !std.AutoArrayHashMapUnmanaged(*Step, void) {
+    var step_stack: std.AutoArrayHashMapUnmanaged(*Step, void) = .{};
+    errdefer step_stack.deinit(gpa);
+
+    if (step_names.len == 0) {
+        if (b.top_level_steps.get("check")) |tls| {
+            try step_stack.put(gpa, &tls.step, {});
+        } else if (!check_step_only) {
+            try step_stack.put(gpa, b.default_step, {});
+        }
+    } else {
+        try step_stack.ensureUnusedCapacity(gpa, step_names.len);
+        for (0..step_names.len) |i| {
+            const step_name = step_names[step_names.len - i - 1];
+            const s = b.top_level_steps.get(step_name) orelse {
+                std.debug.print("no step named '{s}'\n  access the help menu with 'zig build -h'\n", .{step_name});
+                process.exit(1);
+            };
+            step_stack.putAssumeCapacity(&s.step, {});
+        }
+    }
+
+    return step_stack;
+}
+
+fn prepare(
+    gpa: Allocator,
+    b: *std.Build,
+    step_stack: *std.AutoArrayHashMapUnmanaged(*Step, void),
+    run: *Run,
+    seed: u32,
+) error{ OutOfMemory, UncleanExit }!void {
+    const starting_steps = try gpa.dupe(*Step, step_stack.keys());
+    defer gpa.free(starting_steps);
+
+    var rng = std.Random.DefaultPrng.init(seed);
+    const rand = rng.random();
+    rand.shuffle(*Step, starting_steps);
+
+    for (starting_steps) |s| {
+        constructGraphAndCheckForDependencyLoop(b, s, step_stack, rand) catch |err| switch (err) {
+            error.DependencyLoopDetected => return uncleanExit(),
+            else => |e| return e,
+        };
+    }
+
+    {
+        // Check that we have enough memory to complete the build.
+        var any_problems = false;
+        for (step_stack.keys()) |s| {
+            if (s.max_rss == 0) continue;
+            if (s.max_rss > run.max_rss) {
+                if (run.skip_oom_steps) {
+                    s.state = .skipped_oom;
+                } else {
+                    std.debug.print("{s}{s}: this step declares an upper bound of {d} bytes of memory, exceeding the available {d} bytes of memory\n", .{
+                        s.owner.dep_prefix, s.name, s.max_rss, run.max_rss,
+                    });
+                    any_problems = true;
+                }
+            }
+        }
+        if (any_problems) {
+            if (run.max_rss_is_default) {
+                std.debug.print("note: use --maxrss to override the default", .{});
+            }
+            return uncleanExit();
+        }
+    }
+}
+
+fn runSteps(
+    b: *std.Build,
+    steps_stack: *const std.AutoArrayHashMapUnmanaged(*Step, void),
+    parent_prog_node: std.Progress.Node,
+    run: *Run,
+) error{ OutOfMemory, UncleanExit }!void {
+    const thread_pool = &run.thread_pool;
+    const steps = steps_stack.keys();
+
+    var step_prog = parent_prog_node.start("steps", steps.len);
+    defer step_prog.end();
+
+    var wait_group: std.Thread.WaitGroup = .{};
+    defer wait_group.wait();
+
+    // Here we spawn the initial set of tasks with a nice heuristic -
+    // dependency order. Each worker when it finishes a step will then
+    // check whether it should run any dependants.
+    for (steps) |step| {
+        if (step.state == .skipped_oom) continue;
+
+        wait_group.start();
+        thread_pool.spawn(workerMakeOneStep, .{
+            &wait_group, b, steps_stack, step, step_prog, run,
+        }) catch @panic("OOM");
+    }
+
+    if (run.transport) |transport| {
+        for (steps) |step| {
+            const step_id: u32 = @intCast(steps_stack.getIndex(step).?);
+            // missing fields:
+            // - result_error_msgs
+            // - result_stderr
+            serveWatchErrorBundle(transport, step_id, run.cycle, step.result_error_bundle) catch @panic("failed to send watch errors");
+        }
+    }
+}
+
+/// Traverse the dependency graph depth-first and make it undirected by having
+/// steps know their dependants (they only know dependencies at start).
+/// Along the way, check that there is no dependency loop, and record the steps
+/// in traversal order in `step_stack`.
+/// Each step has its dependencies traversed in random order, this accomplishes
+/// two things:
+/// - `step_stack` will be in randomized-depth-first order, so the build runner
+///   spawns steps in a random (but optimized) order
+/// - each step's `dependants` list is also filled in a random order, so that
+///   when it finishes executing in `workerMakeOneStep`, it spawns next steps
+///   to run in random order
+fn constructGraphAndCheckForDependencyLoop(
+    b: *std.Build,
+    s: *Step,
+    step_stack: *std.AutoArrayHashMapUnmanaged(*Step, void),
+    rand: std.Random,
+) error{ OutOfMemory, DependencyLoopDetected }!void {
+    switch (s.state) {
+        .precheck_started => return error.DependencyLoopDetected,
+        .precheck_unstarted => {
+            s.state = .precheck_started;
+
+            try step_stack.ensureUnusedCapacity(b.allocator, s.dependencies.items.len);
+
+            // We dupe to avoid shuffling the steps in the summary, it depends
+            // on s.dependencies' order.
+            const deps = b.allocator.dupe(*Step, s.dependencies.items) catch @panic("OOM");
+            rand.shuffle(*Step, deps);
+
+            for (deps) |dep| {
+                try step_stack.put(b.allocator, dep, {});
+                try dep.dependants.append(b.allocator, s);
+                try constructGraphAndCheckForDependencyLoop(b, dep, step_stack, rand);
+            }
+
+            s.state = .precheck_done;
+        },
+        .precheck_done => {},
+
+        // These don't happen until we actually run the step graph.
+        .dependency_failure,
+        .running,
+        .success,
+        .failure,
+        .skipped,
+        .skipped_oom,
+        => {},
+    }
+}
+
+fn workerMakeOneStep(
+    wg: *std.Thread.WaitGroup,
+    b: *std.Build,
+    steps_stack: *const std.AutoArrayHashMapUnmanaged(*Step, void),
+    s: *Step,
+    prog_node: std.Progress.Node,
+    run: *Run,
+) void {
+    defer wg.finish();
+    const thread_pool = &run.thread_pool;
+
+    // First, check the conditions for running this step. If they are not met,
+    // then we return without doing the step, relying on another worker to
+    // queue this step up again when dependencies are met.
+    for (s.dependencies.items) |dep| {
+        switch (@atomicLoad(Step.State, &dep.state, .seq_cst)) {
+            .success, .skipped => continue,
+            .failure, .dependency_failure, .skipped_oom => {
+                @atomicStore(Step.State, &s.state, .dependency_failure, .seq_cst);
+                return;
+            },
+            .precheck_done, .running => {
+                // dependency is not finished yet.
+                return;
+            },
+            .precheck_unstarted => unreachable,
+            .precheck_started => unreachable,
+        }
+    }
+
+    if (s.max_rss != 0) {
+        run.max_rss_mutex.lock();
+        defer run.max_rss_mutex.unlock();
+
+        // Avoid running steps twice.
+        if (s.state != .precheck_done) {
+            // Another worker got the job.
+            return;
+        }
+
+        const new_claimed_rss = run.claimed_rss + s.max_rss;
+        if (new_claimed_rss > run.max_rss) {
+            // Running this step right now could possibly exceed the allotted RSS.
+            // Add this step to the queue of memory-blocked steps.
+            run.memory_blocked_steps.append(s) catch @panic("OOM");
+            return;
+        }
+
+        run.claimed_rss = new_claimed_rss;
+        s.state = .running;
+    } else {
+        // Avoid running steps twice.
+        if (@cmpxchgStrong(Step.State, &s.state, .precheck_done, .running, .seq_cst, .seq_cst) != null) {
+            // Another worker got the job.
+            return;
+        }
+    }
+
+    var sub_prog_node = prog_node.start(s.name, 0);
+    defer sub_prog_node.end();
+
+    const make_result = s.make(.{
+        .progress_node = sub_prog_node,
+        .thread_pool = thread_pool,
+        .watch = true,
+    });
+
+    if (run.transport) |transport| {
+        const step_id: u32 = @intCast(steps_stack.getIndex(s).?);
+        // missing fields:
+        // - result_error_msgs
+        // - result_stderr
+        serveWatchErrorBundle(transport, step_id, run.cycle, s.result_error_bundle) catch @panic("failed to send watch errors");
+    }
+
+    handle_result: {
+        if (make_result) |_| {
+            @atomicStore(Step.State, &s.state, .success, .seq_cst);
+        } else |err| switch (err) {
+            error.MakeFailed => {
+                @atomicStore(Step.State, &s.state, .failure, .seq_cst);
+                break :handle_result;
+            },
+            error.MakeSkipped => @atomicStore(Step.State, &s.state, .skipped, .seq_cst),
+        }
+
+        // Successful completion of a step, so we queue up its dependants as well.
+        for (s.dependants.items) |dep| {
+            wg.start();
+            thread_pool.spawn(workerMakeOneStep, .{
+                wg, b, steps_stack, dep, prog_node, run,
+            }) catch @panic("OOM");
+        }
+    }
+
+    // If this is a step that claims resources, we must now queue up other
+    // steps that are waiting for resources.
+    if (s.max_rss != 0) {
+        run.max_rss_mutex.lock();
+        defer run.max_rss_mutex.unlock();
+
+        // Give the memory back to the scheduler.
+        run.claimed_rss -= s.max_rss;
+        // Avoid kicking off too many tasks that we already know will not have
+        // enough resources.
+        var remaining = run.max_rss - run.claimed_rss;
+        var i: usize = 0;
+        var j: usize = 0;
+        while (j < run.memory_blocked_steps.items.len) : (j += 1) {
+            const dep = run.memory_blocked_steps.items[j];
+            assert(dep.max_rss != 0);
+            if (dep.max_rss <= remaining) {
+                remaining -= dep.max_rss;
+
+                wg.start();
+                thread_pool.spawn(workerMakeOneStep, .{
+                    wg, b, steps_stack, dep, prog_node, run,
+                }) catch @panic("OOM");
+            } else {
+                run.memory_blocked_steps.items[i] = dep;
+                i += 1;
+            }
+        }
+        run.memory_blocked_steps.shrinkRetainingCapacity(i);
+    }
+}
+
+fn nextArg(args: []const [:0]const u8, idx: *usize) ?[:0]const u8 {
+    if (idx.* >= args.len) return null;
+    defer idx.* += 1;
+    return args[idx.*];
+}
+
+fn nextArgOrFatal(args: []const [:0]const u8, idx: *usize) [:0]const u8 {
+    return nextArg(args, idx) orelse {
+        std.debug.print("expected argument after '{s}'\n  access the help menu with 'zig build -h'\n", .{args[idx.* - 1]});
+        process.exit(1);
+    };
+}
+
+fn argsRest(args: []const [:0]const u8, idx: usize) ?[]const [:0]const u8 {
+    if (idx >= args.len) return null;
+    return args[idx..];
+}
+
+/// Perhaps in the future there could be an Advanced Options flag such as
+/// --debug-build-runner-leaks which would make this function return instead of
+/// calling exit.
+fn cleanExit() void {
+    std.debug.lockStdErr();
+    process.exit(0);
+}
+
+/// Perhaps in the future there could be an Advanced Options flag such as
+/// --debug-build-runner-leaks which would make this function return instead of
+/// calling exit.
+fn uncleanExit() error{UncleanExit} {
+    std.debug.lockStdErr();
+    process.exit(1);
+}
+
+fn fatal(comptime f: []const u8, args: anytype) noreturn {
+    std.debug.print(f ++ "\n", args);
+    process.exit(1);
+}
+
+fn validateSystemLibraryOptions(b: *std.Build) void {
+    var bad = false;
+    for (b.graph.system_library_options.keys(), b.graph.system_library_options.values()) |k, v| {
+        switch (v) {
+            .user_disabled, .user_enabled => {
+                // The user tried to enable or disable a system library integration, but
+                // the build script did not recognize that option.
+                std.debug.print("system library name not recognized by build script: '{s}'\n", .{k});
+                bad = true;
+            },
+            .declared_disabled, .declared_enabled => {},
+        }
+    }
+    if (bad) {
+        std.debug.print("  access the help menu with 'zig build -h'\n", .{});
+        process.exit(1);
+    }
+}
+
+/// Starting from all top-level steps in `b`, traverses the entire step graph
+/// and adds all step dependencies implied by module graphs.
+fn createModuleDependencies(b: *std.Build) Allocator.Error!void {
+    const arena = b.graph.arena;
+
+    var all_steps: std.AutoArrayHashMapUnmanaged(*Step, void) = .empty;
+    var next_step_idx: usize = 0;
+
+    try all_steps.ensureUnusedCapacity(arena, b.top_level_steps.count());
+    for (b.top_level_steps.values()) |tls| {
+        all_steps.putAssumeCapacityNoClobber(&tls.step, {});
+    }
+
+    while (next_step_idx < all_steps.count()) {
+        const step = all_steps.keys()[next_step_idx];
+        next_step_idx += 1;
+
+        // Set up any implied dependencies for this step. It's important that we do this first, so
+        // that the loop below discovers steps implied by the module graph.
+        try createModuleDependenciesForStep(step);
+
+        try all_steps.ensureUnusedCapacity(arena, step.dependencies.items.len);
+        for (step.dependencies.items) |other_step| {
+            all_steps.putAssumeCapacity(other_step, {});
+        }
+    }
+}
+
+/// If the given `Step` is a `Step.Compile`, adds any dependencies for that step which
+/// are implied by the module graph rooted at `step.cast(Step.Compile).?.root_module`.
+fn createModuleDependenciesForStep(step: *Step) Allocator.Error!void {
+    const root_module = if (step.cast(Step.Compile)) |cs| root: {
+        break :root cs.root_module;
+    } else return; // not a compile step so no module dependencies
+
+    // Starting from `root_module`, discover all modules in this graph.
+    const modules = root_module.getGraph().modules;
+
+    // For each of those modules, set up the implied step dependencies.
+    for (modules) |mod| {
+        if (mod.root_source_file) |lp| lp.addStepDependencies(step);
+        for (mod.include_dirs.items) |include_dir| switch (include_dir) {
+            .path,
+            .path_system,
+            .path_after,
+            .framework_path,
+            .framework_path_system,
+            => |lp| lp.addStepDependencies(step),
+
+            .other_step => |other| {
+                other.getEmittedIncludeTree().addStepDependencies(step);
+                step.dependOn(&other.step);
+            },
+
+            .config_header_step => |other| step.dependOn(&other.step),
+        };
+        for (mod.lib_paths.items) |lp| lp.addStepDependencies(step);
+        for (mod.rpaths.items) |rpath| switch (rpath) {
+            .lazy_path => |lp| lp.addStepDependencies(step),
+            .special => {},
+        };
+        for (mod.link_objects.items) |link_object| switch (link_object) {
+            .static_path,
+            .assembly_file,
+            => |lp| lp.addStepDependencies(step),
+            .other_step => |other| step.dependOn(&other.step),
+            .system_lib => {},
+            .c_source_file => |source| source.file.addStepDependencies(step),
+            .c_source_files => |source_files| source_files.root.addStepDependencies(step),
+            .win32_resource_file => |rc_source| {
+                rc_source.file.addStepDependencies(step);
+                for (rc_source.include_paths) |lp| lp.addStepDependencies(step);
+            },
+        };
+    }
+}
+
+//
+//
+// ZLS code
+//
+//
+
+const shared = @import("shared.zig");
+const Transport = shared.Transport;
+const BuildConfig = shared.BuildConfig;
+
+const Packages = struct {
+    allocator: std.mem.Allocator,
+
+    /// Outer key is the package name, inner key is the file path.
+    packages: std.StringArrayHashMapUnmanaged(std.StringArrayHashMapUnmanaged(void)) = .{},
+
+    /// Returns true if the package was already present.
+    pub fn addPackage(self: *Packages, name: []const u8, path: []const u8) !bool {
+        const name_gop_result = try self.packages.getOrPutValue(self.allocator, name, .{});
+        const path_gop_result = try name_gop_result.value_ptr.getOrPut(self.allocator, path);
+        return path_gop_result.found_existing;
+    }
+
+    pub fn toPackageList(self: *Packages) ![]BuildConfig.Package {
+        var result: std.ArrayListUnmanaged(BuildConfig.Package) = .{};
+        errdefer result.deinit(self.allocator);
+
+        const Context = struct {
+            keys: [][]const u8,
+
+            pub fn lessThan(ctx: @This(), a_index: usize, b_index: usize) bool {
+                return std.mem.lessThan(u8, ctx.keys[a_index], ctx.keys[b_index]);
+            }
+        };
+
+        self.packages.sort(Context{ .keys = self.packages.keys() });
+
+        for (self.packages.keys(), self.packages.values()) |name, path_hashmap| {
+            for (path_hashmap.keys()) |path| {
+                try result.append(self.allocator, .{ .name = name, .path = path });
+            }
+        }
+
+        return try result.toOwnedSlice(self.allocator);
+    }
+
+    pub fn deinit(self: *Packages) void {
+        for (self.packages.values()) |*path_hashmap| {
+            path_hashmap.deinit(self.allocator);
+        }
+        self.packages.deinit(self.allocator);
+    }
+};
+
+fn extractBuildInformation(
+    gpa: Allocator,
+    b: *std.Build,
+    arena: Allocator,
+    main_progress_node: std.Progress.Node,
+    run: *Run,
+    seed: u32,
+) !void {
+    var steps = std.AutoArrayHashMapUnmanaged(*Step, void){};
+    defer steps.deinit(gpa);
+
+    // collect the set of all steps
+    {
+        var stack: std.ArrayListUnmanaged(*Step) = .{};
+        defer stack.deinit(gpa);
+
+        try stack.ensureUnusedCapacity(gpa, b.top_level_steps.count());
+        for (b.top_level_steps.values()) |tls| {
+            stack.appendAssumeCapacity(&tls.step);
+        }
+
+        while (switch (comptime builtin.zig_version.order(replace_pop_or_null_version)) {
+            .lt => stack.popOrNull(),
+            .eq, .gt => stack.pop(),
+        }) |step| {
+            const gop = try steps.getOrPut(gpa, step);
+            if (gop.found_existing) continue;
+
+            try stack.appendSlice(gpa, step.dependencies.items);
+        }
+    }
+
+    const helper = struct {
+        fn addStepDependencies(allocator: Allocator, set: *std.AutoArrayHashMapUnmanaged(*Step, void), lazy_path: std.Build.LazyPath) !void {
+            switch (lazy_path) {
+                .src_path, .cwd_relative, .dependency => {},
+                .generated => |gen| try set.put(allocator, gen.file.step, {}),
+            }
+        }
+        fn addModuleDependencies(allocator: Allocator, set: *std.AutoArrayHashMapUnmanaged(*Step, void), module: *std.Build.Module) !void {
+            if (module.root_source_file) |root_source_file| {
+                try addStepDependencies(allocator, set, root_source_file);
+            }
+
+            for (module.import_table.values()) |import| {
+                if (import.root_source_file) |root_source_file| {
+                    try addStepDependencies(allocator, set, root_source_file);
+                }
+            }
+
+            for (module.include_dirs.items) |include_dir| {
+                switch (include_dir) {
+                    .path,
+                    .path_system,
+                    .path_after,
+                    .framework_path,
+                    .framework_path_system,
+                    => |include_path| try addStepDependencies(allocator, set, include_path),
+                    .config_header_step => |config_header| try set.put(allocator, config_header.output_file.step, {}),
+                    .other_step => |other| {
+                        if (other.generated_h) |header| {
+                            try set.put(allocator, header.step, {});
+                        }
+                        if (other.installed_headers_include_tree) |include_tree| {
+                            try set.put(allocator, include_tree.generated_directory.step, {});
+                        }
+                    },
+                }
+            }
+        }
+
+        fn processItem(
+            allocator: Allocator,
+            module: *std.Build.Module,
+            compile: ?*std.Build.Step.Compile,
+            name: []const u8,
+            packages: *Packages,
+            include_dirs: *std.StringArrayHashMapUnmanaged(void),
+            c_macros: *std.StringArrayHashMapUnmanaged(void),
+        ) !void {
+            if (module.root_source_file) |root_source_file| {
+                _ = try packages.addPackage(name, root_source_file.getPath(module.owner));
+            }
+
+            if (compile) |exe| {
+                try processPkgConfig(allocator, include_dirs, c_macros, exe);
+            }
+
+            try c_macros.ensureUnusedCapacity(allocator, module.c_macros.items.len);
+            for (module.c_macros.items) |c_macro| {
+                c_macros.putAssumeCapacity(c_macro, {});
+            }
+
+            for (module.include_dirs.items) |include_dir| {
+                switch (include_dir) {
+                    .path,
+                    .path_system,
+                    .path_after,
+                    .framework_path,
+                    .framework_path_system,
+                    => |include_path| try include_dirs.put(allocator, include_path.getPath(module.owner), {}),
+
+                    .other_step => |other| {
+                        if (other.generated_h) |header| {
+                            try include_dirs.put(
+                                allocator,
+                                std.fs.path.dirname(header.getPath()).?,
+                                {},
+                            );
+                        }
+                        if (other.installed_headers_include_tree) |include_tree| {
+                            try include_dirs.put(
+                                allocator,
+                                include_tree.generated_directory.getPath(),
+                                {},
+                            );
+                        }
+                    },
+                    .config_header_step => |config_header| {
+                        const full_file_path = config_header.output_file.getPath();
+                        const header_dir_path = full_file_path[0 .. full_file_path.len - config_header.include_path.len];
+                        try include_dirs.put(
+                            allocator,
+                            header_dir_path,
+                            {},
+                        );
+                    },
+                }
+            }
+        }
+    };
+
+    var step_dependencies: std.AutoArrayHashMapUnmanaged(*Step, void) = .{};
+    defer step_dependencies.deinit(gpa);
+
+    // collect step dependencies
+    {
+        var modules: std.AutoArrayHashMapUnmanaged(*std.Build.Module, void) = .{};
+        defer modules.deinit(gpa);
+
+        // collect root modules of `Step.Compile`
+        for (steps.keys()) |step| {
+            const compile = step.cast(Step.Compile) orelse continue;
+            const graph = compile.root_module.getGraph();
+            try modules.ensureUnusedCapacity(gpa, graph.modules.len);
+            for (graph.modules) |module| modules.putAssumeCapacity(module, {});
+        }
+
+        // collect public modules
+        for (b.modules.values()) |root_module| {
+            const graph = root_module.getGraph();
+            try modules.ensureUnusedCapacity(gpa, graph.modules.len);
+            for (graph.modules) |module| modules.putAssumeCapacity(module, {});
+        }
+
+        // collect all dependencies of all found modules
+        for (modules.keys()) |module| {
+            try helper.addModuleDependencies(gpa, &step_dependencies, module);
+        }
+    }
+
+    prepare(gpa, b, &step_dependencies, run, seed) catch |err| switch (err) {
+        error.UncleanExit => process.exit(1),
+        else => return err,
+    };
+
+    // run all steps that are dependencies
+    try runSteps(
+        b,
+        &step_dependencies,
+        main_progress_node,
+        run,
+    );
+
+    var include_dirs: std.StringArrayHashMapUnmanaged(void) = .{};
+    defer include_dirs.deinit(gpa);
+
+    var c_macros: std.StringArrayHashMapUnmanaged(void) = .{};
+    defer c_macros.deinit(gpa);
+
+    var packages: Packages = .{ .allocator = gpa };
+    defer packages.deinit();
+
+    // extract packages and include paths
+    {
+        for (steps.keys()) |step| {
+            const compile = step.cast(Step.Compile) orelse continue;
+            const graph = compile.root_module.getGraph();
+            try helper.processItem(gpa, compile.root_module, compile, "root", &packages, &include_dirs, &c_macros);
+            for (graph.modules) |module| {
+                for (module.import_table.keys(), module.import_table.values()) |name, import| {
+                    try helper.processItem(gpa, import, null, name, &packages, &include_dirs, &c_macros);
+                }
+            }
+        }
+
+        for (b.modules.values()) |root_module| {
+            const graph = root_module.getGraph();
+            try helper.processItem(gpa, root_module, null, "root", &packages, &include_dirs, &c_macros);
+            for (graph.modules) |module| {
+                for (module.import_table.keys(), module.import_table.values()) |name, import| {
+                    try helper.processItem(gpa, import, null, name, &packages, &include_dirs, &c_macros);
+                }
+            }
+        }
+    }
+
+    // Sample `@dependencies` structure:
+    // pub const packages = struct {
+    //     pub const @"1220363c7e27b2d3f39de6ff6e90f9537a0634199860fea237a55ddb1e1717f5d6a5" = struct {
+    //         pub const build_root = "/home/rad/.cache/zig/p/1220363c7e27b2d3f39de6ff6e90f9537a0634199860fea237a55ddb1e1717f5d6a5";
+    //         pub const build_zig = @import("1220363c7e27b2d3f39de6ff6e90f9537a0634199860fea237a55ddb1e1717f5d6a5");
+    //         pub const deps: []const struct { []const u8, []const u8 } = &.{};
+    //     };
+    // ...
+    // };
+    // pub const root_deps: []const struct { []const u8, []const u8 } = &.{
+    //     .{ "known_folders", "1220bb12c9bfe291eed1afe6a2070c7c39918ab1979f24a281bba39dfb23f5bcd544" },
+    //     .{ "diffz", "122089a8247a693cad53beb161bde6c30f71376cd4298798d45b32740c3581405864" },
+    // };
+
+    var deps_build_roots: std.ArrayListUnmanaged(BuildConfig.DepsBuildRoots) = .{};
+    for (dependencies.root_deps) |root_dep| {
+        inline for (comptime std.meta.declarations(dependencies.packages)) |package| blk: {
+            if (std.mem.eql(u8, package.name, root_dep[1])) {
+                const package_info = @field(dependencies.packages, package.name);
+                if (!@hasDecl(package_info, "build_root")) break :blk;
+                if (!@hasDecl(package_info, "build_zig")) break :blk;
+                try deps_build_roots.append(arena, .{
+                    .name = root_dep[0],
+                    .path = try std.fs.path.join(arena, &.{ package_info.build_root, "build.zig" }),
+                });
+            }
+        }
+    }
+
+    var available_options: std.json.ArrayHashMap(BuildConfig.AvailableOption) = .{};
+    try available_options.map.ensureTotalCapacity(arena, b.available_options_map.count());
+
+    var it = b.available_options_map.iterator();
+    while (it.next()) |available_option| {
+        available_options.map.putAssumeCapacityNoClobber(available_option.key_ptr.*, available_option.value_ptr.*);
+    }
+
+    try std.json.stringify(
+        BuildConfig{
+            .deps_build_roots = deps_build_roots.items,
+            .packages = try packages.toPackageList(),
+            .include_dirs = include_dirs.keys(),
+            .top_level_steps = b.top_level_steps.keys(),
+            .available_options = available_options,
+            .c_macros = c_macros.keys(),
+        },
+        .{
+            .whitespace = .indent_2,
+        },
+        std.io.getStdOut().writer(),
+    );
+}
+
+fn processPkgConfig(
+    allocator: std.mem.Allocator,
+    include_dirs: *std.StringArrayHashMapUnmanaged(void),
+    c_macros: *std.StringArrayHashMapUnmanaged(void),
+    exe: *Step.Compile,
+) !void {
+    for (exe.root_module.link_objects.items) |link_object| {
+        if (link_object != .system_lib) continue;
+        const system_lib = link_object.system_lib;
+
+        if (system_lib.use_pkg_config == .no) continue;
+
+        const args = copied_from_zig.runPkgConfig(exe, system_lib.name) catch |err| switch (err) {
+            error.PkgConfigInvalidOutput,
+            error.PkgConfigCrashed,
+            error.PkgConfigFailed,
+            error.PkgConfigNotInstalled,
+            error.PackageNotFound,
+            => switch (system_lib.use_pkg_config) {
+                .yes => {
+                    // pkg-config failed, so zig will not add any include paths
+                    continue;
+                },
+                .force => {
+                    std.log.warn("pkg-config failed for library {s}", .{system_lib.name});
+                    continue;
+                },
+                .no => unreachable,
+            },
+            else => |e| return e,
+        };
+        for (args) |arg| {
+            if (std.mem.startsWith(u8, arg, "-I")) {
+                const candidate = arg[2..];
+                try include_dirs.put(allocator, candidate, {});
+            } else if (std.mem.startsWith(u8, arg, "-D")) {
+                try c_macros.put(allocator, arg, {});
+            }
+        }
+    }
+}
+
+// TODO: Having a copy of this is not very nice
+const copied_from_zig = struct {
+    /// Run pkg-config for the given library name and parse the output, returning the arguments
+    /// that should be passed to zig to link the given library.
+    fn runPkgConfig(self: *Step.Compile, lib_name: []const u8) ![]const []const u8 {
+        const b = self.step.owner;
+        const pkg_name = match: {
+            // First we have to map the library name to pkg config name. Unfortunately,
+            // there are several examples where this is not straightforward:
+            // -lSDL2 -> pkg-config sdl2
+            // -lgdk-3 -> pkg-config gdk-3.0
+            // -latk-1.0 -> pkg-config atk
+            const pkgs = try getPkgConfigList(b);
+
+            // Exact match means instant winner.
+            for (pkgs) |pkg| {
+                if (mem.eql(u8, pkg.name, lib_name)) {
+                    break :match pkg.name;
+                }
+            }
+
+            // Next we'll try ignoring case.
+            for (pkgs) |pkg| {
+                if (std.ascii.eqlIgnoreCase(pkg.name, lib_name)) {
+                    break :match pkg.name;
+                }
+            }
+
+            // Now try appending ".0".
+            for (pkgs) |pkg| {
+                if (std.ascii.indexOfIgnoreCase(pkg.name, lib_name)) |pos| {
+                    if (pos != 0) continue;
+                    if (mem.eql(u8, pkg.name[lib_name.len..], ".0")) {
+                        break :match pkg.name;
+                    }
+                }
+            }
+
+            // Trimming "-1.0".
+            if (mem.endsWith(u8, lib_name, "-1.0")) {
+                const trimmed_lib_name = lib_name[0 .. lib_name.len - "-1.0".len];
+                for (pkgs) |pkg| {
+                    if (std.ascii.eqlIgnoreCase(pkg.name, trimmed_lib_name)) {
+                        break :match pkg.name;
+                    }
+                }
+            }
+
+            return error.PackageNotFound;
+        };
+
+        var code: u8 = undefined;
+        const stdout = if (b.runAllowFail(&.{
+            "pkg-config",
+            pkg_name,
+            "--cflags",
+            "--libs",
+        }, &code, .Ignore)) |stdout| stdout else |err| switch (err) {
+            error.ProcessTerminated => return error.PkgConfigCrashed,
+            error.ExecNotSupported => return error.PkgConfigFailed,
+            error.ExitCodeFailure => return error.PkgConfigFailed,
+            error.FileNotFound => return error.PkgConfigNotInstalled,
+            else => return err,
+        };
+
+        var zig_args = ArrayList([]const u8).init(b.allocator);
+        defer zig_args.deinit();
+
+        var it = mem.tokenizeAny(u8, stdout, " \r\n\t");
+        while (it.next()) |tok| {
+            if (mem.eql(u8, tok, "-I")) {
+                const dir = it.next() orelse return error.PkgConfigInvalidOutput;
+                try zig_args.appendSlice(&.{ "-I", dir });
+            } else if (mem.startsWith(u8, tok, "-I")) {
+                try zig_args.append(tok);
+            } else if (mem.eql(u8, tok, "-L")) {
+                const dir = it.next() orelse return error.PkgConfigInvalidOutput;
+                try zig_args.appendSlice(&.{ "-L", dir });
+            } else if (mem.startsWith(u8, tok, "-L")) {
+                try zig_args.append(tok);
+            } else if (mem.eql(u8, tok, "-l")) {
+                const lib = it.next() orelse return error.PkgConfigInvalidOutput;
+                try zig_args.appendSlice(&.{ "-l", lib });
+            } else if (mem.startsWith(u8, tok, "-l")) {
+                try zig_args.append(tok);
+            } else if (mem.eql(u8, tok, "-D")) {
+                const macro = it.next() orelse return error.PkgConfigInvalidOutput;
+                try zig_args.appendSlice(&.{ "-D", macro });
+            } else if (mem.startsWith(u8, tok, "-D")) {
+                try zig_args.append(tok);
+            } else if (b.debug_pkg_config) {
+                return self.step.fail("unknown pkg-config flag '{s}'", .{tok});
+            }
+        }
+
+        return zig_args.toOwnedSlice();
+    }
+
+    fn execPkgConfigList(self: *std.Build, out_code: *u8) (std.Build.PkgConfigError || std.Build.RunError)![]const std.Build.PkgConfigPkg {
+        const stdout = try self.runAllowFail(&.{ "pkg-config", "--list-all" }, out_code, .Ignore);
+        var list = ArrayList(std.Build.PkgConfigPkg).init(self.allocator);
+        errdefer list.deinit();
+        var line_it = mem.tokenizeAny(u8, stdout, "\r\n");
+        while (line_it.next()) |line| {
+            if (mem.trim(u8, line, " \t").len == 0) continue;
+            var tok_it = mem.tokenizeAny(u8, line, " \t");
+            try list.append(.{
+                .name = tok_it.next() orelse return error.PkgConfigInvalidOutput,
+                .desc = tok_it.rest(),
+            });
+        }
+        return list.toOwnedSlice();
+    }
+
+    fn getPkgConfigList(self: *std.Build) ![]const std.Build.PkgConfigPkg {
+        if (self.pkg_config_pkg_list) |res| {
+            return res;
+        }
+        var code: u8 = undefined;
+        if (execPkgConfigList(self, &code)) |list| {
+            self.pkg_config_pkg_list = list;
+            return list;
+        } else |err| {
+            const result = switch (err) {
+                error.ProcessTerminated => error.PkgConfigCrashed,
+                error.ExecNotSupported => error.PkgConfigFailed,
+                error.ExitCodeFailure => error.PkgConfigFailed,
+                error.FileNotFound => error.PkgConfigNotInstalled,
+                error.InvalidName => error.PkgConfigNotInstalled,
+                error.PkgConfigInvalidOutput => error.PkgConfigInvalidOutput,
+                else => return err,
+            };
+            self.pkg_config_pkg_list = result;
+            return result;
+        }
+    }
+};
+
+fn serveWatchErrorBundle(
+    transport: *Transport,
+    step_id: u32,
+    cycle: u32,
+    error_bundle: std.zig.ErrorBundle,
+) !void {
+    const eb_hdr: shared.ServerToClient.ErrorBundle = .{
+        .step_id = step_id,
+        .cycle = cycle,
+        .extra_len = @intCast(error_bundle.extra.len),
+        .string_bytes_len = @intCast(error_bundle.string_bytes.len),
+    };
+    const bytes_len = @sizeOf(shared.ServerToClient.ErrorBundle) + 4 * error_bundle.extra.len + error_bundle.string_bytes.len;
+    try transport.serveMessage(.{
+        .tag = @intFromEnum(shared.ServerToClient.Tag.watch_error_bundle),
+        .bytes_len = @intCast(bytes_len),
+    }, &.{
+        std.mem.asBytes(&eb_hdr),
+        std.mem.sliceAsBytes(error_bundle.extra),
+        error_bundle.string_bytes,
+    });
+}

--- a/src/build_runner/BuildRunnerVersion.zig
+++ b/src/build_runner/BuildRunnerVersion.zig
@@ -8,7 +8,7 @@ const build_options = @import("build_options");
 ///
 /// The GitHub matrix in `.github\workflows\build_runner.yml` should be updated to check Zig master with the latest build runner file.
 pub const BuildRunnerVersion = enum {
-    master,
+    @"0.14.0",
 
     pub fn isTaggedRelease(version: BuildRunnerVersion) bool {
         return !@hasField(BuildRunnerVersion, "master") or version != .master;

--- a/src/tools/langref_0.14.0.html.in
+++ b/src/tools/langref_0.14.0.html.in
@@ -1,0 +1,8458 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="color-scheme" content="light dark">
+    <title>Documentation - The Zig Programming Language</title>
+    <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAgklEQVR4AWMYWuD7EllJIM4G4g4g5oIJ/odhOJ8wToOxSTXgNxDHoeiBMfA4+wGShjyYOCkG/IGqWQziEzYAoUAeiF9D5U+DxEg14DRU7jWIT5IBIOdCxf+A+CQZAAoopEB7QJwBCBwHiip8UYmRdrAlDpIMgApwQZNnNii5Dq0MBgCxxycBnwEd+wAAAABJRU5ErkJggg==">
+    <link rel="icon" href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNTMgMTQwIj48ZyBmaWxsPSIjRjdBNDFEIj48Zz48cG9seWdvbiBwb2ludHM9IjQ2LDIyIDI4LDQ0IDE5LDMwIi8+PHBvbHlnb24gcG9pbnRzPSI0NiwyMiAzMywzMyAyOCw0NCAyMiw0NCAyMiw5NSAzMSw5NSAyMCwxMDAgMTIsMTE3IDAsMTE3IDAsMjIiIHNoYXBlLXJlbmRlcmluZz0iY3Jpc3BFZGdlcyIvPjxwb2x5Z29uIHBvaW50cz0iMzEsOTUgMTIsMTE3IDQsMTA2Ii8+PC9nPjxnPjxwb2x5Z29uIHBvaW50cz0iNTYsMjIgNjIsMzYgMzcsNDQiLz48cG9seWdvbiBwb2ludHM9IjU2LDIyIDExMSwyMiAxMTEsNDQgMzcsNDQgNTYsMzIiIHNoYXBlLXJlbmRlcmluZz0iY3Jpc3BFZGdlcyIvPjxwb2x5Z29uIHBvaW50cz0iMTE2LDk1IDk3LDExNyA5MCwxMDQiLz48cG9seWdvbiBwb2ludHM9IjExNiw5NSAxMDAsMTA0IDk3LDExNyA0MiwxMTcgNDIsOTUiIHNoYXBlLXJlbmRlcmluZz0iY3Jpc3BFZGdlcyIvPjxwb2x5Z29uIHBvaW50cz0iMTUwLDAgNTIsMTE3IDMsMTQwIDEwMSwyMiIvPjwvZz48Zz48cG9seWdvbiBwb2ludHM9IjE0MSwyMiAxNDAsNDAgMTIyLDQ1Ii8+PHBvbHlnb24gcG9pbnRzPSIxNTMsMjIgMTUzLDExNyAxMDYsMTE3IDEyMCwxMDUgMTI1LDk1IDEzMSw5NSAxMzEsNDUgMTIyLDQ1IDEzMiwzNiAxNDEsMjIiIHNoYXBlLXJlbmRlcmluZz0iY3Jpc3BFZGdlcyIvPjxwb2x5Z29uIHBvaW50cz0iMTI1LDk1IDEzMCwxMTAgMTA2LDExNyIvPjwvZz48L2c+PC9zdmc+">
+    <style>
+      :root{
+         --nav-width: 26em;
+         --nav-margin-l: 1em;
+      }
+      body{
+        font-family: system-ui, -apple-system, Roboto, "Segoe UI", sans-serif;
+        margin: 0;
+        line-height: 1.5;
+      }
+      header {
+        padding: 0 1em;
+      }
+      #contents {
+        max-width: 60em;
+        margin: auto;
+        padding: 0 1em;
+      }
+      #navigation {
+        padding: 0 1em;
+      }
+      table ul {
+        list-style-type: none;
+        padding: 0em;
+      }
+      table li {
+        padding-bottom: 1em;
+        line-height:1.2em;
+      }
+      table, th, td {
+        border-collapse: collapse;
+        border: 1px solid grey;
+      }
+      th, td {
+        padding: 0.5em;
+      }
+      th[scope=row] {
+          text-align: left;
+          font-weight: normal;
+      }
+
+      @media screen and (min-width: 1025px) {
+        header {
+          margin-left: calc(var(--nav-width) + var(--nav-margin-l));
+        }
+        header h1 {
+          margin: auto;
+          max-width: 30em;
+        }
+        #navigation {
+          overflow: auto;
+          width: var(--nav-width);
+          height: 100vh;
+          position: fixed;
+          top:0;
+          left:0;
+          bottom:0;
+          padding: unset;
+          margin-left: var(--nav-margin-l);
+        }
+        #navigation nav ul {
+          padding-left: 1em;
+        }
+        #contents-wrapper {
+          margin-left: calc(var(--nav-width) + var(--nav-margin-l));
+        }
+      }
+
+      a:hover,a:focus {
+        background: #fff2a8;
+      }
+      dt {
+        font-weight: bold;
+      }
+      .sgr-1m {
+        font-weight: bold;
+      }
+      .sgr-2m {
+        color: #575757;
+      }
+      .sgr-31_1m {
+        color: #b40000;
+      }
+      .sgr-32_1m {
+        color: green;
+      }
+      .sgr-36_1m {
+        color: #005C7A;
+      }
+      .file {
+        font-weight: bold;
+        border: unset;
+      }
+      code {
+        background: #f8f8f8;
+        border: 1px dotted silver;
+        padding-left: 0.3em;
+        padding-right: 0.3em;
+      }
+      pre > code {
+        display: block;
+        overflow: auto;
+        padding: 0.5em;
+        border: 1px solid #eee;
+        line-height: normal;
+      }
+      samp {
+        background: #fafafa;
+      }
+      pre > samp {
+        display: block;
+        overflow: auto;
+        padding: 0.5em;
+        border: 1px solid #eee;
+        line-height: normal;
+      }
+      kbd {
+        font-weight: normal;
+      }
+      .table-wrapper {
+        width: 100%;
+        overflow-x: auto;
+      }
+
+      .tok-kw {
+          color: #333;
+          font-weight: bold;
+      }
+      .tok-str {
+          color: #d14;
+      }
+      .tok-builtin {
+          color: #005C7A;
+      }
+      .tok-comment {
+          color: #545454;
+          font-style: italic;
+      }
+      .tok-fn {
+          color: #900;
+          font-weight: bold;
+      }
+      .tok-null {
+          color: #005C5C;
+      }
+      .tok-number {
+          color: #005C5C;
+      }
+      .tok-type {
+          color: #458;
+          font-weight: bold;
+      }
+
+      figure {
+        margin: auto 0;
+      }
+      figure pre {
+        margin-top: 0;
+      }
+
+      figcaption {
+        padding-left: 0.5em;
+        font-size: small;
+        border-top-left-radius: 5px;
+        border-top-right-radius: 5px;
+      }
+      figcaption.zig-cap {
+        background: #fcdba5;
+      }
+      figcaption.c-cap {
+        background: #a8b9cc;
+        color: #000;
+      }
+      figcaption.peg-cap {
+        background: #fcdba5;
+      }
+      figcaption.javascript-cap {
+        background: #365d95;
+        color: #fff;
+      }
+      figcaption.shell-cap {
+        background: #ccc;
+        color: #000;
+      }
+
+      aside {
+        border-left: 0.25em solid #f7a41d;
+        padding: 0 1em 0 1em;
+      }
+
+      h1 a, h2 a, h3 a, h4 a, h5 a {
+        text-decoration: none;
+        color: #333;
+      }
+
+      a.hdr {
+        visibility: hidden;
+      }
+      h1:hover > a.hdr, h2:hover > a.hdr, h3:hover > a.hdr, h4:hover > a.hdr, h5:hover > a.hdr {
+        visibility: visible;
+      }
+
+      th pre code {
+          background: none;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        body{
+            background:#121212;
+            color: #ccc;
+        }
+        a {
+            color: #88f;
+        }
+        a:hover,a:focus {
+            color: #000;
+        }
+        table, th, td {
+            border-color: grey;
+        }
+        .sgr-2m {
+            color: grey;
+        }
+        .sgr-31_1m {
+            color: red;
+        }
+        .sgr-32_1m {
+            color: #00B800;
+        }
+        .sgr-36_1m {
+            color: #0086b3;
+        }
+        code {
+          background: #222;
+          border-color: #444;
+        }
+        pre > code {
+            color: #ccc;
+            background: #222;
+            border: unset;
+        }
+        samp {
+          background: #000;
+          color: #ccc;
+        }
+        pre > samp {
+          border: unset;
+        }
+        .tok-kw {
+            color: #eee;
+        }
+        .tok-str {
+            color: #2e5;
+        }
+        .tok-builtin {
+            color: #ff894c;
+        }
+        .tok-comment {
+            color: #aa7;
+        }
+        .tok-fn {
+            color: #B1A0F8;
+        }
+        .tok-null {
+            color: #ff8080;
+        }
+        .tok-number {
+            color: #ff8080;
+        }
+        .tok-type {
+            color: #68f;
+        }
+        h1 a, h2 a, h3 a, h4 a, h5 a {
+            color: #aaa;
+        }
+        figcaption.zig-cap {
+            background-color: #b27306;
+            color: #000;
+        }
+        figcaption.peg-cap {
+            background-color: #b27306;
+            color: #000;
+        }
+        figcaption.shell-cap {
+          background: #2a2a2a;
+          color: #fff;
+        }
+      }
+    </style>
+</head>
+<body>
+  <header><h1>Zig Language Reference</h1></header>
+  <div id="main-wrapper">
+      <div id="navigation">
+        <nav aria-labelledby="zig-version">
+          <h2 id="zig-version">Zig Version</h2>
+          <a href="https://ziglang.org/documentation/0.1.1/">0.1.1</a> |
+          <a href="https://ziglang.org/documentation/0.2.0/">0.2.0</a> |
+          <a href="https://ziglang.org/documentation/0.3.0/">0.3.0</a> |
+          <a href="https://ziglang.org/documentation/0.4.0/">0.4.0</a> |
+          <a href="https://ziglang.org/documentation/0.5.0/">0.5.0</a> |
+          <a href="https://ziglang.org/documentation/0.6.0/">0.6.0</a> |
+          <a href="https://ziglang.org/documentation/0.7.1/">0.7.1</a> |
+          <a href="https://ziglang.org/documentation/0.8.1/">0.8.1</a> |
+          <a href="https://ziglang.org/documentation/0.9.1/">0.9.1</a> |
+          <a href="https://ziglang.org/documentation/0.10.1/">0.10.1</a> |
+          <a href="https://ziglang.org/documentation/0.11.0/">0.11.0</a> |
+          <a href="https://ziglang.org/documentation/0.12.0/">0.12.0</a> |
+          <a href="https://ziglang.org/documentation/0.13.0/">0.13.0</a> |
+          <a href="https://ziglang.org/documentation/0.14.0/">0.14.0</a> |
+          master
+        </nav>
+        <nav aria-labelledby="table-of-contents">
+          <h2 id="table-of-contents">Table of Contents</h2>
+          {#nav#}
+        </nav>
+      </div>
+      <div id="contents-wrapper"><main id="contents">
+      {#header_open|Introduction#}
+      <p>
+      <a href="https://ziglang.org">Zig</a> is a general-purpose programming language and toolchain for maintaining
+      <strong>robust</strong>, <strong>optimal</strong>, and <strong>reusable</strong> software.
+      </p>
+      <dl>
+        <dt>Robust</dt><dd>Behavior is correct even for edge cases such as out of memory.</dd>
+        <dt>Optimal</dt><dd>Write programs the best way they can behave and perform.</dd>
+        <dt>Reusable</dt><dd>The same code works in many environments which have different
+          constraints.</dd>
+        <dt>Maintainable</dt><dd>Precisely communicate intent to the compiler and
+          other programmers. The language imposes a low overhead to reading code and is
+          resilient to changing requirements and environments.</dd>
+      </dl>
+      <p>
+      Often the most efficient way to learn something new is to see examples, so
+      this documentation shows how to use each of Zig's features. It is
+      all on one page so you can search with your browser's search tool.
+      </p>
+      <p>
+      The code samples in this document are compiled and tested as part of the main test suite of Zig.
+      </p>
+      <p>
+      This HTML document depends on no external files, so you can use it offline.
+      </p>
+      {#header_close#}
+
+      {#header_open|Zig Standard Library#}
+      <p>
+        The <a href="https://ziglang.org/documentation/master/std/">Zig Standard Library</a> has its own documentation.
+      </p>
+      <p>
+        Zig's Standard Library contains commonly used algorithms, data structures, and definitions to help you build programs or libraries.
+        You will see many examples of Zig's Standard Library used in this documentation. To learn more about the Zig Standard Library,
+        visit the link above.
+      </p>
+      <p>
+        Alternatively, the Zig Standard Library documentation is provided with each Zig distribution. It can be rendered via a local webserver with:
+      </p>
+      {#shell_samp#}zig std{#end_shell_samp#}
+      {#header_close#}
+
+      {#header_open|Hello World#}
+
+      {#code|hello.zig#}
+
+      <p>
+      Most of the time, it is more appropriate to write to stderr rather than stdout, and
+      whether or not the message is successfully written to the stream is irrelevant.
+      For this common case, there is a simpler API:
+      </p>
+      {#code|hello_again.zig#}
+
+      <p>
+      In this case, the {#syntax#}!{#endsyntax#} may be omitted from the return
+      type of <code>main</code> because no errors are returned from the function.
+      </p>
+      {#see_also|Values|Tuples|@import|Errors|Entry Point|Source Encoding|try#}
+      {#header_close#}
+      {#header_open|Comments#}
+      <p>
+      Zig supports 3 types of comments. Normal comments are ignored, but doc comments
+      and top-level doc comments are used by the compiler to generate the package documentation.
+      </p>
+      <p>
+      The generated documentation is still experimental, and can be produced with:
+      </p>
+      {#shell_samp#}zig test -femit-docs main.zig{#end_shell_samp#}
+      {#code|comments.zig#}
+
+      <p>
+      There are no multiline comments in Zig (e.g. like <code class="c">/* */</code>
+      comments in C).  This allows Zig to have the property that each line
+      of code can be tokenized out of context.
+      </p>
+      {#header_open|Doc Comments#}
+      <p>
+      A doc comment is one that begins with exactly three slashes (i.e.
+      {#syntax#}///{#endsyntax#} but not {#syntax#}////{#endsyntax#});
+      multiple doc comments in a row are merged together to form a multiline
+      doc comment.  The doc comment documents whatever immediately follows it.
+      </p>
+      {#code|doc_comments.zig#}
+
+      <p>
+      Doc comments are only allowed in certain places; it is a compile error to
+      have a doc comment in an unexpected place, such as in the middle of an expression,
+      or just before a non-doc comment.
+      </p>
+      {#code|invalid_doc-comment.zig#}
+
+      {#code|unattached_doc-comment.zig#}
+
+      <p>
+      Doc comments can be interleaved with normal comments. Currently, when producing
+      the package documentation, normal comments are merged with doc comments.
+      </p>
+      {#header_close#}
+      {#header_open|Top-Level Doc Comments#}
+      <p>
+      A top-level doc comment is one that begins with two slashes and an exclamation
+      point: {#syntax#}//!{#endsyntax#}; it documents the current module.
+      </p>
+      <p>
+      It is a compile error if a top-level doc comment is not placed at the start
+      of a {#link|container|Containers#}, before any expressions.
+      </p>
+      {#code|tldoc_comments.zig#}
+
+      {#header_close#}
+      {#header_close#}
+      {#header_open|Values#}
+      {#code|values.zig#}
+
+      {#header_open|Primitive Types#}
+      <div class="table-wrapper">
+      <table>
+        <caption>Primitive Types</caption>
+        <thead>
+            <tr>
+            <th scope="col">Type</th>
+            <th scope="col">C Equivalent</th>
+            <th scope="col">Description</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+            <th scope="row">{#syntax#}i8{#endsyntax#}</th>
+          <td><code class="c">int8_t</code></td>
+          <td>signed 8-bit integer</td>
+        </tr>
+        <tr>
+            <th scope="row">{#syntax#}u8{#endsyntax#}</th>
+          <td><code class="c">uint8_t</code></td>
+          <td>unsigned 8-bit integer</td>
+        </tr>
+        <tr>
+            <th scope="row">{#syntax#}i16{#endsyntax#}</th>
+          <td><code class="c">int16_t</code></td>
+          <td>signed 16-bit integer</td>
+        </tr>
+        <tr>
+            <th scope="row">{#syntax#}u16{#endsyntax#}</th>
+          <td><code class="c">uint16_t</code></td>
+          <td>unsigned 16-bit integer</td>
+        </tr>
+        <tr>
+            <th scope="row">{#syntax#}i32{#endsyntax#}</th>
+          <td><code class="c">int32_t</code></td>
+          <td>signed 32-bit integer</td>
+        </tr>
+        <tr>
+            <th scope="row">{#syntax#}u32{#endsyntax#}</th>
+          <td><code class="c">uint32_t</code></td>
+          <td>unsigned 32-bit integer</td>
+        </tr>
+        <tr>
+            <th scope="row">{#syntax#}i64{#endsyntax#}</th>
+          <td><code class="c">int64_t</code></td>
+          <td>signed 64-bit integer</td>
+        </tr>
+        <tr>
+            <th scope="row">{#syntax#}u64{#endsyntax#}</th>
+          <td><code class="c">uint64_t</code></td>
+          <td>unsigned 64-bit integer</td>
+        </tr>
+        <tr>
+            <th scope="row">{#syntax#}i128{#endsyntax#}</th>
+          <td><code class="c">__int128</code></td>
+          <td>signed 128-bit integer</td>
+        </tr>
+        <tr>
+            <th scope="row">{#syntax#}u128{#endsyntax#}</th>
+          <td><code class="c">unsigned __int128</code></td>
+          <td>unsigned 128-bit integer</td>
+        </tr>
+        <tr>
+            <th scope="row">{#syntax#}isize{#endsyntax#}</th>
+          <td><code class="c">intptr_t</code></td>
+          <td>signed pointer sized integer</td>
+        </tr>
+        <tr>
+            <th scope="row">{#syntax#}usize{#endsyntax#}</th>
+          <td><code class="c">uintptr_t</code>, <code class="c">size_t</code></td>
+          <td>unsigned pointer sized integer. Also see <a href="https://github.com/ziglang/zig/issues/5185">#5185</a></td>
+        </tr>
+
+        <tr>
+            <th scope="row">{#syntax#}c_char{#endsyntax#}</th>
+          <td><code class="c">char</code></td>
+          <td>for ABI compatibility with C</td>
+        </tr>
+        <tr>
+            <th scope="row">{#syntax#}c_short{#endsyntax#}</th>
+          <td><code class="c">short</code></td>
+          <td>for ABI compatibility with C</td>
+        </tr>
+        <tr>
+            <th scope="row">{#syntax#}c_ushort{#endsyntax#}</th>
+          <td><code class="c">unsigned short</code></td>
+          <td>for ABI compatibility with C</td>
+        </tr>
+        <tr>
+            <th scope="row">{#syntax#}c_int{#endsyntax#}</th>
+          <td><code class="c">int</code></td>
+          <td>for ABI compatibility with C</td>
+        </tr>
+        <tr>
+            <th scope="row">{#syntax#}c_uint{#endsyntax#}</th>
+          <td><code class="c">unsigned int</code></td>
+          <td>for ABI compatibility with C</td>
+        </tr>
+        <tr>
+            <th scope="row">{#syntax#}c_long{#endsyntax#}</th>
+          <td><code class="c">long</code></td>
+          <td>for ABI compatibility with C</td>
+        </tr>
+        <tr>
+            <th scope="row">{#syntax#}c_ulong{#endsyntax#}</th>
+          <td><code class="c">unsigned long</code></td>
+          <td>for ABI compatibility with C</td>
+        </tr>
+        <tr>
+            <th scope="row">{#syntax#}c_longlong{#endsyntax#}</th>
+          <td><code class="c">long long</code></td>
+          <td>for ABI compatibility with C</td>
+        </tr>
+        <tr>
+            <th scope="row">{#syntax#}c_ulonglong{#endsyntax#}</th>
+          <td><code class="c">unsigned long long</code></td>
+          <td>for ABI compatibility with C</td>
+        </tr>
+        <tr>
+            <th scope="row">{#syntax#}c_longdouble{#endsyntax#}</th>
+          <td><code class="c">long double</code></td>
+          <td>for ABI compatibility with C</td>
+        </tr>
+
+        <tr>
+            <th scope="row">{#syntax#}f16{#endsyntax#}</th>
+          <td><code class="c">_Float16</code></td>
+          <td>16-bit floating point (10-bit mantissa) IEEE-754-2008 binary16</td>
+        </tr>
+        <tr>
+            <th scope="row">{#syntax#}f32{#endsyntax#}</th>
+          <td><code class="c">float</code></td>
+          <td>32-bit floating point (23-bit mantissa) IEEE-754-2008 binary32</td>
+        </tr>
+        <tr>
+            <th scope="row">{#syntax#}f64{#endsyntax#}</th>
+          <td><code class="c">double</code></td>
+          <td>64-bit floating point (52-bit mantissa) IEEE-754-2008 binary64</td>
+        </tr>
+        <tr>
+            <th scope="row">{#syntax#}f80{#endsyntax#}</th>
+          <td><code class="c">long double</code></td>
+          <td>80-bit floating point (64-bit mantissa) IEEE-754-2008 80-bit extended precision</td>
+        </tr>
+        <tr>
+            <th scope="row">{#syntax#}f128{#endsyntax#}</th>
+            <td><code class="c">_Float128</code></td>
+          <td>128-bit floating point (112-bit mantissa) IEEE-754-2008 binary128</td>
+        </tr>
+        <tr>
+            <th scope="row">{#syntax#}bool{#endsyntax#}</th>
+          <td><code class="c">bool</code></td>
+          <td>{#syntax#}true{#endsyntax#} or {#syntax#}false{#endsyntax#}</td>
+        </tr>
+        <tr>
+            <th scope="row">{#syntax#}anyopaque{#endsyntax#}</th>
+          <td><code class="c">void</code></td>
+          <td>Used for type-erased pointers.</td>
+        </tr>
+        <tr>
+            <th scope="row">{#syntax#}void{#endsyntax#}</th>
+          <td>(none)</td>
+          <td>Always the value {#syntax#}void{}{#endsyntax#}</td>
+        </tr>
+        <tr>
+            <th scope="row">{#syntax#}noreturn{#endsyntax#}</th>
+          <td>(none)</td>
+          <td>the type of {#syntax#}break{#endsyntax#}, {#syntax#}continue{#endsyntax#}, {#syntax#}return{#endsyntax#}, {#syntax#}unreachable{#endsyntax#}, and {#syntax#}while (true) {}{#endsyntax#}</td>
+        </tr>
+        <tr>
+            <th scope="row">{#syntax#}type{#endsyntax#}</th>
+          <td>(none)</td>
+          <td>the type of types</td>
+        </tr>
+        <tr>
+            <th scope="row">{#syntax#}anyerror{#endsyntax#}</th>
+          <td>(none)</td>
+          <td>an error code</td>
+        </tr>
+        <tr>
+            <th scope="row">{#syntax#}comptime_int{#endsyntax#}</th>
+          <td>(none)</td>
+          <td>Only allowed for {#link|comptime#}-known values. The type of integer literals.</td>
+        </tr>
+        <tr>
+            <th scope="row">{#syntax#}comptime_float{#endsyntax#}</th>
+          <td>(none)</td>
+          <td>Only allowed for {#link|comptime#}-known values. The type of float literals.</td>
+        </tr>
+        </tbody>
+      </table>
+      </div>
+      <p>
+      In addition to the integer types above, arbitrary bit-width integers can be referenced by using
+      an identifier of <code>i</code> or <code>u</code> followed by digits. For example, the identifier
+      {#syntax#}i7{#endsyntax#} refers to a signed 7-bit integer. The maximum allowed bit-width of an
+      integer type is {#syntax#}65535{#endsyntax#}.
+      </p>
+      {#see_also|Integers|Floats|void|Errors|@Type#}
+      {#header_close#}
+      {#header_open|Primitive Values#}
+      <div class="table-wrapper">
+      <table>
+        <caption>Primitive Values</caption>
+        <thead>
+        <tr>
+          <th scope="col">Name</th>
+          <th scope="col">Description</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+            <th scope="row">{#syntax#}true{#endsyntax#} and {#syntax#}false{#endsyntax#}</th>
+            <td>{#syntax#}bool{#endsyntax#} values</td>
+        </tr>
+        <tr>
+            <th scope="row">{#syntax#}null{#endsyntax#}</th>
+            <td>used to set an optional type to {#syntax#}null{#endsyntax#}</td>
+        </tr>
+        <tr>
+            <th scope="row">{#syntax#}undefined{#endsyntax#}</th>
+          <td>used to leave a value unspecified</td>
+        </tr>
+        </tbody>
+      </table>
+      </div>
+      {#see_also|Optionals|undefined#}
+      {#header_close#}
+      {#header_open|String Literals and Unicode Code Point Literals#}
+      <p>
+      String literals are constant single-item {#link|Pointers#} to null-terminated byte arrays.
+      The type of string literals encodes both the length, and the fact that they are null-terminated,
+      and thus they can be {#link|coerced|Type Coercion#} to both {#link|Slices#} and
+      {#link|Null-Terminated Pointers|Sentinel-Terminated Pointers#}.
+      Dereferencing string literals converts them to {#link|Arrays#}.
+      </p>
+      <p>
+      Because Zig source code is {#link|UTF-8 encoded|Source Encoding#}, any
+      non-ASCII bytes appearing within a string literal in source code carry
+      their UTF-8 meaning into the content of the string in the Zig program;
+      the bytes are not modified by the compiler. It is possible to embed
+      non-UTF-8 bytes into a string literal using <code>\xNN</code> notation.
+      </p>
+      <p>Indexing into a string containing non-ASCII bytes returns individual
+      bytes, whether valid UTF-8 or not.</p>
+      <p>
+      Unicode code point literals have type {#syntax#}comptime_int{#endsyntax#}, the same as
+      {#link|Integer Literals#}. All {#link|Escape Sequences#} are valid in both string literals
+      and Unicode code point literals.
+      </p>
+      {#code|string_literals.zig#}
+
+      {#see_also|Arrays|Source Encoding#}
+      {#header_open|Escape Sequences#}
+      <div class="table-wrapper">
+      <table>
+        <caption>Escape Sequences</caption>
+        <thead>
+        <tr>
+          <th scope="col">Escape Sequence</th>
+          <th scope="col">Name</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+            <th scope="row"><code>\n</code></th>
+          <td>Newline</td>
+        </tr>
+        <tr>
+            <th scope="row"><code>\r</code></th>
+          <td>Carriage Return</td>
+        </tr>
+        <tr>
+            <th scope="row"><code>\t</code></th>
+          <td>Tab</td>
+        </tr>
+        <tr>
+            <th scope="row"><code>\\</code></th>
+          <td>Backslash</td>
+        </tr>
+        <tr>
+            <th scope="row"><code>\'</code></th>
+          <td>Single Quote</td>
+        </tr>
+        <tr>
+            <th scope="row"><code>\"</code></th>
+          <td>Double Quote</td>
+        </tr>
+        <tr>
+            <th scope="row"><code>\xNN</code></th>
+          <td>hexadecimal 8-bit byte value (2 digits)</td>
+        </tr>
+        <tr>
+            <th scope="row"><code>\u{NNNNNN}</code></th>
+          <td>hexadecimal Unicode scalar value UTF-8 encoded (1 or more digits)</td>
+        </tr>
+        </tbody>
+      </table>
+      </div>
+      <p>Note that the maximum valid Unicode scalar value is {#syntax#}0x10ffff{#endsyntax#}.</p>
+      {#header_close#}
+      {#header_open|Multiline String Literals#}
+      <p>
+      Multiline string literals have no escapes and can span across multiple lines.
+      To start a multiline string literal, use the {#syntax#}\\{#endsyntax#} token. Just like a comment,
+      the string literal goes until the end of the line. The end of the line is
+      not included in the string literal.
+      However, if the next line begins with {#syntax#}\\{#endsyntax#} then a newline is appended and
+      the string literal continues.
+      </p>
+      {#code|multiline_string_literals.zig#}
+
+      {#see_also|@embedFile#}
+      {#header_close#}
+      {#header_close#}
+      {#header_open|Assignment#}
+      <p>Use the {#syntax#}const{#endsyntax#} keyword to assign a value to an identifier:</p>
+      {#code|constant_identifier_cannot_change.zig#}
+
+      <p>{#syntax#}const{#endsyntax#} applies to all of the bytes that the identifier immediately addresses. {#link|Pointers#} have their own const-ness.</p>
+      <p>If you need a variable that you can modify, use the {#syntax#}var{#endsyntax#} keyword:</p>
+      {#code|mutable_var.zig#}
+
+      <p>Variables must be initialized:</p>
+      {#code|var_must_be_initialized.zig#}
+
+      {#header_open|undefined#}
+      <p>Use {#syntax#}undefined{#endsyntax#} to leave variables uninitialized:</p>
+      {#code|assign_undefined.zig#}
+
+      <p>
+      {#syntax#}undefined{#endsyntax#} can be {#link|coerced|Type Coercion#} to any type.
+          Once this happens, it is no longer possible to detect that the value is {#syntax#}undefined{#endsyntax#}.
+              {#syntax#}undefined{#endsyntax#} means the value could be anything, even something that is nonsense
+                  according to the type. Translated into English, {#syntax#}undefined{#endsyntax#} means "Not a meaningful
+      value. Using this value would be a bug. The value will be unused, or overwritten before being used."
+      </p>
+      <p>
+      In {#link|Debug#} mode, Zig writes {#syntax#}0xaa{#endsyntax#} bytes to undefined memory. This is to catch
+      bugs early, and to help detect use of undefined memory in a debugger. However, this behavior is only an
+      implementation feature, not a language semantic, so it is not guaranteed to be observable to code.
+      </p>
+      {#header_close#}
+
+      {#header_open|Destructuring#}
+      <p>
+        A destructuring assignment can separate elements of indexable aggregate types
+        ({#link|Tuples#}, {#link|Arrays#}, {#link|Vectors#}):
+      </p>
+      {#code|destructuring_to_existing.zig#}
+
+      <p>
+        A destructuring expression may only appear within a block (i.e. not at container scope).
+        The left hand side of the assignment must consist of a comma separated list,
+        each element of which may be either an lvalue (for instance, an existing `var`) or a variable declaration:
+      </p>
+      {#code|destructuring_mixed.zig#}
+
+      <p>
+        A destructure may be prefixed with the {#syntax#}comptime{#endsyntax#} keyword, in which case the entire
+        destructure expression is evaluated at {#link|comptime#}. All {#syntax#}var{#endsyntax#}s declared would
+        be {#syntax#}comptime var{#endsyntax#}s and all expressions (both result locations and the assignee
+        expression) are evaluated at {#link|comptime#}.
+      </p>
+
+      {#see_also|Destructuring Tuples|Destructuring Arrays|Destructuring Vectors#}
+      {#header_close#}
+      {#header_close#}
+      {#header_close#}
+      {#header_open|Zig Test#}
+      <p>
+        Code written within one or more {#syntax#}test{#endsyntax#} declarations can be used to ensure behavior meets expectations:
+      </p>
+      {#code|testing_introduction.zig#}
+
+      <p>
+        The <code class="file">testing_introduction.zig</code> code sample tests the {#link|function|Functions#}
+        {#syntax#}addOne{#endsyntax#} to ensure that it returns {#syntax#}42{#endsyntax#} given the input
+        {#syntax#}41{#endsyntax#}. From this test's perspective, the {#syntax#}addOne{#endsyntax#} function is
+        said to be <em>code under test</em>.
+      </p>
+      <p>
+        <kbd>zig test</kbd> is a tool that creates and runs a test build. By default, it builds and runs an
+        executable program using the <em>default test runner</em> provided by the {#link|Zig Standard Library#}
+        as its main entry point. During the build, {#syntax#}test{#endsyntax#} declarations found while
+        {#link|resolving|File and Declaration Discovery#} the given Zig source file are included for the default test runner
+        to run and report on.
+      </p>
+      <aside>
+        This documentation discusses the features of the default test runner as provided by the Zig Standard Library.
+        Its source code is located in <code class="file">lib/compiler/test_runner.zig</code>.
+      </aside>
+      <p>
+        The shell output shown above displays two lines after the <kbd>zig test</kbd> command. These lines are
+        printed to standard error by the default test runner:
+      </p>
+      <dl>
+        <dt><samp>1/2 testing_introduction.test.expect addOne adds one to 41...</samp></dt>
+        <dd>Lines like this indicate which test, out of the total number of tests, is being run.
+          In this case, <samp>1/2</samp> indicates that the first test, out of a total of two tests,
+          is being run. Note that, when the test runner program's standard error is output
+          to the terminal, these lines are cleared when a test succeeds.
+        </dd>
+        <dt><samp>2/2 testing_introduction.decltest.addOne...</samp></dt>
+        <dd>When the test name is an identifier, the default test runner uses the text
+          decltest instead of test.
+        </dd>
+        <dt><samp>All 2 tests passed.</samp></dt>
+        <dd>This line indicates the total number of tests that have passed.</dd>
+      </dl>
+      {#header_open|Test Declarations#}
+      <p>
+        Test declarations contain the {#link|keyword|Keyword Reference#} {#syntax#}test{#endsyntax#}, followed by an
+        optional name written as a {#link|string literal|String Literals and Unicode Code Point Literals#} or an
+        {#link|identifier|Identifiers#}, followed by a {#link|block|Blocks#} containing any valid Zig code that
+        is allowed in a {#link|function|Functions#}.
+      </p>
+      <p>Non-named test blocks always run during test builds and are exempt from
+        {#link|Skip Tests#}.</p>
+      <p>
+        Test declarations are similar to {#link|Functions#}: they have a return type and a block of code. The implicit
+        return type of {#syntax#}test{#endsyntax#} is the {#link|Error Union Type#} {#syntax#}anyerror!void{#endsyntax#},
+        and it cannot be changed. When a Zig source file is not built using the <kbd>zig test</kbd> tool, the test
+        declarations are omitted from the build.
+      </p>
+      <p>
+        Test declarations can be written in the same file, where code under test is written, or in a separate Zig source file.
+        Since test declarations are top-level declarations, they are order-independent and can
+        be written before or after the code under test.
+      </p>
+      {#see_also|The Global Error Set|Grammar#}
+      {#header_open|Doctests#}
+      <p>
+        Test declarations named using an identifier are <em>doctests</em>. The identifier must refer to another declaration in
+        scope. A doctest, like a {#link|doc comment|Doc Comments#}, serves as documentation for the associated declaration, and
+        will appear in the generated documentation for the declaration.
+      </p>
+      <p>
+        An effective doctest should be self-contained and focused on the declaration being tested, answering questions a new
+        user might have about its interface or intended usage, while avoiding unnecessary or confusing details. A doctest is not
+        a substitute for a doc comment, but rather a supplement and companion providing a testable, code-driven example, verified
+        by <kbd>zig test</kbd>.
+      </p>
+      {#header_close#}
+      {#header_close#}
+      {#header_open|Test Failure#}
+      <p>
+        The default test runner checks for an {#link|error|Errors#} returned from a test.
+        When a test returns an error, the test is considered a failure and its {#link|error return trace|Error Return Traces#}
+        is output to standard error. The total number of failures will be reported after all tests have run.
+      </p>
+      {#code|testing_failure.zig#}
+
+      {#header_close#}
+      {#header_open|Skip Tests#}
+      <p>
+        One way to skip tests is to filter them out by using the <kbd>zig test</kbd> command line parameter
+        <kbd>--test-filter [text]</kbd>. This makes the test build only include tests whose name contains the
+        supplied filter text. Note that non-named tests are run even when using the <kbd>--test-filter [text]</kbd>
+        command line parameter.
+      </p>
+      <p>
+        To programmatically skip a test, make a {#syntax#}test{#endsyntax#} return the error
+        {#syntax#}error.SkipZigTest{#endsyntax#} and the default test runner will consider the test as being skipped.
+        The total number of skipped tests will be reported after all tests have run.
+      </p>
+      {#code|testing_skip.zig#}
+
+      {#header_close#}
+
+      {#header_open|Report Memory Leaks#}
+      <p>
+        When code allocates {#link|Memory#} using the {#link|Zig Standard Library#}'s testing allocator,
+        {#syntax#}std.testing.allocator{#endsyntax#}, the default test runner will report any leaks that are
+        found from using the testing allocator:
+      </p>
+      {#code|testing_detect_leak.zig#}
+
+      {#see_also|defer|Memory#}
+      {#header_close#}
+      {#header_open|Detecting Test Build#}
+      <p>
+        Use the {#link|compile variable|Compile Variables#} {#syntax#}@import("builtin").is_test{#endsyntax#}
+        to detect a test build:
+      </p>
+      {#code|testing_detect_test.zig#}
+
+      {#header_close#}
+      {#header_open|Test Output and Logging#}
+      <p>
+        The default test runner and the Zig Standard Library's testing namespace output messages to standard error.
+      </p>
+      {#header_close#}
+      {#header_open|The Testing Namespace#}
+      <p>
+        The Zig Standard Library's <code>testing</code> namespace contains useful functions to help
+        you create tests. In addition to the <code>expect</code> function, this document uses a couple of more functions
+        as exemplified here:
+      </p>
+      {#code|testing_namespace.zig#}
+
+      <p>The Zig Standard Library also contains functions to compare {#link|Slices#}, strings, and more. See the rest of the
+        {#syntax#}std.testing{#endsyntax#} namespace in the {#link|Zig Standard Library#} for more available functions.</p>
+      {#header_close#}
+      {#header_open|Test Tool Documentation#}
+      <p>
+        <kbd>zig test</kbd> has a few command line parameters which affect the compilation.
+        See <kbd>zig test --help</kbd> for a full list.
+      </p>
+      {#header_close#}
+      {#header_close#}
+
+      {#header_open|Variables#}
+      <p>
+      A variable is a unit of {#link|Memory#} storage.
+      </p>
+      <p>
+      It is generally preferable to use {#syntax#}const{#endsyntax#} rather than
+      {#syntax#}var{#endsyntax#} when declaring a variable. This causes less work for both
+      humans and computers to do when reading code, and creates more optimization opportunities.
+      </p>
+      <p>
+      The {#syntax#}extern{#endsyntax#} keyword or {#link|@extern#} builtin function can be used to link against a variable that is exported
+      from another object. The {#syntax#}export{#endsyntax#} keyword or {#link|@export#} builtin function
+      can be used to make a variable available to other objects at link time. In both cases,
+      the type of the variable must be C ABI compatible.
+      </p>
+      {#see_also|Exporting a C Library#}
+
+      {#header_open|Identifiers#}
+      <p>
+      Variable identifiers are never allowed to shadow identifiers from an outer scope.
+      </p>
+      <p>
+      Identifiers must start with an alphabetic character or underscore and may be followed
+      by any number of alphanumeric characters or underscores.
+      They must not overlap with any keywords. See {#link|Keyword Reference#}.
+      </p>
+      <p>
+      If a name that does not fit these requirements is needed, such as for linking with external libraries, the {#syntax#}@""{#endsyntax#} syntax may be used.
+      </p>
+      {#code|identifiers.zig#}
+
+      {#header_close#}
+
+      {#header_open|Container Level Variables#}
+      <p>
+      {#link|Container|Containers#} level variables have static lifetime and are order-independent and lazily analyzed.
+      The initialization value of container level variables is implicitly
+      {#link|comptime#}. If a container level variable is {#syntax#}const{#endsyntax#} then its value is
+      {#syntax#}comptime{#endsyntax#}-known, otherwise it is runtime-known.
+      </p>
+      {#code|test_container_level_variables.zig#}
+
+      <p>
+      Container level variables may be declared inside a {#link|struct#}, {#link|union#}, {#link|enum#}, or {#link|opaque#}:
+      </p>
+      {#code|test_namespaced_container_level_variable.zig#}
+
+      {#header_close#}
+
+      {#header_open|Static Local Variables#}
+      <p>
+        It is also possible to have local variables with static lifetime by using containers inside functions.
+      </p>
+      {#code|test_static_local_variable.zig#}
+
+      {#header_close#}
+
+      {#header_open|Thread Local Variables#}
+      <p>A variable may be specified to be a thread-local variable using the
+      {#syntax#}threadlocal{#endsyntax#} keyword,
+      which makes each thread work with a separate instance of the variable:</p>
+      {#code|test_thread_local_variables.zig#}
+
+      <p>
+      For {#link|Single Threaded Builds#}, all thread local variables are treated as regular {#link|Container Level Variables#}.
+      </p>
+      <p>
+      Thread local variables may not be {#syntax#}const{#endsyntax#}.
+      </p>
+      {#header_close#}
+
+      {#header_open|Local Variables#}
+      <p>
+      Local variables occur inside {#link|Functions#}, {#link|comptime#} blocks, and {#link|@cImport#} blocks.
+      </p>
+      <p>
+      When a local variable is {#syntax#}const{#endsyntax#}, it means that after initialization, the variable's
+      value will not change. If the initialization value of a {#syntax#}const{#endsyntax#} variable is
+      {#link|comptime#}-known, then the variable is also {#syntax#}comptime{#endsyntax#}-known.
+      </p>
+      <p>
+      A local variable may be qualified with the {#syntax#}comptime{#endsyntax#} keyword. This causes
+      the variable's value to be {#syntax#}comptime{#endsyntax#}-known, and all loads and stores of the
+      variable to happen during semantic analysis of the program, rather than at runtime.
+      All variables declared in a {#syntax#}comptime{#endsyntax#} expression are implicitly
+      {#syntax#}comptime{#endsyntax#} variables.
+      </p>
+      {#code|test_comptime_variables.zig#}
+
+      {#header_close#}
+      {#header_close#}
+
+      {#header_open|Integers#}
+      {#header_open|Integer Literals#}
+      {#code|integer_literals.zig#}
+
+      {#header_close#}
+      {#header_open|Runtime Integer Values#}
+      <p>
+      Integer literals have no size limitation, and if any Illegal Behavior occurs,
+      the compiler catches it.
+      </p>
+      <p>
+      However, once an integer value is no longer known at compile-time, it must have a
+      known size, and is vulnerable to safety-checked {#link|Illegal Behavior#}.
+      </p>
+      {#code|runtime_vs_comptime.zig#}
+
+      <p>
+      In this function, values {#syntax#}a{#endsyntax#} and {#syntax#}b{#endsyntax#} are known only at runtime,
+      and thus this division operation is vulnerable to both {#link|Integer Overflow#} and
+      {#link|Division by Zero#}.
+      </p>
+      <p>
+      Operators such as {#syntax#}+{#endsyntax#} and {#syntax#}-{#endsyntax#} cause {#link|Illegal Behavior#} on
+      integer overflow. Alternative operators are provided for wrapping and saturating arithmetic on all targets.
+      {#syntax#}+%{#endsyntax#} and {#syntax#}-%{#endsyntax#} perform wrapping arithmetic
+      while {#syntax#}+|{#endsyntax#} and {#syntax#}-|{#endsyntax#} perform saturating arithmetic.
+      </p>
+      <p>
+      Zig supports arbitrary bit-width integers, referenced by using
+      an identifier of <code>i</code> or <code>u</code> followed by digits. For example, the identifier
+      {#syntax#}i7{#endsyntax#} refers to a signed 7-bit integer. The maximum allowed bit-width of an
+      integer type is {#syntax#}65535{#endsyntax#}. For signed integer types, Zig uses a
+      <a href="https://en.wikipedia.org/wiki/Two's_complement">two's complement</a> representation.
+      </p>
+      {#see_also|Wrapping Operations#}
+      {#header_close#}
+      {#header_close#}
+      {#header_open|Floats#}
+      <p>Zig has the following floating point types:</p>
+      <ul>
+          <li>{#syntax#}f16{#endsyntax#} - IEEE-754-2008 binary16</li>
+          <li>{#syntax#}f32{#endsyntax#} - IEEE-754-2008 binary32</li>
+          <li>{#syntax#}f64{#endsyntax#} - IEEE-754-2008 binary64</li>
+          <li>{#syntax#}f80{#endsyntax#} - IEEE-754-2008 80-bit extended precision</li>
+          <li>{#syntax#}f128{#endsyntax#} - IEEE-754-2008 binary128</li>
+          <li>{#syntax#}c_longdouble{#endsyntax#} - matches <code class="c">long double</code> for the target C ABI</li>
+      </ul>
+      {#header_open|Float Literals#}
+      <p>
+      Float literals have type {#syntax#}comptime_float{#endsyntax#} which is guaranteed to have
+      the same precision and operations of the largest other floating point type, which is
+      {#syntax#}f128{#endsyntax#}.
+      </p>
+      <p>
+      Float literals {#link|coerce|Type Coercion#} to any floating point type,
+      and to any {#link|integer|Integers#} type when there is no fractional component.
+      </p>
+      {#code|float_literals.zig#}
+
+      <p>
+      There is no syntax for NaN, infinity, or negative infinity. For these special values,
+      one must use the standard library:
+      </p>
+      {#code|float_special_values.zig#}
+
+      {#header_close#}
+      {#header_open|Floating Point Operations#}
+      <p>By default floating point operations use {#syntax#}Strict{#endsyntax#} mode,
+          but you can switch to {#syntax#}Optimized{#endsyntax#} mode on a per-block basis:</p>
+      {#code|float_mode_obj.zig#}
+
+      <p>For this test we have to separate code into two object files -
+      otherwise the optimizer figures out all the values at compile-time,
+      which operates in strict mode.</p>
+      {#code|float_mode_exe.zig#}
+
+      {#see_also|@setFloatMode|Division by Zero#}
+      {#header_close#}
+      {#header_close#}
+      {#header_open|Operators#}
+      <p>
+      There is no operator overloading. When you see an operator in Zig, you know that
+      it is doing something from this table, and nothing else.
+      </p>
+      {#header_open|Table of Operators#}
+      <div class="table-wrapper">
+      <table>
+        <thead>
+        <tr>
+          <th scope="col">Name</th>
+          <th scope="col">Syntax</th>
+          <th scope="col">Types</th>
+          <th scope="col">Remarks</th>
+          <th scope="col">Example</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+          <td>Addition</td>
+          <td><pre>{#syntax#}a + b
+a += b{#endsyntax#}</pre></td>
+          <td>
+            <ul>
+              <li>{#link|Integers#}</li>
+              <li>{#link|Floats#}</li>
+            </ul>
+          </td>
+          <td>
+            <ul>
+              <li>Can cause {#link|overflow|Default Operations#} for integers.</li>
+              <li>Invokes {#link|Peer Type Resolution#} for the operands.</li>
+              <li>See also {#link|@addWithOverflow#}.</li>
+            </ul>
+          </td>
+          <td>
+            <pre>{#syntax#}2 + 5 == 7{#endsyntax#}</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>Wrapping Addition</td>
+          <td><pre>{#syntax#}a +% b
+a +%= b{#endsyntax#}</pre></td>
+          <td>
+            <ul>
+              <li>{#link|Integers#}</li>
+            </ul>
+          </td>
+          <td>
+            <ul>
+              <li>Twos-complement wrapping behavior.</li>
+              <li>Invokes {#link|Peer Type Resolution#} for the operands.</li>
+              <li>See also {#link|@addWithOverflow#}.</li>
+            </ul>
+          </td>
+          <td>
+            <pre>{#syntax#}@as(u32, 0xffffffff) +% 1 == 0{#endsyntax#}</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>Saturating Addition</td>
+          <td><pre>{#syntax#}a +| b
+a +|= b{#endsyntax#}</pre></td>
+          <td>
+            <ul>
+              <li>{#link|Integers#}</li>
+            </ul>
+          </td>
+          <td>
+            <ul>
+              <li>Invokes {#link|Peer Type Resolution#} for the operands.</li>
+            </ul>
+          </td>
+          <td>
+            <pre>{#syntax#}@as(u8, 255) +| 1 == @as(u8, 255){#endsyntax#}</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>Subtraction</td>
+          <td><pre>{#syntax#}a - b
+a -= b{#endsyntax#}</pre></td>
+          <td>
+            <ul>
+              <li>{#link|Integers#}</li>
+              <li>{#link|Floats#}</li>
+            </ul>
+          </td>
+          <td>
+            <ul>
+              <li>Can cause {#link|overflow|Default Operations#} for integers.</li>
+              <li>Invokes {#link|Peer Type Resolution#} for the operands.</li>
+              <li>See also {#link|@subWithOverflow#}.</li>
+            </ul>
+          </td>
+          <td>
+            <pre>{#syntax#}2 - 5 == -3{#endsyntax#}</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>Wrapping Subtraction</td>
+          <td><pre>{#syntax#}a -% b
+a -%= b{#endsyntax#}</pre></td>
+          <td>
+            <ul>
+              <li>{#link|Integers#}</li>
+            </ul>
+          </td>
+          <td>
+            <ul>
+              <li>Twos-complement wrapping behavior.</li>
+              <li>Invokes {#link|Peer Type Resolution#} for the operands.</li>
+              <li>See also {#link|@subWithOverflow#}.</li>
+            </ul>
+          </td>
+          <td>
+            <pre>{#syntax#}@as(u8, 0) -% 1 == 255{#endsyntax#}</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>Saturating Subtraction</td>
+          <td><pre>{#syntax#}a -| b
+a -|= b{#endsyntax#}</pre></td>
+          <td>
+            <ul>
+              <li>{#link|Integers#}</li>
+            </ul>
+          </td>
+          <td>
+            <ul>
+              <li>Invokes {#link|Peer Type Resolution#} for the operands.</li>
+            </ul>
+          </td>
+          <td>
+            <pre>{#syntax#}@as(u32, 0) -| 1 == 0{#endsyntax#}</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>Negation</td>
+          <td><pre>{#syntax#}-a{#endsyntax#}</pre></td>
+          <td>
+            <ul>
+              <li>{#link|Integers#}</li>
+              <li>{#link|Floats#}</li>
+            </ul>
+          </td>
+          <td>
+            <ul>
+              <li>Can cause {#link|overflow|Default Operations#} for integers.</li>
+            </ul>
+          </td>
+          <td>
+            <pre>{#syntax#}-1 == 0 - 1{#endsyntax#}</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>Wrapping Negation</td>
+          <td><pre>{#syntax#}-%a{#endsyntax#}</pre></td>
+          <td>
+            <ul>
+              <li>{#link|Integers#}</li>
+            </ul>
+          </td>
+          <td>
+            <ul>
+              <li>Twos-complement wrapping behavior.</li>
+            </ul>
+          </td>
+          <td>
+            <pre>{#syntax#}-%@as(i8, -128) == -128{#endsyntax#}</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>Multiplication</td>
+          <td><pre>{#syntax#}a * b
+a *= b{#endsyntax#}</pre></td>
+          <td>
+            <ul>
+              <li>{#link|Integers#}</li>
+              <li>{#link|Floats#}</li>
+            </ul>
+          </td>
+          <td>
+            <ul>
+              <li>Can cause {#link|overflow|Default Operations#} for integers.</li>
+              <li>Invokes {#link|Peer Type Resolution#} for the operands.</li>
+              <li>See also {#link|@mulWithOverflow#}.</li>
+            </ul>
+          </td>
+          <td>
+            <pre>{#syntax#}2 * 5 == 10{#endsyntax#}</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>Wrapping Multiplication</td>
+          <td><pre>{#syntax#}a *% b
+a *%= b{#endsyntax#}</pre></td>
+          <td>
+            <ul>
+              <li>{#link|Integers#}</li>
+            </ul>
+          </td>
+          <td>
+            <ul>
+              <li>Twos-complement wrapping behavior.</li>
+              <li>Invokes {#link|Peer Type Resolution#} for the operands.</li>
+              <li>See also {#link|@mulWithOverflow#}.</li>
+            </ul>
+          </td>
+          <td>
+            <pre>{#syntax#}@as(u8, 200) *% 2 == 144{#endsyntax#}</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>Saturating Multiplication</td>
+          <td><pre>{#syntax#}a *| b
+a *|= b{#endsyntax#}</pre></td>
+          <td>
+            <ul>
+              <li>{#link|Integers#}</li>
+            </ul>
+          </td>
+          <td>
+            <ul>
+              <li>Invokes {#link|Peer Type Resolution#} for the operands.</li>
+            </ul>
+          </td>
+          <td>
+            <pre>{#syntax#}@as(u8, 200) *| 2 == 255{#endsyntax#}</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>Division</td>
+          <td><pre>{#syntax#}a / b
+a /= b{#endsyntax#}</pre></td>
+          <td>
+            <ul>
+              <li>{#link|Integers#}</li>
+              <li>{#link|Floats#}</li>
+            </ul>
+          </td>
+          <td>
+            <ul>
+              <li>Can cause {#link|overflow|Default Operations#} for integers.</li>
+              <li>Can cause {#link|Division by Zero#} for integers.</li>
+              <li>Can cause {#link|Division by Zero#} for floats in {#link|FloatMode.Optimized Mode|Floating Point Operations#}.</li>
+              <li>Signed integer operands must be comptime-known and positive. In other cases, use
+                {#link|@divTrunc#},
+                {#link|@divFloor#}, or
+                {#link|@divExact#} instead.
+              </li>
+              <li>Invokes {#link|Peer Type Resolution#} for the operands.</li>
+            </ul>
+          </td>
+          <td>
+            <pre>{#syntax#}10 / 5 == 2{#endsyntax#}</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>Remainder Division</td>
+          <td><pre>{#syntax#}a % b
+a %= b{#endsyntax#}</pre></td>
+          <td>
+            <ul>
+              <li>{#link|Integers#}</li>
+              <li>{#link|Floats#}</li>
+            </ul>
+          </td>
+          <td>
+            <ul>
+              <li>Can cause {#link|Division by Zero#} for integers.</li>
+              <li>Can cause {#link|Division by Zero#} for floats in {#link|FloatMode.Optimized Mode|Floating Point Operations#}.</li>
+              <li>Signed or floating-point operands must be comptime-known and positive. In other cases, use
+                {#link|@rem#} or
+                {#link|@mod#} instead.
+              </li>
+              <li>Invokes {#link|Peer Type Resolution#} for the operands.</li>
+            </ul>
+          </td>
+          <td>
+            <pre>{#syntax#}10 % 3 == 1{#endsyntax#}</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>Bit Shift Left</td>
+          <td><pre>{#syntax#}a << b
+a <<= b{#endsyntax#}</pre></td>
+          <td>
+            <ul>
+              <li>{#link|Integers#}</li>
+            </ul>
+          </td>
+          <td>
+            <ul>
+              <li>Moves all bits to the left, inserting new zeroes at the
+              least-significant bit.</li>
+              <li>{#syntax#}b{#endsyntax#} must be
+              {#link|comptime-known|comptime#} or have a type with log2 number
+              of bits as {#syntax#}a{#endsyntax#}.</li>
+              <li>See also {#link|@shlExact#}.</li>
+              <li>See also {#link|@shlWithOverflow#}.</li>
+            </ul>
+          </td>
+          <td>
+            <pre>{#syntax#}0b1 << 8 == 0b100000000{#endsyntax#}</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>Saturating Bit Shift Left</td>
+          <td><pre>{#syntax#}a <<| b
+a <<|= b{#endsyntax#}</pre></td>
+          <td>
+            <ul>
+              <li>{#link|Integers#}</li>
+            </ul>
+          </td>
+          <td>
+            <ul>
+              <li>See also {#link|@shlExact#}.</li>
+              <li>See also {#link|@shlWithOverflow#}.</li>
+            </ul>
+          </td>
+          <td>
+            <pre>{#syntax#}@as(u8, 1) <<| 8 == 255{#endsyntax#}</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>Bit Shift Right</td>
+          <td><pre>{#syntax#}a >> b
+a >>= b{#endsyntax#}</pre></td>
+          <td>
+            <ul>
+              <li>{#link|Integers#}</li>
+            </ul>
+          </td>
+          <td>
+            <ul>
+              <li>Moves all bits to the right, inserting zeroes at the most-significant bit.</li>
+              <li>{#syntax#}b{#endsyntax#} must be
+                {#link|comptime-known|comptime#} or have a type with log2 number
+                of bits as {#syntax#}a{#endsyntax#}.</li>
+              <li>See also {#link|@shrExact#}.</li>
+            </ul>
+          </td>
+          <td>
+            <pre>{#syntax#}0b1010 >> 1 == 0b101{#endsyntax#}</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>Bitwise And</td>
+          <td><pre>{#syntax#}a & b
+a &= b{#endsyntax#}</pre></td>
+          <td>
+            <ul>
+              <li>{#link|Integers#}</li>
+            </ul>
+          </td>
+          <td>
+            <ul>
+              <li>Invokes {#link|Peer Type Resolution#} for the operands.</li>
+            </ul>
+          </td>
+          <td>
+            <pre>{#syntax#}0b011 & 0b101 == 0b001{#endsyntax#}</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>Bitwise Or</td>
+          <td><pre>{#syntax#}a | b
+a |= b{#endsyntax#}</pre></td>
+          <td>
+            <ul>
+              <li>{#link|Integers#}</li>
+            </ul>
+          </td>
+          <td>
+            <ul>
+              <li>Invokes {#link|Peer Type Resolution#} for the operands.</li>
+            </ul>
+          </td>
+          <td>
+            <pre>{#syntax#}0b010 | 0b100 == 0b110{#endsyntax#}</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>Bitwise Xor</td>
+          <td><pre>{#syntax#}a ^ b
+a ^= b{#endsyntax#}</pre></td>
+          <td>
+            <ul>
+              <li>{#link|Integers#}</li>
+            </ul>
+          </td>
+          <td>
+            <ul>
+              <li>Invokes {#link|Peer Type Resolution#} for the operands.</li>
+            </ul>
+          </td>
+          <td>
+            <pre>{#syntax#}0b011 ^ 0b101 == 0b110{#endsyntax#}</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>Bitwise Not</td>
+          <td><pre>{#syntax#}~a{#endsyntax#}</pre></td>
+          <td>
+            <ul>
+              <li>{#link|Integers#}</li>
+            </ul>
+          </td>
+          <td></td>
+          <td>
+            <pre>{#syntax#}~@as(u8, 0b10101111) == 0b01010000{#endsyntax#}</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>Defaulting Optional Unwrap</td>
+          <td><pre>{#syntax#}a orelse b{#endsyntax#}</pre></td>
+          <td>
+            <ul>
+              <li>{#link|Optionals#}</li>
+            </ul>
+          </td>
+          <td>If {#syntax#}a{#endsyntax#} is {#syntax#}null{#endsyntax#},
+          returns {#syntax#}b{#endsyntax#} ("default value"),
+          otherwise returns the unwrapped value of {#syntax#}a{#endsyntax#}.
+          Note that {#syntax#}b{#endsyntax#} may be a value of type {#link|noreturn#}.
+          </td>
+          <td>
+            <pre>{#syntax#}const value: ?u32 = null;
+const unwrapped = value orelse 1234;
+unwrapped == 1234{#endsyntax#}</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>Optional Unwrap</td>
+          <td><pre>{#syntax#}a.?{#endsyntax#}</pre></td>
+          <td>
+            <ul>
+              <li>{#link|Optionals#}</li>
+            </ul>
+          </td>
+          <td>
+            Equivalent to:
+            <pre>{#syntax#}a orelse unreachable{#endsyntax#}</pre>
+          </td>
+          <td>
+            <pre>{#syntax#}const value: ?u32 = 5678;
+value.? == 5678{#endsyntax#}</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>Defaulting Error Unwrap</td>
+          <td><pre>{#syntax#}a catch b
+a catch |err| b{#endsyntax#}</pre></td>
+          <td>
+            <ul>
+              <li>{#link|Error Unions|Errors#}</li>
+            </ul>
+          </td>
+          <td>If {#syntax#}a{#endsyntax#} is an {#syntax#}error{#endsyntax#},
+          returns {#syntax#}b{#endsyntax#} ("default value"),
+          otherwise returns the unwrapped value of {#syntax#}a{#endsyntax#}.
+          Note that {#syntax#}b{#endsyntax#} may be a value of type {#link|noreturn#}.
+{#syntax#}err{#endsyntax#} is the {#syntax#}error{#endsyntax#} and is in scope of the expression {#syntax#}b{#endsyntax#}.
+          </td>
+          <td>
+            <pre>{#syntax#}const value: anyerror!u32 = error.Broken;
+const unwrapped = value catch 1234;
+unwrapped == 1234{#endsyntax#}</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>Logical And</td>
+          <td><pre>{#syntax#}a and b{#endsyntax#}</pre></td>
+          <td>
+            <ul>
+              <li>{#link|bool|Primitive Types#}</li>
+            </ul>
+          </td>
+          <td>
+          If {#syntax#}a{#endsyntax#} is {#syntax#}false{#endsyntax#}, returns {#syntax#}false{#endsyntax#}
+          without evaluating {#syntax#}b{#endsyntax#}. Otherwise, returns {#syntax#}b{#endsyntax#}.
+          </td>
+          <td>
+            <pre>{#syntax#}(false and true) == false{#endsyntax#}</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>Logical Or</td>
+          <td><pre>{#syntax#}a or b{#endsyntax#}</pre></td>
+          <td>
+            <ul>
+              <li>{#link|bool|Primitive Types#}</li>
+            </ul>
+          </td>
+          <td>
+              If {#syntax#}a{#endsyntax#} is {#syntax#}true{#endsyntax#},
+              returns {#syntax#}true{#endsyntax#} without evaluating
+              {#syntax#}b{#endsyntax#}. Otherwise, returns
+              {#syntax#}b{#endsyntax#}.
+          </td>
+          <td>
+            <pre>{#syntax#}(false or true) == true{#endsyntax#}</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>Boolean Not</td>
+          <td><pre>{#syntax#}!a{#endsyntax#}</pre></td>
+          <td>
+            <ul>
+              <li>{#link|bool|Primitive Types#}</li>
+            </ul>
+          </td>
+          <td></td>
+          <td>
+            <pre>{#syntax#}!false == true{#endsyntax#}</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>Equality</td>
+          <td><pre>{#syntax#}a == b{#endsyntax#}</pre></td>
+          <td>
+            <ul>
+              <li>{#link|Integers#}</li>
+              <li>{#link|Floats#}</li>
+              <li>{#link|bool|Primitive Types#}</li>
+              <li>{#link|type|Primitive Types#}</li>
+            </ul>
+          </td>
+          <td>
+              Returns {#syntax#}true{#endsyntax#} if a and b are equal, otherwise returns {#syntax#}false{#endsyntax#}.
+            Invokes {#link|Peer Type Resolution#} for the operands.
+          </td>
+          <td>
+            <pre>{#syntax#}(1 == 1) == true{#endsyntax#}</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>Null Check</td>
+          <td><pre>{#syntax#}a == null{#endsyntax#}</pre></td>
+          <td>
+            <ul>
+              <li>{#link|Optionals#}</li>
+            </ul>
+          </td>
+          <td>
+              Returns {#syntax#}true{#endsyntax#} if a is {#syntax#}null{#endsyntax#}, otherwise returns {#syntax#}false{#endsyntax#}.
+          </td>
+          <td>
+            <pre>{#syntax#}const value: ?u32 = null;
+(value == null) == true{#endsyntax#}</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>Inequality</td>
+          <td><pre>{#syntax#}a != b{#endsyntax#}</pre></td>
+          <td>
+            <ul>
+              <li>{#link|Integers#}</li>
+              <li>{#link|Floats#}</li>
+              <li>{#link|bool|Primitive Types#}</li>
+              <li>{#link|type|Primitive Types#}</li>
+            </ul>
+          </td>
+          <td>
+              Returns {#syntax#}false{#endsyntax#} if a and b are equal, otherwise returns {#syntax#}true{#endsyntax#}.
+            Invokes {#link|Peer Type Resolution#} for the operands.
+          </td>
+          <td>
+            <pre>{#syntax#}(1 != 1) == false{#endsyntax#}</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>Non-Null Check</td>
+          <td><pre>{#syntax#}a != null{#endsyntax#}</pre></td>
+          <td>
+            <ul>
+              <li>{#link|Optionals#}</li>
+            </ul>
+          </td>
+          <td>
+              Returns {#syntax#}false{#endsyntax#} if a is {#syntax#}null{#endsyntax#}, otherwise returns {#syntax#}true{#endsyntax#}.
+          </td>
+          <td>
+            <pre>{#syntax#}const value: ?u32 = null;
+(value != null) == false{#endsyntax#}</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>Greater Than</td>
+          <td><pre>{#syntax#}a > b{#endsyntax#}</pre></td>
+          <td>
+            <ul>
+              <li>{#link|Integers#}</li>
+              <li>{#link|Floats#}</li>
+            </ul>
+          </td>
+          <td>
+              Returns {#syntax#}true{#endsyntax#} if a is greater than b, otherwise returns {#syntax#}false{#endsyntax#}.
+            Invokes {#link|Peer Type Resolution#} for the operands.
+          </td>
+          <td>
+            <pre>{#syntax#}(2 > 1) == true{#endsyntax#}</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>Greater or Equal</td>
+          <td><pre>{#syntax#}a >= b{#endsyntax#}</pre></td>
+          <td>
+            <ul>
+              <li>{#link|Integers#}</li>
+              <li>{#link|Floats#}</li>
+            </ul>
+          </td>
+          <td>
+              Returns {#syntax#}true{#endsyntax#} if a is greater than or equal to b, otherwise returns {#syntax#}false{#endsyntax#}.
+            Invokes {#link|Peer Type Resolution#} for the operands.
+          </td>
+          <td>
+            <pre>{#syntax#}(2 >= 1) == true{#endsyntax#}</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>Less Than</td>
+          <td><pre>{#syntax#}a < b{#endsyntax#}</pre></td>
+          <td>
+            <ul>
+              <li>{#link|Integers#}</li>
+              <li>{#link|Floats#}</li>
+            </ul>
+          </td>
+          <td>
+              Returns {#syntax#}true{#endsyntax#} if a is less than b, otherwise returns {#syntax#}false{#endsyntax#}.
+            Invokes {#link|Peer Type Resolution#} for the operands.
+          </td>
+          <td>
+            <pre>{#syntax#}(1 < 2) == true{#endsyntax#}</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>Lesser or Equal</td>
+          <td><pre>{#syntax#}a <= b{#endsyntax#}</pre></td>
+          <td>
+            <ul>
+              <li>{#link|Integers#}</li>
+              <li>{#link|Floats#}</li>
+            </ul>
+          </td>
+          <td>
+              Returns {#syntax#}true{#endsyntax#} if a is less than or equal to b, otherwise returns {#syntax#}false{#endsyntax#}.
+            Invokes {#link|Peer Type Resolution#} for the operands.
+          </td>
+          <td>
+            <pre>{#syntax#}(1 <= 2) == true{#endsyntax#}</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>Array Concatenation</td>
+          <td><pre>{#syntax#}a ++ b{#endsyntax#}</pre></td>
+          <td>
+            <ul>
+              <li>{#link|Arrays#}</li>
+            </ul>
+          </td>
+          <td>
+            <ul>
+              <li>Only available when the lengths of both {#syntax#}a{#endsyntax#} and {#syntax#}b{#endsyntax#} are {#link|compile-time known|comptime#}.</li>
+            </ul>
+          </td>
+          <td>
+            <pre>{#syntax#}const mem = @import("std").mem;
+const array1 = [_]u32{1,2};
+const array2 = [_]u32{3,4};
+const together = array1 ++ array2;
+mem.eql(u32, &together, &[_]u32{1,2,3,4}){#endsyntax#}</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>Array Multiplication</td>
+          <td><pre>{#syntax#}a ** b{#endsyntax#}</pre></td>
+          <td>
+            <ul>
+              <li>{#link|Arrays#}</li>
+            </ul>
+          </td>
+          <td>
+            <ul>
+              <li>Only available when the length of {#syntax#}a{#endsyntax#} and {#syntax#}b{#endsyntax#} are {#link|compile-time known|comptime#}.</li>
+            </ul>
+          </td>
+          <td>
+            <pre>{#syntax#}const mem = @import("std").mem;
+const pattern = "ab" ** 3;
+mem.eql(u8, pattern, "ababab"){#endsyntax#}</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>Pointer Dereference</td>
+          <td><pre>{#syntax#}a.*{#endsyntax#}</pre></td>
+          <td>
+            <ul>
+              <li>{#link|Pointers#}</li>
+            </ul>
+          </td>
+          <td>
+            Pointer dereference.
+          </td>
+          <td>
+            <pre>{#syntax#}const x: u32 = 1234;
+const ptr = &x;
+ptr.* == 1234{#endsyntax#}</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>Address Of</td>
+          <td><pre>{#syntax#}&a{#endsyntax#}</pre></td>
+          <td>
+            All types
+          </td>
+          <td>
+          </td>
+          <td>
+            <pre>{#syntax#}const x: u32 = 1234;
+const ptr = &x;
+ptr.* == 1234{#endsyntax#}</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>Error Set Merge</td>
+          <td><pre>{#syntax#}a || b{#endsyntax#}</pre></td>
+          <td>
+            <ul>
+              <li>{#link|Error Set Type#}</li>
+            </ul>
+          </td>
+          <td>
+              {#link|Merging Error Sets#}
+          </td>
+          <td>
+            <pre>{#syntax#}const A = error{One};
+const B = error{Two};
+(A || B) == error{One, Two}{#endsyntax#}</pre>
+          </td>
+        </tr>
+        </tbody>
+      </table>
+      </div>
+      {#header_close#}
+      {#header_open|Precedence#}
+      <pre>{#syntax#}x() x[] x.y x.* x.?
+a!b
+x{}
+!x -x -%x ~x &x ?x
+* / % ** *% *| ||
++ - ++ +% -% +| -|
+<< >> <<|
+& ^ | orelse catch
+== != < > <= >=
+and
+or
+= *= *%= *|= /= %= += +%= +|= -= -%= -|= <<= <<|= >>= &= ^= |={#endsyntax#}</pre>
+      {#header_close#}
+      {#header_close#}
+      {#header_open|Arrays#}
+      {#code|test_arrays.zig#}
+
+      {#see_also|for|Slices#}
+
+      {#header_open|Multidimensional Arrays#}
+      <p>
+      Multidimensional arrays can be created by nesting arrays:
+      </p>
+      {#code|test_multidimensional_arrays.zig#}
+
+      {#header_close#}
+
+      {#header_open|Sentinel-Terminated Arrays#}
+      <p>
+      The syntax {#syntax#}[N:x]T{#endsyntax#} describes an array which has a sentinel element of value {#syntax#}x{#endsyntax#} at the
+      index corresponding to the length {#syntax#}N{#endsyntax#}.
+      </p>
+      {#code|test_null_terminated_array.zig#}
+
+      {#see_also|Sentinel-Terminated Pointers|Sentinel-Terminated Slices#}
+      {#header_close#}
+
+      {#header_open|Destructuring Arrays#}
+      <p>
+        Arrays can be destructured:
+      </p>
+      {#code|destructuring_arrays.zig#}
+
+      {#see_also|Destructuring|Destructuring Tuples|Destructuring Vectors#}
+      {#header_close#}
+      {#header_close#}
+
+      {#header_open|Vectors#}
+      <p>
+      A vector is a group of booleans, {#link|Integers#}, {#link|Floats#}, or
+      {#link|Pointers#} which are operated on in parallel, using SIMD instructions if possible.
+      Vector types are created with the builtin function {#link|@Vector#}.
+      </p>
+      <p>
+      Vectors support the same builtin operators as their underlying base types.
+      These operations are performed element-wise, and return a vector of the same length
+      as the input vectors. This includes:
+      </p>
+      <ul>
+          <li>Arithmetic ({#syntax#}+{#endsyntax#}, {#syntax#}-{#endsyntax#}, {#syntax#}/{#endsyntax#}, {#syntax#}*{#endsyntax#},
+                         {#syntax#}@divFloor{#endsyntax#}, {#syntax#}@sqrt{#endsyntax#}, {#syntax#}@ceil{#endsyntax#},
+                         {#syntax#}@log{#endsyntax#}, etc.)</li>
+          <li>Bitwise operators ({#syntax#}>>{#endsyntax#}, {#syntax#}<<{#endsyntax#}, {#syntax#}&{#endsyntax#},
+                                 {#syntax#}|{#endsyntax#}, {#syntax#}~{#endsyntax#}, etc.)</li>
+          <li>Comparison operators ({#syntax#}<{#endsyntax#}, {#syntax#}>{#endsyntax#}, {#syntax#}=={#endsyntax#}, etc.)</li>
+      </ul>
+      <p>
+      It is prohibited to use a math operator on a mixture of scalars (individual numbers)
+      and vectors. Zig provides the {#link|@splat#} builtin to easily convert from scalars
+      to vectors, and it supports {#link|@reduce#} and array indexing syntax to convert
+      from vectors to scalars. Vectors also support assignment to and from fixed-length
+      arrays with comptime-known length.
+      </p>
+      <p>
+      For rearranging elements within and between vectors, Zig provides the {#link|@shuffle#} and {#link|@select#} functions.
+      </p>
+      <p>
+      Operations on vectors shorter than the target machine's native SIMD size will typically compile to single SIMD
+      instructions, while vectors longer than the target machine's native SIMD size will compile to multiple SIMD
+      instructions. If a given operation doesn't have SIMD support on the target architecture, the compiler will default
+      to operating on each vector element one at a time. Zig supports any comptime-known vector length up to 2^32-1,
+      although small powers of two (2-64) are most typical. Note that excessively long vector lengths (e.g. 2^20) may
+      result in compiler crashes on current versions of Zig.
+      </p>
+      {#code|test_vector.zig#}
+
+      <p>
+      TODO talk about C ABI interop<br>
+      TODO consider suggesting std.MultiArrayList
+      </p>
+      {#see_also|@splat|@shuffle|@select|@reduce#}
+
+      {#header_open|Destructuring Vectors#}
+      <p>
+        Vectors can be destructured:
+      </p>
+      {#code|destructuring_vectors.zig#}
+      {#see_also|Destructuring|Destructuring Tuples|Destructuring Arrays#}
+      {#header_close#}
+
+      {#header_close#}
+
+      {#header_open|Pointers#}
+      <p>
+      Zig has two kinds of pointers: single-item and many-item.
+      </p>
+      <ul>
+          <li>{#syntax#}*T{#endsyntax#} - single-item pointer to exactly one item.
+            <ul>
+              <li>Supports deref syntax: {#syntax#}ptr.*{#endsyntax#}</li>
+              <li>Supports slice syntax: {#syntax#}ptr[0..1]{#endsyntax#}</li>
+              <li>Supports pointer subtraction: {#syntax#}ptr - ptr{#endsyntax#}</li>
+            </ul>
+          </li>
+          <li>{#syntax#}[*]T{#endsyntax#} - many-item pointer to unknown number of items.
+            <ul>
+              <li>Supports index syntax: {#syntax#}ptr[i]{#endsyntax#}</li>
+              <li>Supports slice syntax: {#syntax#}ptr[start..end]{#endsyntax#} and {#syntax#}ptr[start..]{#endsyntax#}</li>
+              <li>Supports pointer-integer arithmetic: {#syntax#}ptr + int{#endsyntax#}, {#syntax#}ptr - int{#endsyntax#}</li>
+              <li>Supports pointer subtraction: {#syntax#}ptr - ptr{#endsyntax#}</li>
+            </ul>
+            {#syntax#}T{#endsyntax#} must have a known size, which means that it cannot be
+            {#syntax#}anyopaque{#endsyntax#} or any other {#link|opaque type|opaque#}.
+          </li>
+      </ul>
+      <p>These types are closely related to {#link|Arrays#} and {#link|Slices#}:</p>
+        <ul>
+            <li>{#syntax#}*[N]T{#endsyntax#} - pointer to N items, same as single-item pointer to an array.
+            <ul>
+                <li>Supports index syntax: {#syntax#}array_ptr[i]{#endsyntax#}</li>
+                <li>Supports slice syntax: {#syntax#}array_ptr[start..end]{#endsyntax#}</li>
+                <li>Supports len property: {#syntax#}array_ptr.len{#endsyntax#}</li>
+                <li>Supports pointer subtraction: {#syntax#}array_ptr - array_ptr{#endsyntax#}</li>
+            </ul>
+            </li>
+        </ul>
+        <ul>
+            <li>{#syntax#}[]T{#endsyntax#} - is a slice (a fat pointer, which contains a pointer of type {#syntax#}[*]T{#endsyntax#} and a length).
+            <ul>
+                <li>Supports index syntax: {#syntax#}slice[i]{#endsyntax#}</li>
+                <li>Supports slice syntax: {#syntax#}slice[start..end]{#endsyntax#}</li>
+                <li>Supports len property: {#syntax#}slice.len{#endsyntax#}</li>
+            </ul>
+            </li>
+        </ul>
+        <p>Use {#syntax#}&x{#endsyntax#} to obtain a single-item pointer:</p>
+      {#code|test_single_item_pointer.zig#}
+
+      <p>
+       Zig supports pointer arithmetic. It's better to assign the pointer to {#syntax#}[*]T{#endsyntax#} and increment that variable. For example, directly incrementing the pointer from a slice will corrupt it.
+      </p>
+      {#code|test_pointer_arithmetic.zig#}
+
+      <p>
+        In Zig, we generally prefer {#link|Slices#} rather than {#link|Sentinel-Terminated Pointers#}.
+        You can turn an array or pointer into a slice using slice syntax.
+      </p>
+      <p>
+        Slices have bounds checking and are therefore protected
+        against this kind of Illegal Behavior. This is one reason
+        we prefer slices to pointers.
+      </p>
+      {#code|test_slice_bounds.zig#}
+
+      <p>Pointers work at compile-time too, as long as the code does not depend on
+      an undefined memory layout:</p>
+      {#code|test_comptime_pointers.zig#}
+
+      <p>To convert an integer address into a pointer, use {#syntax#}@ptrFromInt{#endsyntax#}.
+      To convert a pointer to an integer, use {#syntax#}@intFromPtr{#endsyntax#}:</p>
+      {#code|test_integer_pointer_conversion.zig#}
+
+      <p>Zig is able to preserve memory addresses in comptime code, as long as
+      the pointer is never dereferenced:</p>
+      {#code|test_comptime_pointer_conversion.zig#}
+
+      <p>
+      {#link|@ptrCast#} converts a pointer's element type to another. This
+      creates a new pointer that can cause undetectable Illegal Behavior
+      depending on the loads and stores that pass through it. Generally, other
+      kinds of type conversions are preferable to
+      {#syntax#}@ptrCast{#endsyntax#} if possible.
+      </p>
+      {#code|test_pointer_casting.zig#}
+
+      {#see_also|Optional Pointers|@ptrFromInt|@intFromPtr|C Pointers#}
+      {#header_open|volatile#}
+      <p>Loads and stores are assumed to not have side effects. If a given load or store
+      should have side effects, such as Memory Mapped Input/Output (MMIO), use {#syntax#}volatile{#endsyntax#}.
+      In the following code, loads and stores with {#syntax#}mmio_ptr{#endsyntax#} are guaranteed to all happen
+      and in the same order as in source code:</p>
+      {#code|test_volatile.zig#}
+
+      <p>
+      Note that {#syntax#}volatile{#endsyntax#} is unrelated to concurrency and {#link|Atomics#}.
+      If you see code that is using {#syntax#}volatile{#endsyntax#} for something other than Memory Mapped
+      Input/Output, it is probably a bug.
+      </p>
+      {#header_close#}
+
+      {#header_open|Alignment#}
+      <p>
+      Each type has an <strong>alignment</strong> - a number of bytes such that,
+      when a value of the type is loaded from or stored to memory,
+      the memory address must be evenly divisible by this number. You can use
+      {#link|@alignOf#} to find out this value for any type.
+      </p>
+      <p>
+      Alignment depends on the CPU architecture, but is always a power of two, and
+      less than {#syntax#}1 << 29{#endsyntax#}.
+      </p>
+      <p>
+      In Zig, a pointer type has an alignment value. If the value is equal to the
+      alignment of the underlying type, it can be omitted from the type:
+      </p>
+      {#code|test_variable_alignment.zig#}
+
+      <p>In the same way that a {#syntax#}*i32{#endsyntax#} can be {#link|coerced|Type Coercion#} to a
+          {#syntax#}*const i32{#endsyntax#}, a pointer with a larger alignment can be implicitly
+      cast to a pointer with a smaller alignment, but not vice versa.
+      </p>
+      <p>
+      You can specify alignment on variables and functions. If you do this, then
+      pointers to them get the specified alignment:
+      </p>
+      {#code|test_variable_func_alignment.zig#}
+
+      <p>
+      If you have a pointer or a slice that has a small alignment, but you know that it actually
+      has a bigger alignment, use {#link|@alignCast#} to change the
+      pointer into a more aligned pointer. This is a no-op at runtime, but inserts a
+      {#link|safety check|Incorrect Pointer Alignment#}:
+      </p>
+      {#code|test_incorrect_pointer_alignment.zig#}
+
+      {#header_close#}
+
+      {#header_open|allowzero#}
+      <p>
+      This pointer attribute allows a pointer to have address zero. This is only ever needed on the
+      freestanding OS target, where the address zero is mappable. If you want to represent null pointers, use
+      {#link|Optional Pointers#} instead. {#link|Optional Pointers#} with {#syntax#}allowzero{#endsyntax#}
+      are not the same size as pointers. In this code example, if the pointer
+      did not have the {#syntax#}allowzero{#endsyntax#} attribute, this would be a
+      {#link|Pointer Cast Invalid Null#} panic:
+      </p>
+      {#code|test_allowzero.zig#}
+
+      {#header_close#}
+
+      {#header_open|Sentinel-Terminated Pointers#}
+      <p>
+      The syntax {#syntax#}[*:x]T{#endsyntax#} describes a pointer that
+      has a length determined by a sentinel value. This provides protection
+      against buffer overflow and overreads.
+      </p>
+      {#code|sentinel-terminated_pointer.zig#}
+
+      {#see_also|Sentinel-Terminated Slices|Sentinel-Terminated Arrays#}
+      {#header_close#}
+      {#header_close#}
+
+      {#header_open|Slices#}
+      <p>
+      A slice is a pointer and a length. The difference between an array and
+      a slice is that the array's length is part of the type and known at
+      compile-time, whereas the slice's length is known at runtime.
+      Both can be accessed with the {#syntax#}len{#endsyntax#} field.
+      </p>
+      {#code|test_basic_slices.zig#}
+
+      <p>This is one reason we prefer slices to pointers.</p>
+      {#code|test_slices.zig#}
+
+      {#see_also|Pointers|for|Arrays#}
+
+      {#header_open|Sentinel-Terminated Slices#}
+      <p>
+      The syntax {#syntax#}[:x]T{#endsyntax#} is a slice which has a runtime-known length
+      and also guarantees a sentinel value at the element indexed by the length. The type does not
+      guarantee that there are no sentinel elements before that. Sentinel-terminated slices allow element
+      access to the {#syntax#}len{#endsyntax#} index.
+      </p>
+      {#code|test_null_terminated_slice.zig#}
+
+      <p>
+      Sentinel-terminated slices can also be created using a variation of the slice syntax
+      {#syntax#}data[start..end :x]{#endsyntax#}, where {#syntax#}data{#endsyntax#} is a many-item pointer,
+      array or slice and {#syntax#}x{#endsyntax#} is the sentinel value.
+      </p>
+      {#code|test_null_terminated_slicing.zig#}
+
+      <p>
+      Sentinel-terminated slicing asserts that the element in the sentinel position of the backing data is
+      actually the sentinel value. If this is not the case, safety-checked {#link|Illegal Behavior#} results.
+      </p>
+      {#code|test_sentinel_mismatch.zig#}
+
+      {#see_also|Sentinel-Terminated Pointers|Sentinel-Terminated Arrays#}
+      {#header_close#}
+      {#header_close#}
+
+      {#header_open|struct#}
+      {#code|test_structs.zig#}
+
+
+      {#header_open|Default Field Values#}
+      <p>
+      Each struct field may have an expression indicating the default field
+      value. Such expressions are executed at {#link|comptime#}, and allow the
+      field to be omitted in a struct literal expression:
+      </p>
+      {#code|struct_default_field_values.zig#}
+
+      {#header_open|Faulty Default Field Values#}
+      <p>
+      Default field values are only appropriate when the data invariants of a struct
+      cannot be violated by omitting that field from an initialization.
+      </p>
+      <p>
+      For example, here is an inappropriate use of default struct field initialization:
+      </p>
+      {#code|bad_default_value.zig#}
+
+      <p>
+      Above you can see the danger of ignoring this principle. The default
+      field values caused the data invariant to be violated, causing illegal
+      behavior.
+      </p>
+      <p>
+      To fix this, remove the default values from all the struct fields, and provide
+      a named default value:
+      </p>
+      {#code|struct_default_value.zig#}
+
+      <p>If a struct value requires a runtime-known value in order to be initialized
+      without violating data invariants, then use an initialization method that accepts
+      those runtime values, and populates the remaining fields.</p>
+      {#header_close#}
+      {#header_close#}
+
+      {#header_open|extern struct#}
+      <p>An {#syntax#}extern struct{#endsyntax#} has in-memory layout matching
+      the C ABI for the target.</p>
+      <p>If well-defined in-memory layout is not required, {#link|struct#} is a better choice
+      because it places fewer restrictions on the compiler.</p>
+      <p>See {#link|packed struct#} for a struct that has the ABI of its backing integer,
+      which can be useful for modeling flags.</p>
+      {#see_also|extern union|extern enum#}
+      {#header_close#}
+
+      {#header_open|packed struct#}
+      <p>
+      Unlike normal structs, {#syntax#}packed{#endsyntax#} structs have guaranteed in-memory layout:
+      </p>
+      <ul>
+        <li>Fields remain in the order declared, least to most significant.</li>
+        <li>There is no padding between fields.</li>
+        <li>Zig supports arbitrary width {#link|Integers#} and although normally, integers with fewer
+        than 8 bits will still use 1 byte of memory, in packed structs, they use
+        exactly their bit width.
+        </li>
+        <li>{#syntax#}bool{#endsyntax#} fields use exactly 1 bit.</li>
+        <li>An {#link|enum#} field uses exactly the bit width of its integer tag type.</li>
+        <li>A {#link|packed union#} field uses exactly the bit width of the union field with
+        the largest bit width.</li>
+        <li>Packed structs support equality operators.</li>
+      </ul>
+      <p>
+      This means that a {#syntax#}packed struct{#endsyntax#} can participate
+      in a {#link|@bitCast#} or a {#link|@ptrCast#} to reinterpret memory.
+      This even works at {#link|comptime#}:
+      </p>
+      {#code|test_packed_structs.zig#}
+
+      <p>
+      The backing integer is inferred from the fields' total bit width.
+      Optionally, it can be explicitly provided and enforced at compile time:
+      </p>
+      {#code|test_missized_packed_struct.zig#}
+
+      <p>
+      Zig allows the address to be taken of a non-byte-aligned field:
+      </p>
+      {#code|test_pointer_to_non-byte_aligned_field.zig#}
+
+      <p>
+      However, the pointer to a non-byte-aligned field has special properties and cannot
+      be passed when a normal pointer is expected:
+      </p>
+      {#code|test_misaligned_pointer.zig#}
+
+      <p>
+      In this case, the function {#syntax#}bar{#endsyntax#} cannot be called because the pointer
+      to the non-ABI-aligned field mentions the bit offset, but the function expects an ABI-aligned pointer.
+      </p>
+      <p>
+      Pointers to non-ABI-aligned fields share the same address as the other fields within their host integer:
+      </p>
+      {#code|test_packed_struct_field_address.zig#}
+
+      <p>
+      This can be observed with {#link|@bitOffsetOf#} and {#link|offsetOf#}:
+      </p>
+      {#code|test_bitOffsetOf_offsetOf.zig#}
+
+      <p>
+      Packed structs have the same alignment as their backing integer, however, overaligned
+      pointers to packed structs can override this:
+      </p>
+      {#code|test_overaligned_packed_struct.zig#}
+
+      <p>
+      It's also possible to set alignment of struct fields:
+      </p>
+      {#code|test_aligned_struct_fields.zig#}
+
+      <p>
+      Equating packed structs results in a comparison of the backing integer, 
+      and only works for the `==` and `!=` operators.
+      </p>
+      {#code|test_packed_struct_equality.zig#}
+
+      <p>
+      Using packed structs with {#link|volatile#} is problematic, and may be a compile error in the future.
+      For details on this subscribe to
+      <a href="https://github.com/ziglang/zig/issues/1761">this issue</a>.
+      TODO update these docs with a recommendation on how to use packed structs with MMIO
+      (the use case for volatile packed structs) once this issue is resolved.
+      Don't worry, there will be a good solution for this use case in zig.
+      </p>
+      {#header_close#}
+
+      {#header_open|Struct Naming#}
+      <p>Since all structs are anonymous, Zig infers the type name based on a few rules.</p>
+      <ul>
+          <li>If the struct is in the initialization expression of a variable, it gets named after
+          that variable.</li>
+          <li>If the struct is in the {#syntax#}return{#endsyntax#} expression, it gets named after
+          the function it is returning from, with the parameter values serialized.</li>
+          <li>Otherwise, the struct gets a name such as <code>(filename.funcname__struct_ID)</code>.</li>
+          <li>If the struct is declared inside another struct, it gets named after both the parent
+          struct and the name inferred by the previous rules, separated by a dot.</li>
+      </ul>
+      {#code|struct_name.zig#}
+
+      {#header_close#}
+
+      {#header_open|Anonymous Struct Literals#}
+      <p>
+      Zig allows omitting the struct type of a literal. When the result is {#link|coerced|Type Coercion#},
+      the struct literal will directly instantiate the {#link|result location|Result Location Semantics#},
+      with no copy:
+      </p>
+      {#code|test_struct_result.zig#}
+
+      <p>
+      The struct type can be inferred. Here the {#link|result location|Result Location Semantics#}
+      does not include a type, and so Zig infers the type:
+      </p>
+      {#code|test_anonymous_struct.zig#}
+
+      {#header_close#}
+
+      {#header_open|Tuples#}
+      <p>
+      Anonymous structs can be created without specifying field names, and are referred to as "tuples". An empty tuple looks like <code>.{}</code> and can be seen in one of the {#link|Hello World examples|Hello World#}.
+      </p>
+      <p>
+      The fields are implicitly named using numbers starting from 0. Because their names are integers,
+      they cannot be accessed with {#syntax#}.{#endsyntax#} syntax without also wrapping them in
+      {#syntax#}@""{#endsyntax#}. Names inside {#syntax#}@""{#endsyntax#} are always recognised as
+      {#link|identifiers|Identifiers#}.
+      </p>
+      <p>
+      Like arrays, tuples have a .len field, can be indexed (provided the index is comptime-known)
+      and work with the ++ and ** operators. They can also be iterated over with {#link|inline for#}.
+      </p>
+      {#code|test_tuples.zig#}
+
+      {#header_open|Destructuring Tuples#}
+      <p>
+        Tuples can be {#link|destructured|Destructuring#}.
+      </p>
+      <p>
+        Tuple destructuring is helpful for returning multiple values from a block:
+      </p>
+      {#code|destructuring_block.zig#}
+
+      <p>
+        Tuple destructuring is helpful for dealing with functions and built-ins that return multiple values
+        as a tuple:
+      </p>
+      {#code|destructuring_return_value.zig#}
+
+      {#see_also|Destructuring|Destructuring Arrays|Destructuring Vectors#}
+      {#header_close#}
+      {#header_close#}
+      {#see_also|comptime|@fieldParentPtr#}
+      {#header_close#}
+      {#header_open|enum#}
+      {#code|test_enums.zig#}
+
+      {#see_also|@typeInfo|@tagName|@sizeOf#}
+
+      {#header_open|extern enum#}
+      <p>
+      By default, enums are not guaranteed to be compatible with the C ABI:
+      </p>
+      {#code|enum_export_error.zig#}
+
+      <p>
+      For a C-ABI-compatible enum, provide an explicit tag type to
+      the enum:
+      </p>
+      {#code|enum_export.zig#}
+
+      {#header_close#}
+
+      {#header_open|Enum Literals#}
+      <p>
+      Enum literals allow specifying the name of an enum field without specifying the enum type:
+      </p>
+      {#code|test_enum_literals.zig#}
+
+      {#header_close#}
+
+      {#header_open|Non-exhaustive enum#}
+      <p>
+      A non-exhaustive enum can be created by adding a trailing {#syntax#}_{#endsyntax#} field.
+      The enum must specify a tag type and cannot consume every enumeration value.
+      </p>
+      <p>
+      {#link|@enumFromInt#} on a non-exhaustive enum involves the safety semantics
+      of {#link|@intCast#} to the integer tag type, but beyond that always results in
+      a well-defined enum value.
+      </p>
+      <p>
+      A switch on a non-exhaustive enum can include a {#syntax#}_{#endsyntax#} prong as an alternative to an {#syntax#}else{#endsyntax#} prong.
+      With a {#syntax#}_{#endsyntax#} prong the compiler errors if all the known tag names are not handled by the switch.
+      </p>
+      {#code|test_switch_non-exhaustive.zig#}
+
+      {#header_close#}
+      {#header_close#}
+
+      {#header_open|union#}
+      <p>
+      A bare {#syntax#}union{#endsyntax#} defines a set of possible types that a value
+      can be as a list of fields. Only one field can be active at a time.
+      The in-memory representation of bare unions is not guaranteed.
+      Bare unions cannot be used to reinterpret memory. For that, use {#link|@ptrCast#},
+      or use an {#link|extern union#} or a {#link|packed union#} which have
+      guaranteed in-memory layout.
+      {#link|Accessing the non-active field|Wrong Union Field Access#} is
+      safety-checked {#link|Illegal Behavior#}:
+      </p>
+      {#code|test_wrong_union_access.zig#}
+
+      <p>You can activate another field by assigning the entire union:</p>
+      {#code|test_simple_union.zig#}
+
+      <p>
+      In order to use {#link|switch#} with a union, it must be a {#link|Tagged union#}.
+      </p>
+      <p>
+      To initialize a union when the tag is a {#link|comptime#}-known name, see {#link|@unionInit#}.
+      </p>
+
+      {#header_open|Tagged union#}
+      <p>Unions can be declared with an enum tag type.
+      This turns the union into a <em>tagged</em> union, which makes it eligible
+      to use with {#link|switch#} expressions.
+      Tagged unions coerce to their tag type: {#link|Type Coercion: Unions and Enums#}.
+      </p>
+      {#code|test_tagged_union.zig#}
+
+      <p>In order to modify the payload of a tagged union in a switch expression,
+      place a {#syntax#}*{#endsyntax#} before the variable name to make it a pointer:
+      </p>
+      {#code|test_switch_modify_tagged_union.zig#}
+
+      <p>
+      Unions can be made to infer the enum tag type.
+      Further, unions can have methods just like structs and enums.
+      </p>
+      {#code|test_union_method.zig#}
+
+      <p>
+      {#link|@tagName#} can be used to return a {#link|comptime#}
+      {#syntax#}[:0]const u8{#endsyntax#} value representing the field name:
+      </p>
+      {#code|test_tagName.zig#}
+
+      {#header_close#}
+
+      {#header_open|extern union#}
+      <p>
+      An {#syntax#}extern union{#endsyntax#} has memory layout guaranteed to be compatible with
+      the target C ABI.
+      </p>
+      {#see_also|extern struct#}
+      {#header_close#}
+
+      {#header_open|packed union#}
+      <p>A {#syntax#}packed union{#endsyntax#} has well-defined in-memory layout and is eligible
+          to be in a {#link|packed struct#}.</p>
+      {#header_close#}
+
+      {#header_open|Anonymous Union Literals#}
+      <p>{#link|Anonymous Struct Literals#} syntax can be used to initialize unions without specifying
+      the type:</p>
+      {#code|test_anonymous_union.zig#}
+
+      {#header_close#}
+
+      {#header_close#}
+
+      {#header_open|opaque#}
+      <p>
+      {#syntax#}opaque {}{#endsyntax#} declares a new type with an unknown (but non-zero) size and alignment.
+      It can contain declarations the same as {#link|structs|struct#}, {#link|unions|union#},
+      and {#link|enums|enum#}.
+      </p>
+      <p>
+      This is typically used for type safety when interacting with C code that does not expose struct details.
+      Example:
+      </p>
+      {#code|test_opaque.zig#}
+
+      {#header_close#}
+
+      {#header_open|Blocks#}
+      <p>
+      Blocks are used to limit the scope of variable declarations:
+      </p>
+      {#code|test_blocks.zig#}
+
+      <p>Blocks are expressions. When labeled, {#syntax#}break{#endsyntax#} can be used
+      to return a value from the block:
+      </p>
+      {#code|test_labeled_break.zig#}
+
+      <p>Here, {#syntax#}blk{#endsyntax#} can be any name.</p>
+      {#see_also|Labeled while|Labeled for#}
+
+      {#header_open|Shadowing#}
+      <p>{#link|Identifiers#} are never allowed to "hide" other identifiers by using the same name:</p>
+      {#code|test_shadowing.zig#}
+
+      <p>
+      Because of this, when you read Zig code you can always rely on an identifier to consistently mean
+      the same thing within the scope it is defined. Note that you can, however, use the same name if
+      the scopes are separate:
+      </p>
+      {#code|test_scopes.zig#}
+
+      {#header_close#}
+
+      {#header_open|Empty Blocks#}
+      <p>An empty block is equivalent to {#syntax#}void{}{#endsyntax#}:</p>
+      {#code|test_empty_block.zig#}
+
+      {#header_close#}
+      {#header_close#}
+
+      {#header_open|switch#}
+      {#code|test_switch.zig#}
+
+      <p>
+      {#syntax#}switch{#endsyntax#} can be used to capture the field values
+      of a {#link|Tagged union#}. Modifications to the field values can be
+      done by placing a {#syntax#}*{#endsyntax#} before the capture variable name,
+      turning it into a pointer.
+      </p>
+      {#code|test_switch_tagged_union.zig#}
+
+      {#see_also|comptime|enum|@compileError|Compile Variables#}
+
+      {#header_open|Exhaustive Switching#}
+      <p>
+      When a {#syntax#}switch{#endsyntax#} expression does not have an {#syntax#}else{#endsyntax#} clause,
+      it must exhaustively list all the possible values. Failure to do so is a compile error:
+      </p>
+      {#code|test_unhandled_enumeration_value.zig#}
+
+      {#header_close#}
+
+      {#header_open|Switching with Enum Literals#}
+      <p>
+      {#link|Enum Literals#} can be useful to use with {#syntax#}switch{#endsyntax#} to avoid
+      repetitively specifying {#link|enum#} or {#link|union#} types:
+      </p>
+      {#code|test_exhaustive_switch.zig#}
+
+      {#header_close#}
+
+      {#header_open|Labeled switch#}
+      <p>
+      When a switch statement is labeled, it can be referenced from a
+      {#syntax#}break{#endsyntax#} or {#syntax#}continue{#endsyntax#}.
+      {#syntax#}break{#endsyntax#} will return a value from the {#syntax#}
+      switch{#endsyntax#}.
+      </p>
+      <p>
+      A {#syntax#}continue{#endsyntax#} targeting a switch must have an
+      operand. When executed, it will jump to the matching prong, as if the
+      {#syntax#}switch{#endsyntax#} were executed again with the {#syntax#}
+      continue{#endsyntax#}'s operand replacing the initial switch value.
+      </p>
+
+      {#code|test_switch_continue.zig#}
+
+      <p>
+      Semantically, this is equivalent to the following loop:
+      </p>
+      {#code|test_switch_continue_equivalent.zig#}
+
+      <p>
+      This can improve clarity of (for example) state machines, where the syntax {#syntax#}continue :sw .next_state{#endsyntax#} is unambiguous, explicit, and immediately understandable.
+      </p>
+      <p>
+      However, the motivating example is a switch on each element of an array, where using a single switch can improve clarity and performance:
+      </p>
+      {#code|test_switch_dispatch_loop.zig#}
+
+      <p>
+      If the operand to {#syntax#}continue{#endsyntax#} is
+      {#link|comptime#}-known, then it can be lowered to an unconditional branch
+      to the relevant case. Such a branch is perfectly predicted, and hence
+      typically very fast to execute.
+      </p>
+
+      <p>
+      If the operand is runtime-known, each {#syntax#}continue{#endsyntax#} can
+      embed a conditional branch inline (ideally through a jump table), which
+      allows a CPU to predict its target independently of any other prong. A
+      loop-based lowering would force every branch through the same dispatch
+      point, hindering branch prediction.
+      </p>
+
+
+      {#header_close#}
+
+      {#header_open|Inline Switch Prongs#}
+      <p>
+      Switch prongs can be marked as {#syntax#}inline{#endsyntax#} to generate
+      the prong's body for each possible value it could have, making the
+      captured value {#link|comptime#}.
+      </p>
+      {#code|test_inline_switch.zig#}
+
+      <p>The {#syntax#}inline{#endsyntax#} keyword may also be combined with ranges:</p>
+      {#code|inline_prong_range.zig#}
+
+      <p>
+      {#syntax#}inline else{#endsyntax#} prongs can be used as a type safe
+      alternative to {#syntax#}inline for{#endsyntax#} loops:
+      </p>
+      {#code|test_inline_else.zig#}
+
+      <p>
+      When using an inline prong switching on an union an additional
+      capture can be used to obtain the union's enum tag value.
+      </p>
+      {#code|test_inline_switch_union_tag.zig#}
+
+      {#see_also|inline while|inline for#}
+      {#header_close#}
+      {#header_close#}
+
+      {#header_open|while#}
+      <p>
+      A while loop is used to repeatedly execute an expression until
+      some condition is no longer true.
+      </p>
+      {#code|test_while.zig#}
+
+      <p>
+      Use {#syntax#}break{#endsyntax#} to exit a while loop early.
+      </p>
+      {#code|test_while_break.zig#}
+
+      <p>
+      Use {#syntax#}continue{#endsyntax#} to jump back to the beginning of the loop.
+      </p>
+      {#code|test_while_continue.zig#}
+
+      <p>
+      While loops support a continue expression which is executed when the loop
+      is continued. The {#syntax#}continue{#endsyntax#} keyword respects this expression.
+      </p>
+      {#code|test_while_continue_expression.zig#}
+
+      <p>
+      While loops are expressions. The result of the expression is the
+      result of the {#syntax#}else{#endsyntax#} clause of a while loop, which is executed when
+      the condition of the while loop is tested as false.
+      </p>
+      <p>
+      {#syntax#}break{#endsyntax#}, like {#syntax#}return{#endsyntax#}, accepts a value
+              parameter. This is the result of the {#syntax#}while{#endsyntax#} expression.
+                  When you {#syntax#}break{#endsyntax#} from a while loop, the {#syntax#}else{#endsyntax#} branch is not
+      evaluated.
+      </p>
+      {#code|test_while_else.zig#}
+
+      {#header_open|Labeled while#}
+      <p>When a {#syntax#}while{#endsyntax#} loop is labeled, it can be referenced from a {#syntax#}break{#endsyntax#}
+              or {#syntax#}continue{#endsyntax#} from within a nested loop:</p>
+      {#code|test_while_nested_break.zig#}
+
+      {#header_close#}
+      {#header_open|while with Optionals#}
+      <p>
+      Just like {#link|if#} expressions, while loops can take an optional as the
+      condition and capture the payload. When {#link|null#} is encountered the loop
+      exits.
+      </p>
+      <p>
+      When the {#syntax#}|x|{#endsyntax#} syntax is present on a {#syntax#}while{#endsyntax#} expression,
+      the while condition must have an {#link|Optional Type#}.
+      </p>
+      <p>
+      The {#syntax#}else{#endsyntax#} branch is allowed on optional iteration. In this case, it will
+      be executed on the first null value encountered.
+      </p>
+      {#code|test_while_null_capture.zig#}
+
+      {#header_close#}
+
+      {#header_open|while with Error Unions#}
+      <p>
+      Just like {#link|if#} expressions, while loops can take an error union as
+      the condition and capture the payload or the error code. When the
+      condition results in an error code the else branch is evaluated and
+      the loop is finished.
+      </p>
+      <p>
+      When the {#syntax#}else |x|{#endsyntax#} syntax is present on a {#syntax#}while{#endsyntax#} expression,
+      the while condition must have an {#link|Error Union Type#}.
+      </p>
+      {#code|test_while_error_capture.zig#}
+
+      {#header_close#}
+
+      {#header_open|inline while#}
+      <p>
+      While loops can be inlined. This causes the loop to be unrolled, which
+      allows the code to do some things which only work at compile time,
+      such as use types as first class values.
+      </p>
+      {#code|test_inline_while.zig#}
+
+      <p>
+      It is recommended to use {#syntax#}inline{#endsyntax#} loops only for one of these reasons:
+      </p>
+      <ul>
+        <li>You need the loop to execute at {#link|comptime#} for the semantics to work.</li>
+        <li>
+        You have a benchmark to prove that forcibly unrolling the loop in this way is measurably faster.
+        </li>
+      </ul>
+      {#header_close#}
+      {#see_also|if|Optionals|Errors|comptime|unreachable#}
+      {#header_close#}
+      {#header_open|for#}
+      {#code|test_for.zig#}
+
+      {#header_open|Labeled for#}
+      <p>When a {#syntax#}for{#endsyntax#} loop is labeled, it can be referenced from a {#syntax#}break{#endsyntax#}
+              or {#syntax#}continue{#endsyntax#} from within a nested loop:</p>
+      {#code|test_for_nested_break.zig#}
+
+      {#header_close#}
+      {#header_open|inline for#}
+      <p>
+      For loops can be inlined. This causes the loop to be unrolled, which
+      allows the code to do some things which only work at compile time,
+      such as use types as first class values.
+      The capture value and iterator value of inlined for loops are
+      compile-time known.
+      </p>
+      {#code|test_inline_for.zig#}
+
+      <p>
+      It is recommended to use {#syntax#}inline{#endsyntax#} loops only for one of these reasons:
+      </p>
+      <ul>
+        <li>You need the loop to execute at {#link|comptime#} for the semantics to work.</li>
+        <li>
+        You have a benchmark to prove that forcibly unrolling the loop in this way is measurably faster.
+        </li>
+      </ul>
+      {#header_close#}
+      {#see_also|while|comptime|Arrays|Slices#}
+      {#header_close#}
+      {#header_open|if#}
+      {#code|test_if.zig#}
+
+      {#header_open|if with Optionals#}
+
+      {#code|test_if_optionals.zig#}
+
+      {#header_close#}
+      {#see_also|Optionals|Errors#}
+      {#header_close#}
+      {#header_open|defer#}
+      <p>Executes an expression unconditionally at scope exit.</p>
+      {#code|test_defer.zig#}
+
+      <p>Defer expressions are evaluated in reverse order.</p>
+      {#code|defer_unwind.zig#}
+
+      <p>Inside a defer expression the return statement is not allowed.</p>
+      {#code|test_invalid_defer.zig#}
+
+      {#see_also|Errors#}
+      {#header_close#}
+      {#header_open|unreachable#}
+      <p>
+      In {#link|Debug#} and {#link|ReleaseSafe#} mode
+      {#syntax#}unreachable{#endsyntax#} emits a call to {#syntax#}panic{#endsyntax#} with the message <code>reached unreachable code</code>.
+      </p>
+      <p>
+      In {#link|ReleaseFast#} and {#link|ReleaseSmall#} mode, the optimizer uses the assumption that {#syntax#}unreachable{#endsyntax#} code
+      will never be hit to perform optimizations.
+      </p>
+      {#header_open|Basics#}
+      {#code|test_unreachable.zig#}
+
+      <p>In fact, this is how {#syntax#}std.debug.assert{#endsyntax#} is implemented:</p>
+      {#code|test_assertion_failure.zig#}
+
+      {#header_close#}
+      {#header_open|At Compile-Time#}
+      {#code|test_comptime_unreachable.zig#}
+
+      {#see_also|Zig Test|Build Mode|comptime#}
+      {#header_close#}
+      {#header_close#}
+      {#header_open|noreturn#}
+      <p>
+      {#syntax#}noreturn{#endsyntax#} is the type of:
+      </p>
+      <ul>
+          <li>{#syntax#}break{#endsyntax#}</li>
+          <li>{#syntax#}continue{#endsyntax#}</li>
+          <li>{#syntax#}return{#endsyntax#}</li>
+          <li>{#syntax#}unreachable{#endsyntax#}</li>
+          <li>{#syntax#}while (true) {}{#endsyntax#}</li>
+      </ul>
+      <p>When resolving types together, such as {#syntax#}if{#endsyntax#} clauses or {#syntax#}switch{#endsyntax#} prongs,
+              the {#syntax#}noreturn{#endsyntax#} type is compatible with every other type. Consider:
+      </p>
+      {#code|test_noreturn.zig#}
+
+      <p>Another use case for {#syntax#}noreturn{#endsyntax#} is the {#syntax#}exit{#endsyntax#} function:</p>
+      {#code|test_noreturn_from_exit.zig#}
+
+      {#header_close#}
+
+      {#header_open|Functions#}
+      {#code|test_functions.zig#}
+
+      <p>There is a difference between a function <em>body</em> and a function <em>pointer</em>.
+      Function bodies are {#link|comptime#}-only types while function {#link|Pointers#} may be
+      runtime-known.</p>
+      {#header_open|Pass-by-value Parameters#}
+      <p>
+      Primitive types such as {#link|Integers#} and {#link|Floats#} passed as parameters
+      are copied, and then the copy is available in the function body. This is called "passing by value".
+      Copying a primitive type is essentially free and typically involves nothing more than
+      setting a register.
+      </p>
+      <p>
+      Structs, unions, and arrays can sometimes be more efficiently passed as a reference, since a copy
+      could be arbitrarily expensive depending on the size. When these types are passed
+      as parameters, Zig may choose to copy and pass by value, or pass by reference, whichever way
+      Zig decides will be faster. This is made possible, in part, by the fact that parameters are immutable.
+      </p>
+      {#code|test_pass_by_reference_or_value.zig#}
+
+      <p>
+      For extern functions, Zig follows the C ABI for passing structs and unions by value.
+      </p>
+      {#header_close#}
+      {#header_open|Function Parameter Type Inference#}
+      <p>
+      Function parameters can be declared with {#syntax#}anytype{#endsyntax#} in place of the type.
+      In this case the parameter types will be inferred when the function is called.
+      Use {#link|@TypeOf#} and {#link|@typeInfo#} to get information about the inferred type.
+      </p>
+      {#code|test_fn_type_inference.zig#}
+
+
+      {#header_close#}
+
+      {#header_open|inline fn#}
+      <p>
+      Adding the {#syntax#}inline{#endsyntax#} keyword to a function definition makes that
+      function become <em>semantically inlined</em> at the callsite. This is
+      not a hint to be possibly observed by optimization passes, but has
+      implications on the types and values involved in the function call.
+      </p>
+      <p>
+      Unlike normal function calls, arguments at an inline function callsite which are
+      compile-time known are treated as {#link|Compile Time Parameters#}. This can potentially
+      propagate all the way to the return value:
+      </p>
+      {#code|inline_call.zig#}
+
+      <p>If {#syntax#}inline{#endsyntax#} is removed, the test fails with the compile error
+      instead of passing.</p>
+      <p>It is generally better to let the compiler decide when to inline a
+      function, except for these scenarios:</p>
+      <ul>
+        <li>To change how many stack frames are in the call stack, for debugging purposes.</li>
+        <li>To force comptime-ness of the arguments to propagate to the return value of the function, as in the above example.</li>
+        <li>Real world performance measurements demand it.</li>
+      </ul>
+      <p>Note that {#syntax#}inline{#endsyntax#} actually <em>restricts</em>
+      what the compiler is allowed to do. This can harm binary size,
+      compilation speed, and even runtime performance.</p>
+      {#header_close#}
+
+      {#header_open|Function Reflection#}
+      {#code|test_fn_reflection.zig#}
+
+      {#header_close#}
+      {#header_close#}
+      {#header_open|Errors#}
+      {#header_open|Error Set Type#}
+      <p>
+      An error set is like an {#link|enum#}.
+      However, each error name across the entire compilation gets assigned an unsigned integer
+      greater than 0. You are allowed to declare the same error name more than once, and if you do, it
+      gets assigned the same integer value.
+      </p>
+      <p>
+      The error set type defaults to a {#syntax#}u16{#endsyntax#}, though if the maximum number of distinct
+      error values is provided via the <kbd>--error-limit [num]</kbd> command line parameter an integer type
+      with the minimum number of bits required to represent all of the error values will be used.
+      </p>
+      <p>
+      You can {#link|coerce|Type Coercion#} an error from a subset to a superset:
+      </p>
+      {#code|test_coerce_error_subset_to_superset.zig#}
+
+      <p>
+      But you cannot {#link|coerce|Type Coercion#} an error from a superset to a subset:
+      </p>
+      {#code|test_coerce_error_superset_to_subset.zig#}
+
+      <p>
+      There is a shortcut for declaring an error set with only 1 value, and then getting that value:
+      </p>
+      {#code|single_value_error_set_shortcut.zig#}
+
+      <p>This is equivalent to:</p>
+      {#code|single_value_error_set.zig#}
+
+      <p>
+      This becomes useful when using {#link|Inferred Error Sets#}.
+      </p>
+      {#header_open|The Global Error Set#}
+      <p>{#syntax#}anyerror{#endsyntax#} refers to the global error set.
+      This is the error set that contains all errors in the entire compilation unit, i.e. it is the union of all other error sets.
+      </p>
+      <p>
+      You can {#link|coerce|Type Coercion#} any error set to the global one, and you can explicitly
+      cast an error of the global error set to a non-global one. This inserts a language-level
+      assert to make sure the error value is in fact in the destination error set.
+      </p>
+      <p>
+      The global error set should generally be avoided because it prevents the
+      compiler from knowing what errors are possible at compile-time. Knowing
+      the error set at compile-time is better for generated documentation and
+      helpful error messages, such as forgetting a possible error value in a {#link|switch#}.
+      </p>
+      {#header_close#}
+      {#header_close#}
+      {#header_open|Error Union Type#}
+      <p>
+      An error set type and normal type can be combined with the {#syntax#}!{#endsyntax#}
+      binary operator to form an error union type. You are likely to use an
+      error union type more often than an error set type by itself.
+      </p>
+      <p>
+      Here is a function to parse a string into a 64-bit integer:
+      </p>
+      {#code|error_union_parsing_u64.zig#}
+
+      <p>
+      Notice the return type is {#syntax#}!u64{#endsyntax#}. This means that the function
+      either returns an unsigned 64 bit integer, or an error. We left off the error set
+      to the left of the {#syntax#}!{#endsyntax#}, so the error set is inferred.
+      </p>
+      <p>
+      Within the function definition, you can see some return statements that return
+      an error, and at the bottom a return statement that returns a {#syntax#}u64{#endsyntax#}.
+          Both types {#link|coerce|Type Coercion#} to {#syntax#}anyerror!u64{#endsyntax#}.
+      </p>
+      <p>
+      What it looks like to use this function varies depending on what you're
+      trying to do. One of the following:
+      </p>
+      <ul>
+        <li>You want to provide a default value if it returned an error.</li>
+        <li>If it returned an error then you want to return the same error.</li>
+        <li>You know with complete certainty it will not return an error, so want to unconditionally unwrap it.</li>
+        <li>You want to take a different action for each possible error.</li>
+      </ul>
+      {#header_open|catch#}
+      <p>If you want to provide a default value, you can use the {#syntax#}catch{#endsyntax#} binary operator:</p>
+      {#code|catch.zig#}
+
+      <p>
+      In this code, {#syntax#}number{#endsyntax#} will be equal to the successfully parsed string, or
+          a default value of 13. The type of the right hand side of the binary {#syntax#}catch{#endsyntax#} operator must
+              match the unwrapped error union type, or be of type {#syntax#}noreturn{#endsyntax#}.
+      </p>
+     <p>
+      If you want to provide a default value with
+      {#syntax#}catch{#endsyntax#} after performing some logic, you
+      can combine {#syntax#}catch{#endsyntax#} with named {#link|Blocks#}:
+      </p>
+      {#code|handle_error_with_catch_block.zig.zig#}
+
+      {#header_close#}
+      {#header_open|try#}
+      <p>Let's say you wanted to return the error if you got one, otherwise continue with the
+      function logic:</p>
+      {#code|catch_err_return.zig#}
+
+      <p>
+      There is a shortcut for this. The {#syntax#}try{#endsyntax#} expression:
+      </p>
+      {#code|try.zig#}
+
+      <p>
+      {#syntax#}try{#endsyntax#} evaluates an error union expression. If it is an error, it returns
+      from the current function with the same error. Otherwise, the expression results in
+      the unwrapped value.
+      </p>
+      {#header_close#}
+      <p>
+        Maybe you know with complete certainty that an expression will never be an error.
+        In this case you can do this:
+      </p>
+      {#syntax#}const number = parseU64("1234", 10) catch unreachable;{#endsyntax#}
+      <p>
+      Here we know for sure that "1234" will parse successfully. So we put the
+      {#syntax#}unreachable{#endsyntax#} value on the right hand side.
+      {#syntax#}unreachable{#endsyntax#} invokes safety-checked {#link|Illegal Behavior#}, so
+      in {#link|Debug#} and {#link|ReleaseSafe#}, triggers a safety panic by default. So, while
+      we're debugging the application, if there <em>was</em> a surprise error here, the application
+      would crash appropriately.
+      </p>
+      <p>
+      You may want to take a different action for every situation. For that, we combine
+      the {#link|if#} and {#link|switch#} expression:
+      </p>
+      {#syntax_block|zig|handle_all_error_scenarios.zig#}
+fn doAThing(str: []u8) void {
+    if (parseU64(str, 10)) |number| {
+        doSomethingWithNumber(number);
+    } else |err| switch (err) {
+        error.Overflow => {
+            // handle overflow...
+        },
+        // we promise that InvalidChar won't happen (or crash in debug mode if it does)
+        error.InvalidChar => unreachable,
+    }
+}
+      {#end_syntax_block#}
+      <p>
+      Finally, you may want to handle only some errors. For that, you can capture the unhandled
+      errors in the {#syntax#}else{#endsyntax#} case, which now contains a narrower error set:
+      </p>
+      {#syntax_block|zig|handle_some_error_scenarios.zig#}
+ fn doAnotherThing(str: []u8) error{InvalidChar}!void {
+    if (parseU64(str, 10)) |number| {
+        doSomethingWithNumber(number);
+    } else |err| switch (err) {
+        error.Overflow => {
+            // handle overflow...
+        },
+        else => |leftover_err| return leftover_err,
+    }
+}
+      {#end_syntax_block#}
+      <p>
+      You must use the variable capture syntax. If you don't need the
+      variable, you can capture with {#syntax#}_{#endsyntax#} and avoid the
+      {#syntax#}switch{#endsyntax#}.
+      </p>
+      {#syntax_block|zig|handle_no_error_scenarios.zig#}
+fn doADifferentThing(str: []u8) void {
+    if (parseU64(str, 10)) |number| {
+        doSomethingWithNumber(number);
+    } else |_| {
+        // do as you'd like
+    }
+}
+      {#end_syntax_block#}
+      {#header_open|errdefer#}
+      <p>
+      The other component to error handling is defer statements.
+      In addition to an unconditional {#link|defer#}, Zig has {#syntax#}errdefer{#endsyntax#},
+      which evaluates the deferred expression on block exit path if and only if
+      the function returned with an error from the block.
+      </p>
+      <p>
+      Example:
+      </p>
+      {#syntax_block|zig|errdefer_example.zig#}
+fn createFoo(param: i32) !Foo {
+    const foo = try tryToAllocateFoo();
+    // now we have allocated foo. we need to free it if the function fails.
+    // but we want to return it if the function succeeds.
+    errdefer deallocateFoo(foo);
+
+    const tmp_buf = allocateTmpBuffer() orelse return error.OutOfMemory;
+    // tmp_buf is truly a temporary resource, and we for sure want to clean it up
+    // before this block leaves scope
+    defer deallocateTmpBuffer(tmp_buf);
+
+    if (param > 1337) return error.InvalidParam;
+
+    // here the errdefer will not run since we're returning success from the function.
+    // but the defer will run!
+    return foo;
+}
+      {#end_syntax_block#}
+      <p>
+      The neat thing about this is that you get robust error handling without
+      the verbosity and cognitive overhead of trying to make sure every exit path
+      is covered. The deallocation code is always directly following the allocation code.
+      </p>
+      <p>
+      The {#syntax#}errdefer{#endsyntax#} statement can optionally capture the error:
+      </p>
+      {#code|test_errdefer_capture.zig#}
+      {#header_close#}
+      <p>
+      A couple of other tidbits about error handling:
+      </p>
+      <ul>
+        <li>These primitives give enough expressiveness that it's completely practical
+            to have failing to check for an error be a compile error. If you really want
+            to ignore the error, you can add {#syntax#}catch unreachable{#endsyntax#} and
+            get the added benefit of crashing in Debug and ReleaseSafe modes if your assumption was wrong.
+        </li>
+        <li>
+          Since Zig understands error types, it can pre-weight branches in favor of
+          errors not occurring. Just a small optimization benefit that is not available
+          in other languages.
+        </li>
+      </ul>
+      {#see_also|defer|if|switch#}
+
+      <p>An error union is created with the {#syntax#}!{#endsyntax#} binary operator.
+      You can use compile-time reflection to access the child type of an error union:</p>
+      {#code|test_error_union.zig#}
+
+      {#header_open|Merging Error Sets#}
+      <p>
+      Use the {#syntax#}||{#endsyntax#} operator to merge two error sets together. The resulting
+      error set contains the errors of both error sets. Doc comments from the left-hand
+      side override doc comments from the right-hand side. In this example, the doc
+      comments for {#syntax#}C.PathNotFound{#endsyntax#} is <code>A doc comment</code>.
+      </p>
+      <p>
+      This is especially useful for functions which return different error sets depending
+      on {#link|comptime#} branches. For example, the Zig standard library uses
+      {#syntax#}LinuxFileOpenError || WindowsFileOpenError{#endsyntax#} for the error set of opening
+      files.
+      </p>
+      {#code|test_merging_error_sets.zig#}
+
+      {#header_close#}
+      {#header_open|Inferred Error Sets#}
+      <p>
+      Because many functions in Zig return a possible error, Zig supports inferring the error set.
+      To infer the error set for a function, prepend the {#syntax#}!{#endsyntax#} operator to the function’s return type, like {#syntax#}!T{#endsyntax#}:
+      </p>
+      {#code|test_inferred_error_sets.zig#}
+
+      <p>
+      When a function has an inferred error set, that function becomes generic and thus it becomes
+      trickier to do certain things with it, such as obtain a function pointer, or have an error
+      set that is consistent across different build targets. Additionally, inferred error sets
+      are incompatible with recursion.
+      </p>
+      <p>
+      In these situations, it is recommended to use an explicit error set. You can generally start
+      with an empty error set and let compile errors guide you toward completing the set.
+      </p>
+      <p>
+      These limitations may be overcome in a future version of Zig.
+      </p>
+      {#header_close#}
+      {#header_close#}
+      {#header_open|Error Return Traces#}
+      <p>
+      Error Return Traces show all the points in the code that an error was returned to the calling function. This makes it practical to use {#link|try#} everywhere and then still be able to know what happened if an error ends up bubbling all the way out of your application.
+      </p>
+      {#code|error_return_trace.zig#}
+
+      <p>
+      Look closely at this example. This is no stack trace.
+      </p>
+      <p>
+      You can see that the final error bubbled up was {#syntax#}PermissionDenied{#endsyntax#},
+          but the original error that started this whole thing was {#syntax#}FileNotFound{#endsyntax#}. In the {#syntax#}bar{#endsyntax#} function, the code handles the original error code,
+      and then returns another one, from the switch statement. Error Return Traces make this clear, whereas a stack trace would look like this:
+      </p>
+      {#code|stack_trace.zig#}
+
+      <p>
+      Here, the stack trace does not explain how the control
+      flow in {#syntax#}bar{#endsyntax#} got to the {#syntax#}hello(){#endsyntax#} call.
+      One would have to open a debugger or further instrument the application
+      in order to find out. The error return trace, on the other hand,
+      shows exactly how the error bubbled up.
+      </p>
+      <p>
+      This debugging feature makes it easier to iterate quickly on code that
+      robustly handles all error conditions. This means that Zig developers
+      will naturally find themselves writing correct, robust code in order
+      to increase their development pace.
+      </p>
+      <p>
+      Error Return Traces are enabled by default in {#link|Debug#} and {#link|ReleaseSafe#} builds and disabled by default in {#link|ReleaseFast#} and {#link|ReleaseSmall#} builds.
+      </p>
+      <p>
+      There are a few ways to activate this error return tracing feature:
+      </p>
+      <ul>
+        <li>Return an error from main</li>
+        <li>An error makes its way to {#syntax#}catch unreachable{#endsyntax#} and you have not overridden the default panic handler</li>
+        <li>Use {#link|errorReturnTrace#} to access the current return trace. You can use {#syntax#}std.debug.dumpStackTrace{#endsyntax#} to print it. This function returns comptime-known {#link|null#} when building without error return tracing support.</li>
+      </ul>
+      {#header_open|Implementation Details#}
+      <p>
+      To analyze performance cost, there are two cases:
+      </p>
+      <ul>
+        <li>when no errors are returned</li>
+        <li>when returning errors</li>
+      </ul>
+      <p>
+      For the case when no errors are returned, the cost is a single memory write operation, only in the first non-failable function in the call graph that calls a failable function, i.e. when a function returning {#syntax#}void{#endsyntax#} calls a function returning {#syntax#}error{#endsyntax#}.
+      This is to initialize this struct in the stack memory:
+      </p>
+      {#syntax_block|zig|stack_trace_struct.zig#}
+pub const StackTrace = struct {
+    index: usize,
+    instruction_addresses: [N]usize,
+};
+      {#end_syntax_block#}
+      <p>
+      Here, N is the maximum function call depth as determined by call graph analysis. Recursion is ignored and counts for 2.
+      </p>
+      <p>
+      A pointer to {#syntax#}StackTrace{#endsyntax#} is passed as a secret parameter to every function that can return an error, but it's always the first parameter, so it can likely sit in a register and stay there.
+      </p>
+      <p>
+      That's it for the path when no errors occur. It's practically free in terms of performance.
+      </p>
+      <p>
+      When generating the code for a function that returns an error, just before the {#syntax#}return{#endsyntax#} statement (only for the {#syntax#}return{#endsyntax#} statements that return errors), Zig generates a call to this function:
+      </p>
+      {#syntax_block|zig|zig_return_error_fn.zig#}
+// marked as "no-inline" in LLVM IR
+fn __zig_return_error(stack_trace: *StackTrace) void {
+    stack_trace.instruction_addresses[stack_trace.index] = @returnAddress();
+    stack_trace.index = (stack_trace.index + 1) % N;
+}
+      {#end_syntax_block#}
+      <p>
+      The cost is 2 math operations plus some memory reads and writes. The memory accessed is constrained and should remain cached for the duration of the error return bubbling.
+      </p>
+      <p>
+      As for code size cost, 1 function call before a return statement is no big deal. Even so,
+      I have <a href="https://github.com/ziglang/zig/issues/690">a plan</a> to make the call to
+      {#syntax#}__zig_return_error{#endsyntax#} a tail call, which brings the code size cost down to actually zero. What is a return statement in code without error return tracing can become a jump instruction in code with error return tracing.
+      </p>
+      {#header_close#}
+      {#header_close#}
+      {#header_close#}
+      {#header_open|Optionals#}
+      <p>
+      One area that Zig provides safety without compromising efficiency or
+      readability is with the optional type.
+      </p>
+      <p>
+      The question mark symbolizes the optional type. You can convert a type to an optional
+      type by putting a question mark in front of it, like this:
+      </p>
+      {#code|optional_integer.zig#}
+
+      <p>
+      Now the variable {#syntax#}optional_int{#endsyntax#} could be an {#syntax#}i32{#endsyntax#}, or {#syntax#}null{#endsyntax#}.
+      </p>
+      <p>
+      Instead of integers, let's talk about pointers. Null references are the source of many runtime
+      exceptions, and even stand accused of being
+      <a href="https://www.lucidchart.com/techblog/2015/08/31/the-worst-mistake-of-computer-science/">the worst mistake of computer science</a>.
+      </p>
+      <p>Zig does not have them.</p>
+      <p>
+      Instead, you can use an optional pointer. This secretly compiles down to a normal pointer,
+      since we know we can use 0 as the null value for the optional type. But the compiler
+      can check your work and make sure you don't assign null to something that can't be null.
+      </p>
+      <p>
+      Typically the downside of not having null is that it makes the code more verbose to
+      write. But, let's compare some equivalent C code and Zig code.
+      </p>
+      <p>
+      Task: call malloc, if the result is null, return null.
+      </p>
+      <p>C code</p>
+      {#syntax_block|c|call_malloc_in_c.c#}
+// malloc prototype included for reference
+void *malloc(size_t size);
+
+struct Foo *do_a_thing(void) {
+    char *ptr = malloc(1234);
+    if (!ptr) return NULL;
+    // ...
+}
+      {#end_syntax_block#}
+      <p>Zig code</p>
+      {#syntax_block|zig|call_malloc_from_zig.zig#}
+// malloc prototype included for reference
+extern fn malloc(size: usize) ?[*]u8;
+
+fn doAThing() ?*Foo {
+    const ptr = malloc(1234) orelse return null;
+    _ = ptr; // ...
+}
+      {#end_syntax_block#}
+      <p>
+        Here, Zig is at least as convenient, if not more, than C. And, the type of "ptr"
+        is {#syntax#}[*]u8{#endsyntax#} <em>not</em> {#syntax#}?[*]u8{#endsyntax#}. The {#syntax#}orelse{#endsyntax#} keyword
+                    unwrapped the optional type and therefore {#syntax#}ptr{#endsyntax#} is guaranteed to be non-null everywhere
+        it is used in the function.
+      </p>
+      <p>
+        The other form of checking against NULL you might see looks like this:
+      </p>
+      {#syntax_block|c|checking_null_in_c.c#}
+void do_a_thing(struct Foo *foo) {
+    // do some stuff
+
+    if (foo) {
+        do_something_with_foo(foo);
+    }
+
+    // do some stuff
+}
+      {#end_syntax_block#}
+      <p>
+        In Zig you can accomplish the same thing:
+      </p>
+      {#code|checking_null_in_zig.zig#}
+
+      <p>
+      Once again, the notable thing here is that inside the if block,
+      {#syntax#}foo{#endsyntax#} is no longer an optional pointer, it is a pointer, which
+      cannot be null.
+      </p>
+      <p>
+      One benefit to this is that functions which take pointers as arguments can
+      be annotated with the "nonnull" attribute - <code>__attribute__((nonnull))</code> in
+      <a href="https://gcc.gnu.org/onlinedocs/gcc-4.0.0/gcc/Function-Attributes.html">GCC</a>.
+      The optimizer can sometimes make better decisions knowing that pointer arguments
+      cannot be null.
+      </p>
+      {#header_open|Optional Type#}
+      <p>An optional is created by putting {#syntax#}?{#endsyntax#} in front of a type. You can use compile-time
+      reflection to access the child type of an optional:</p>
+      {#code|test_optional_type.zig#}
+
+      {#header_close#}
+      {#header_open|null#}
+      <p>
+      Just like {#link|undefined#}, {#syntax#}null{#endsyntax#} has its own type, and the only way to use it is to
+      cast it to a different type:
+      </p>
+      {#code|null.zig#}
+
+      {#header_close#}
+      {#header_open|Optional Pointers#}
+      <p>An optional pointer is guaranteed to be the same size as a pointer. The {#syntax#}null{#endsyntax#} of
+      the optional is guaranteed to be address 0.</p>
+      {#code|test_optional_pointer.zig#}
+
+      {#header_close#}
+
+      {#see_also|while with Optionals|if with Optionals#}
+      {#header_close#}
+      {#header_open|Casting#}
+      <p>
+      A <strong>type cast</strong> converts a value of one type to another.
+      Zig has {#link|Type Coercion#} for conversions that are known to be completely safe and unambiguous,
+      and {#link|Explicit Casts#} for conversions that one would not want to happen on accident.
+      There is also a third kind of type conversion called {#link|Peer Type Resolution#} for
+      the case when a result type must be decided given multiple operand types.
+      </p>
+      {#header_open|Type Coercion#}
+      <p>
+      Type coercion occurs when one type is expected, but different type is provided:
+      </p>
+      {#code|test_type_coercion.zig#}
+
+      <p>
+      Type coercions are only allowed when it is completely unambiguous how to get from one type to another,
+      and the transformation is guaranteed to be safe. There is one exception, which is {#link|C Pointers#}.
+      </p>
+      {#header_open|Type Coercion: Stricter Qualification#}
+      <p>
+      Values which have the same representation at runtime can be cast to increase the strictness
+      of the qualifiers, no matter how nested the qualifiers are:
+      </p>
+      <ul>
+          <li>{#syntax#}const{#endsyntax#} - non-const to const is allowed</li>
+          <li>{#syntax#}volatile{#endsyntax#} - non-volatile to volatile is allowed</li>
+          <li>{#syntax#}align{#endsyntax#} - bigger to smaller alignment is allowed </li>
+          <li>{#link|error sets|Error Set Type#} to supersets is allowed</li>
+      </ul>
+      <p>
+      These casts are no-ops at runtime since the value representation does not change.
+      </p>
+      {#code|test_no_op_casts.zig#}
+
+      <p>
+      In addition, pointers coerce to const optional pointers:
+      </p>
+      {#code|test_pointer_coerce_const_optional.zig#}
+
+      {#header_close#}
+      {#header_open|Type Coercion: Integer and Float Widening#}
+      <p>
+      {#link|Integers#} coerce to integer types which can represent every value of the old type, and likewise
+      {#link|Floats#} coerce to float types which can represent every value of the old type.
+      </p>
+      {#code|test_integer_widening.zig#}
+
+      {#header_close#}
+      {#header_open|Type Coercion: Float to Int#}
+      <p>
+      A compiler error is appropriate because this ambiguous expression leaves the compiler
+      two choices about the coercion.
+      </p>
+      <ul>
+        <li>Cast {#syntax#}54.0{#endsyntax#} to {#syntax#}comptime_int{#endsyntax#} resulting in {#syntax#}@as(comptime_int, 10){#endsyntax#}, which is casted to {#syntax#}@as(f32, 10){#endsyntax#}</li>
+        <li>Cast {#syntax#}5{#endsyntax#} to {#syntax#}comptime_float{#endsyntax#} resulting in {#syntax#}@as(comptime_float, 10.8){#endsyntax#}, which is casted to {#syntax#}@as(f32, 10.8){#endsyntax#}</li>
+      </ul>
+      {#code|test_ambiguous_coercion.zig#}
+
+      {#header_close#}
+      {#header_open|Type Coercion: Slices, Arrays and Pointers#}
+      {#code|test_coerce_slices_arrays_and_pointers.zig#}
+
+      {#see_also|C Pointers#}
+      {#header_close#}
+      {#header_open|Type Coercion: Optionals#}
+      <p>
+      The payload type of {#link|Optionals#}, as well as {#link|null#}, coerce to the optional type.
+      </p>
+      {#code|test_coerce_optionals.zig#}
+
+      <p>Optionals work nested inside the {#link|Error Union Type#}, too:</p>
+      {#code|test_coerce_optional_wrapped_error_union.zig#}
+
+      {#header_close#}
+      {#header_open|Type Coercion: Error Unions#}
+      <p>The payload type of an {#link|Error Union Type#} as well as the {#link|Error Set Type#}
+      coerce to the error union type:
+      </p>
+      {#code|test_coerce_to_error_union.zig#}
+
+      {#header_close#}
+      {#header_open|Type Coercion: Compile-Time Known Numbers#}
+      <p>When a number is {#link|comptime#}-known to be representable in the destination type,
+      it may be coerced:
+      </p>
+      {#code|test_coerce_large_to_small.zig#}
+
+      {#header_close#}
+      {#header_open|Type Coercion: Unions and Enums#}
+      <p>Tagged unions can be coerced to enums, and enums can be coerced to tagged unions
+      when they are {#link|comptime#}-known to be a field of the union that has only one possible value, such as
+      {#link|void#}:
+      </p>
+      {#code|test_coerce_unions_enums.zig#}
+
+      {#see_also|union|enum#}
+      {#header_close#}
+      {#header_open|Type Coercion: undefined#}
+      <p>{#link|undefined#} can be coerced to any type.</p>
+      {#header_close#}
+
+      {#header_open|Type Coercion: Tuples to Arrays#}
+      <p>{#link|Tuples#} can be coerced to arrays, if all of the fields have the same type.</p>
+      {#code|test_coerce_tuples_arrays.zig#}
+
+      {#header_close#}
+      {#header_close#}
+
+      {#header_open|Explicit Casts#}
+      <p>
+      Explicit casts are performed via {#link|Builtin Functions#}.
+      Some explicit casts are safe; some are not.
+      Some explicit casts perform language-level assertions; some do not.
+      Some explicit casts are no-ops at runtime; some are not.
+      </p>
+      <ul>
+          <li>{#link|@bitCast#} - change type but maintain bit representation</li>
+          <li>{#link|@alignCast#} - make a pointer have more alignment</li>
+          <li>{#link|@enumFromInt#} - obtain an enum value based on its integer tag value</li>
+          <li>{#link|@errorFromInt#} - obtain an error code based on its integer value</li>
+          <li>{#link|@errorCast#} - convert to a smaller error set</li>
+          <li>{#link|@floatCast#} - convert a larger float to a smaller float</li>
+          <li>{#link|@floatFromInt#} - convert an integer to a float value</li>
+          <li>{#link|@intCast#} - convert between integer types</li>
+          <li>{#link|@intFromBool#} - convert true to 1 and false to 0</li>
+          <li>{#link|@intFromEnum#} - obtain the integer tag value of an enum or tagged union</li>
+          <li>{#link|@intFromError#} - obtain the integer value of an error code</li>
+          <li>{#link|@intFromFloat#} - obtain the integer part of a float value</li>
+          <li>{#link|@intFromPtr#} - obtain the address of a pointer</li>
+          <li>{#link|@ptrFromInt#} - convert an address to a pointer</li>
+          <li>{#link|@ptrCast#} - convert between pointer types</li>
+          <li>{#link|@truncate#} - convert between integer types, chopping off bits</li>
+      </ul>
+      {#header_close#}
+
+      {#header_open|Peer Type Resolution#}
+      <p>Peer Type Resolution occurs in these places:</p>
+      <ul>
+        <li>{#link|switch#} expressions</li>
+        <li>{#link|if#} expressions</li>
+        <li>{#link|while#} expressions</li>
+        <li>{#link|for#} expressions</li>
+        <li>Multiple break statements in a block</li>
+        <li>Some {#link|binary operations|Table of Operators#}</li>
+      </ul>
+      <p>
+      This kind of type resolution chooses a type that all peer types can coerce into. Here are
+      some examples:
+      </p>
+      {#code|test_peer_type_resolution.zig#}
+
+      {#header_close#}
+      {#header_close#}
+
+      {#header_open|Zero Bit Types#}
+      <p>For some types, {#link|@sizeOf#} is 0:</p>
+      <ul>
+          <li>{#link|void#}</li>
+          <li>The {#link|Integers#} {#syntax#}u0{#endsyntax#} and {#syntax#}i0{#endsyntax#}.</li>
+          <li>{#link|Arrays#} and {#link|Vectors#} with len 0, or with an element type that is a zero bit type.</li>
+          <li>An {#link|enum#} with only 1 tag.</li>
+          <li>A {#link|struct#} with all fields being zero bit types.</li>
+          <li>A {#link|union#} with only 1 field which is a zero bit type.</li>
+      </ul>
+      <p>
+      These types can only ever have one possible value, and thus
+      require 0 bits to represent. Code that makes use of these types is
+      not included in the final generated code:
+      </p>
+      {#code|zero_bit_types.zig#}
+
+      <p>When this turns into machine code, there is no code generated in the
+      body of {#syntax#}entry{#endsyntax#}, even in {#link|Debug#} mode. For example, on x86_64:</p>
+      <pre><code>0000000000000010 &lt;entry&gt;:
+  10:	55                   	push   %rbp
+  11:	48 89 e5             	mov    %rsp,%rbp
+  14:	5d                   	pop    %rbp
+  15:	c3                   	retq   </code></pre>
+      <p>These assembly instructions do not have any code associated with the void values -
+      they only perform the function call prologue and epilogue.</p>
+
+      {#header_open|void#}
+      <p>
+      {#syntax#}void{#endsyntax#} can be useful for instantiating generic types. For example, given a
+          {#syntax#}Map(Key, Value){#endsyntax#}, one can pass {#syntax#}void{#endsyntax#} for the {#syntax#}Value{#endsyntax#}
+                      type to make it into a {#syntax#}Set{#endsyntax#}:
+      </p>
+      {#code|test_void_in_hashmap.zig#}
+
+      <p>Note that this is different from using a dummy value for the hash map value.
+      By using {#syntax#}void{#endsyntax#} as the type of the value, the hash map entry type has no value field, and
+      thus the hash map takes up less space. Further, all the code that deals with storing and loading the
+      value is deleted, as seen above.
+      </p>
+      <p>
+      {#syntax#}void{#endsyntax#} is distinct from {#syntax#}anyopaque{#endsyntax#}.
+      {#syntax#}void{#endsyntax#} has a known size of 0 bytes, and {#syntax#}anyopaque{#endsyntax#} has an unknown, but non-zero, size.
+      </p>
+      <p>
+      Expressions of type {#syntax#}void{#endsyntax#} are the only ones whose value can be ignored. For example, ignoring
+      a non-{#syntax#}void{#endsyntax#} expression is a compile error:
+      </p>
+      {#code|test_expression_ignored.zig#}
+
+      <p>However, if the expression has type {#syntax#}void{#endsyntax#}, there will be no error. Expression results can be explicitly ignored by assigning them to {#syntax#}_{#endsyntax#}. </p>
+      {#code|test_void_ignored.zig#}
+
+      {#header_close#}
+      {#header_close#}
+
+      {#header_open|Result Location Semantics#}
+      <p>
+      During compilation, every Zig expression and sub-expression is assigned optional result location
+      information. This information dictates what type the expression should have (its result type), and
+      where the resulting value should be placed in memory (its result location). The information is
+      optional in the sense that not every expression has this information: assignment to
+      {#syntax#}_{#endsyntax#}, for instance, does not provide any information about the type of an
+      expression, nor does it provide a concrete memory location to place it in.
+      </p>
+      <p>
+      As a motivating example, consider the statement {#syntax#}const x: u32 = 42;{#endsyntax#}. The type
+      annotation here provides a result type of {#syntax#}u32{#endsyntax#} to the initialization expression
+      {#syntax#}42{#endsyntax#}, instructing the compiler to coerce this integer (initially of type
+      {#syntax#}comptime_int{#endsyntax#}) to this type. We will see more examples shortly.
+      </p>
+      <p>
+      This is not an implementation detail: the logic outlined above is codified into the Zig language
+      specification, and is the primary mechanism of type inference in the language. This system is
+      collectively referred to as "Result Location Semantics".
+      </p>
+      {#header_open|Result Types#}
+      <p>
+      Result types are propagated recursively through expressions where possible. For instance, if the
+      expression {#syntax#}&e{#endsyntax#} has result type {#syntax#}*u32{#endsyntax#}, then
+      {#syntax#}e{#endsyntax#} is given a result type of {#syntax#}u32{#endsyntax#}, allowing the
+      language to perform this coercion before taking a reference.
+      </p>
+      <p>
+      The result type mechanism is utilized by casting builtins such as {#syntax#}@intCast{#endsyntax#}.
+      Rather than taking as an argument the type to cast to, these builtins use their result type to
+      determine this information. The result type is often known from context; where it is not, the
+      {#syntax#}@as{#endsyntax#} builtin can be used to explicitly provide a result type.
+      </p>
+      <p>
+      We can break down the result types for each component of a simple expression as follows:
+      </p>
+      {#code|result_type_propagation.zig#}
+
+      <p>
+      This result type information is useful for the aforementioned cast builtins, as well as to avoid
+      the construction of pre-coercion values, and to avoid the need for explicit type coercions in some
+      cases. The following table details how some common expressions propagate result types, where
+      {#syntax#}x{#endsyntax#} and {#syntax#}y{#endsyntax#} are arbitrary sub-expressions.
+      </p>
+      <div class="table-wrapper">
+      <table>
+        <thead>
+          <tr>
+            <th scope="col">Expression</th>
+            <th scope="col">Parent Result Type</th>
+            <th scope="col">Sub-expression Result Type</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">{#syntax#}const val: T = x{#endsyntax#}</th>
+            <td>-</td>
+            <td>{#syntax#}x{#endsyntax#} is a {#syntax#}T{#endsyntax#}</td>
+          </tr>
+          <tr>
+            <th scope="row">{#syntax#}var val: T = x{#endsyntax#}</th>
+            <td>-</td>
+            <td>{#syntax#}x{#endsyntax#} is a {#syntax#}T{#endsyntax#}</td>
+          </tr>
+          <tr>
+            <th scope="row">{#syntax#}val = x{#endsyntax#}</th>
+            <td>-</td>
+            <td>{#syntax#}x{#endsyntax#} is a {#syntax#}@TypeOf(val){#endsyntax#}</td>
+          </tr>
+          <tr>
+            <th scope="row">{#syntax#}@as(T, x){#endsyntax#}</th>
+            <td>-</td>
+            <td>{#syntax#}x{#endsyntax#} is a {#syntax#}T{#endsyntax#}</td>
+          </tr>
+          <tr>
+            <th scope="row">{#syntax#}&x{#endsyntax#}</th>
+            <td>{#syntax#}*T{#endsyntax#}</td>
+            <td>{#syntax#}x{#endsyntax#} is a {#syntax#}T{#endsyntax#}</td>
+          </tr>
+          <tr>
+            <th scope="row">{#syntax#}&x{#endsyntax#}</th>
+            <td>{#syntax#}[]T{#endsyntax#}</td>
+            <td>{#syntax#}x{#endsyntax#} is some array of {#syntax#}T{#endsyntax#}</td>
+          </tr>
+          <tr>
+            <th scope="row">{#syntax#}f(x){#endsyntax#}</th>
+            <td>-</td>
+            <td>{#syntax#}x{#endsyntax#} has the type of the first parameter of {#syntax#}f{#endsyntax#}</td>
+          </tr>
+          <tr>
+            <th scope="row">{#syntax#}.{x}{#endsyntax#}</th>
+            <td>{#syntax#}T{#endsyntax#}</td>
+            <td>{#syntax#}x{#endsyntax#} is a {#syntax#}std.meta.FieldType(T, .@"0"){#endsyntax#}</td>
+          </tr>
+          <tr>
+            <th scope="row">{#syntax#}.{ .a = x }{#endsyntax#}</th>
+            <td>{#syntax#}T{#endsyntax#}</td>
+            <td>{#syntax#}x{#endsyntax#} is a {#syntax#}std.meta.FieldType(T, .a){#endsyntax#}</td>
+          </tr>
+          <tr>
+            <th scope="row">{#syntax#}T{x}{#endsyntax#}</th>
+            <td>-</td>
+            <td>{#syntax#}x{#endsyntax#} is a {#syntax#}std.meta.FieldType(T, .@"0"){#endsyntax#}</td>
+          </tr>
+          <tr>
+            <th scope="row">{#syntax#}T{ .a = x }{#endsyntax#}</th>
+            <td>-</td>
+            <td>{#syntax#}x{#endsyntax#} is a {#syntax#}std.meta.FieldType(T, .a){#endsyntax#}</td>
+          </tr>
+          <tr>
+            <th scope="row">{#syntax#}@Type(x){#endsyntax#}</th>
+            <td>-</td>
+            <td>{#syntax#}x{#endsyntax#} is a {#syntax#}std.builtin.Type{#endsyntax#}</td>
+          </tr>
+          <tr>
+            <th scope="row">{#syntax#}@typeInfo(x){#endsyntax#}</th>
+            <td>-</td>
+            <td>{#syntax#}x{#endsyntax#} is a {#syntax#}type{#endsyntax#}</td>
+          </tr>
+          <tr>
+            <th scope="row">{#syntax#}x << y{#endsyntax#}</th>
+            <td>-</td>
+            <td>{#syntax#}y{#endsyntax#} is a {#syntax#}std.math.Log2IntCeil(@TypeOf(x)){#endsyntax#}</td>
+          </tr>
+        </tbody>
+      </table>
+      </div>
+      {#header_close#}
+      {#header_open|Result Locations#}
+      <p>
+      In addition to result type information, every expression may be optionally assigned a result
+      location: a pointer to which the value must be directly written. This system can be used to prevent
+      intermediate copies when initializing data structures, which can be important for types which must
+      have a fixed memory address ("pinned" types).
+      </p>
+      <p>
+      When compiling the simple assignment expression {#syntax#}x = e{#endsyntax#}, many languages would
+      create the temporary value {#syntax#}e{#endsyntax#} on the stack, and then assign it to
+      {#syntax#}x{#endsyntax#}, potentially performing a type coercion in the process. Zig approaches this
+      differently. The expression {#syntax#}e{#endsyntax#} is given a result type matching the type of
+      {#syntax#}x{#endsyntax#}, and a result location of {#syntax#}&x{#endsyntax#}. For many syntactic
+      forms of {#syntax#}e{#endsyntax#}, this has no practical impact. However, it can have important
+      semantic effects when working with more complex syntax forms.
+      </p>
+      <p>
+      For instance, if the expression {#syntax#}.{ .a = x, .b = y }{#endsyntax#} has a result location of
+      {#syntax#}ptr{#endsyntax#}, then {#syntax#}x{#endsyntax#} is given a result location of
+      {#syntax#}&ptr.a{#endsyntax#}, and {#syntax#}y{#endsyntax#} a result location of {#syntax#}&ptr.b{#endsyntax#}.
+      Without this system, this expression would construct a temporary struct value entirely on the stack, and
+      only then copy it to the destination address. In essence, Zig desugars the assignment
+      {#syntax#}foo = .{ .a = x, .b = y }{#endsyntax#} to the two statements {#syntax#}foo.a = x; foo.b = y;{#endsyntax#}.
+      </p>
+      <p>
+      This can sometimes be important when assigning an aggregate value where the initialization
+      expression depends on the previous value of the aggregate. The easiest way to demonstrate this is by
+      attempting to swap fields of a struct or array - the following logic looks sound, but in fact is not:
+      </p>
+      {#code|result_location_interfering_with_swap.zig#}
+
+      <p>
+      The following table details how some common expressions propagate result locations, where
+      {#syntax#}x{#endsyntax#} and {#syntax#}y{#endsyntax#} are arbitrary sub-expressions. Note that
+      some expressions cannot provide meaningful result locations to sub-expressions, even if they
+      themselves have a result location.
+      </p>
+      <div class="table-wrapper">
+      <table>
+        <thead>
+          <tr>
+            <th scope="col">Expression</th>
+            <th scope="col">Result Location</th>
+            <th scope="col">Sub-expression Result Locations</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">{#syntax#}const val: T = x{#endsyntax#}</th>
+            <td>-</td>
+            <td>{#syntax#}x{#endsyntax#} has result location {#syntax#}&val{#endsyntax#}</td>
+          </tr>
+          <tr>
+            <th scope="row">{#syntax#}var val: T = x{#endsyntax#}</th>
+            <td>-</td>
+            <td>{#syntax#}x{#endsyntax#} has result location {#syntax#}&val{#endsyntax#}</td>
+          </tr>
+          <tr>
+            <th scope="row">{#syntax#}val = x{#endsyntax#}</th>
+            <td>-</td>
+            <td>{#syntax#}x{#endsyntax#} has result location {#syntax#}&val{#endsyntax#}</td>
+          </tr>
+          <tr>
+            <th scope="row">{#syntax#}@as(T, x){#endsyntax#}</th>
+            <td>{#syntax#}ptr{#endsyntax#}</td>
+            <td>{#syntax#}x{#endsyntax#} has no result location</td>
+          </tr>
+          <tr>
+            <th scope="row">{#syntax#}&x{#endsyntax#}</th>
+            <td>{#syntax#}ptr{#endsyntax#}</td>
+            <td>{#syntax#}x{#endsyntax#} has no result location</td>
+          </tr>
+          <tr>
+            <th scope="row">{#syntax#}f(x){#endsyntax#}</th>
+            <td>{#syntax#}ptr{#endsyntax#}</td>
+            <td>{#syntax#}x{#endsyntax#} has no result location</td>
+          </tr>
+          <tr>
+            <th scope="row">{#syntax#}.{x}{#endsyntax#}</th>
+            <td>{#syntax#}ptr{#endsyntax#}</td>
+            <td>{#syntax#}x{#endsyntax#} has result location {#syntax#}&ptr[0]{#endsyntax#}</td>
+          </tr>
+          <tr>
+            <th scope="row">{#syntax#}.{ .a = x }{#endsyntax#}</th>
+            <td>{#syntax#}ptr{#endsyntax#}</td>
+            <td>{#syntax#}x{#endsyntax#} has result location {#syntax#}&ptr.a{#endsyntax#}</td>
+          </tr>
+          <tr>
+            <th scope="row">{#syntax#}T{x}{#endsyntax#}</th>
+            <td>{#syntax#}ptr{#endsyntax#}</td>
+            <td>{#syntax#}x{#endsyntax#} has no result location (typed initializers do not propagate result locations)</td>
+          </tr>
+          <tr>
+            <th scope="row">{#syntax#}T{ .a = x }{#endsyntax#}</th>
+            <td>{#syntax#}ptr{#endsyntax#}</td>
+            <td>{#syntax#}x{#endsyntax#} has no result location (typed initializers do not propagate result locations)</td>
+          </tr>
+          <tr>
+            <th scope="row">{#syntax#}@Type(x){#endsyntax#}</th>
+            <td>{#syntax#}ptr{#endsyntax#}</td>
+            <td>{#syntax#}x{#endsyntax#} has no result location</td>
+          </tr>
+          <tr>
+            <th scope="row">{#syntax#}@typeInfo(x){#endsyntax#}</th>
+            <td>{#syntax#}ptr{#endsyntax#}</td>
+            <td>{#syntax#}x{#endsyntax#} has no result location</td>
+          </tr>
+          <tr>
+            <th scope="row">{#syntax#}x << y{#endsyntax#}</th>
+            <td>{#syntax#}ptr{#endsyntax#}</td>
+            <td>{#syntax#}x{#endsyntax#} and {#syntax#}y{#endsyntax#} do not have result locations</td>
+          </tr>
+        </tbody>
+      </table>
+      </div>
+      {#header_close#}
+      {#header_close#}
+
+      {#header_open|usingnamespace#}
+      <p>
+      {#syntax#}usingnamespace{#endsyntax#} is a declaration that mixes all the public
+      declarations of the operand, which must be a {#link|struct#}, {#link|union#}, {#link|enum#},
+      or {#link|opaque#}, into the namespace:
+      </p>
+      {#code|test_usingnamespace.zig#}
+
+      <p>
+      {#syntax#}usingnamespace{#endsyntax#} has an important use case when organizing the public
+      API of a file or package. For example, one might have <code class="file">c.zig</code> with all of the
+      {#link|C imports|Import from C Header File#}:
+      </p>
+      {#syntax_block|zig|c.zig#}
+pub usingnamespace @cImport({
+    @cInclude("epoxy/gl.h");
+    @cInclude("GLFW/glfw3.h");
+    @cDefine("STBI_ONLY_PNG", "");
+    @cDefine("STBI_NO_STDIO", "");
+    @cInclude("stb_image.h");
+});
+      {#end_syntax_block#}
+      <p>
+      The above example demonstrates using {#syntax#}pub{#endsyntax#} to qualify the
+      {#syntax#}usingnamespace{#endsyntax#} additionally makes the imported declarations
+      {#syntax#}pub{#endsyntax#}. This can be used to forward declarations, giving precise control
+      over what declarations a given file exposes.
+      </p>
+      {#header_close#}
+
+
+      {#header_open|comptime#}
+      <p>
+      Zig places importance on the concept of whether an expression is known at compile-time.
+      There are a few different places this concept is used, and these building blocks are used
+      to keep the language small, readable, and powerful.
+      </p>
+      {#header_open|Introducing the Compile-Time Concept#}
+      {#header_open|Compile-Time Parameters#}
+      <p>
+      Compile-time parameters is how Zig implements generics. It is compile-time duck typing.
+      </p>
+      {#code|compile-time_duck_typing.zig#}
+
+      <p>
+      In Zig, types are first-class citizens. They can be assigned to variables, passed as parameters to functions,
+      and returned from functions. However, they can only be used in expressions which are known at <em>compile-time</em>,
+      which is why the parameter {#syntax#}T{#endsyntax#} in the above snippet must be marked with {#syntax#}comptime{#endsyntax#}.
+      </p>
+      <p>
+      A {#syntax#}comptime{#endsyntax#} parameter means that:
+      </p>
+      <ul>
+        <li>At the callsite, the value must be known at compile-time, or it is a compile error.</li>
+        <li>In the function definition, the value is known at compile-time.</li>
+      </ul>
+      <p>
+      For example, if we were to introduce another function to the above snippet:
+      </p>
+      {#code|test_unresolved_comptime_value.zig#}
+
+      <p>
+      This is an error because the programmer attempted to pass a value only known at run-time
+      to a function which expects a value known at compile-time.
+      </p>
+      <p>
+      Another way to get an error is if we pass a type that violates the type checker when the
+      function is analyzed. This is what it means to have <em>compile-time duck typing</em>.
+      </p>
+      <p>
+      For example:
+      </p>
+      {#code|test_comptime_mismatched_type.zig#}
+
+      <p>
+      On the flip side, inside the function definition with the {#syntax#}comptime{#endsyntax#} parameter, the
+      value is known at compile-time. This means that we actually could make this work for the bool type
+      if we wanted to:
+      </p>
+      {#code|test_comptime_max_with_bool.zig#}
+
+      <p>
+      This works because Zig implicitly inlines {#syntax#}if{#endsyntax#} expressions when the condition
+      is known at compile-time, and the compiler guarantees that it will skip analysis of
+      the branch not taken.
+      </p>
+      <p>
+      This means that the actual function generated for {#syntax#}max{#endsyntax#} in this situation looks like
+      this:
+      </p>
+      {#code|compiler_generated_function.zig#}
+
+      <p>
+      All the code that dealt with compile-time known values is eliminated and we are left with only
+      the necessary run-time code to accomplish the task.
+      </p>
+      <p>
+      This works the same way for {#syntax#}switch{#endsyntax#} expressions - they are implicitly inlined
+      when the target expression is compile-time known.
+      </p>
+      {#header_close#}
+      {#header_open|Compile-Time Variables#}
+      <p>
+      In Zig, the programmer can label variables as {#syntax#}comptime{#endsyntax#}. This guarantees to the compiler
+      that every load and store of the variable is performed at compile-time. Any violation of this results in a
+      compile error.
+      </p>
+      <p>
+      This combined with the fact that we can {#syntax#}inline{#endsyntax#} loops allows us to write
+      a function which is partially evaluated at compile-time and partially at run-time.
+      </p>
+      <p>
+      For example:
+      </p>
+      {#code|test_comptime_evaluation.zig#}
+
+      <p>
+      This example is a bit contrived, because the compile-time evaluation component is unnecessary;
+      this code would work fine if it was all done at run-time. But it does end up generating
+      different code. In this example, the function {#syntax#}performFn{#endsyntax#} is generated three different times,
+          for the different values of {#syntax#}prefix_char{#endsyntax#} provided:
+      </p>
+      {#syntax_block|zig|performFn_1#}
+// From the line:
+// expect(performFn('t', 1) == 6);
+fn performFn(start_value: i32) i32 {
+    var result: i32 = start_value;
+    result = two(result);
+    result = three(result);
+    return result;
+}
+      {#end_syntax_block#}
+      {#syntax_block|zig|performFn_2#}
+// From the line:
+// expect(performFn('o', 0) == 1);
+fn performFn(start_value: i32) i32 {
+    var result: i32 = start_value;
+    result = one(result);
+    return result;
+}
+      {#end_syntax_block#}
+      {#syntax_block|zig|performFn_3#}
+// From the line:
+// expect(performFn('w', 99) == 99);
+fn performFn(start_value: i32) i32 {
+    var result: i32 = start_value;
+    _ = &result;
+    return result;
+}
+      {#end_syntax_block#}
+      <p>
+      Note that this happens even in a debug build.
+      This is not a way to write more optimized code, but it is a way to make sure that what <em>should</em> happen
+      at compile-time, <em>does</em> happen at compile-time. This catches more errors and allows expressiveness
+      that in other languages requires using macros, generated code, or a preprocessor to accomplish.
+      </p>
+      {#header_close#}
+      {#header_open|Compile-Time Expressions#}
+      <p>
+      In Zig, it matters whether a given expression is known at compile-time or run-time. A programmer can
+      use a {#syntax#}comptime{#endsyntax#} expression to guarantee that the expression will be evaluated at compile-time.
+      If this cannot be accomplished, the compiler will emit an error. For example:
+      </p>
+      {#code|test_comptime_call_extern_function.zig#}
+
+      <p>
+      It doesn't make sense that a program could call {#syntax#}exit(){#endsyntax#} (or any other external function)
+          at compile-time, so this is a compile error. However, a {#syntax#}comptime{#endsyntax#} expression does much
+      more than sometimes cause a compile error.
+      </p>
+      <p>
+      Within a {#syntax#}comptime{#endsyntax#} expression:
+      </p>
+      <ul>
+          <li>All variables are {#syntax#}comptime{#endsyntax#} variables.</li>
+          <li>All {#syntax#}if{#endsyntax#}, {#syntax#}while{#endsyntax#}, {#syntax#}for{#endsyntax#}, and {#syntax#}switch{#endsyntax#}
+          expressions are evaluated at compile-time, or emit a compile error if this is not possible.</li>
+          <li>All {#syntax#}return{#endsyntax#} and {#syntax#}try{#endsyntax#} expressions are invalid (unless the function itself is called at compile-time).</li>
+          <li>All code with runtime side effects or depending on runtime values emits a compile error.</li>
+          <li>All function calls cause the compiler to interpret the function at compile-time, emitting a
+          compile error if the function tries to do something that has global runtime side effects.</li>
+      </ul>
+      <p>
+      This means that a programmer can create a function which is called both at compile-time and run-time, with
+      no modification to the function required.
+      </p>
+      <p>
+      Let's look at an example:
+      </p>
+      {#code|test_fibonacci_recursion.zig#}
+
+      <p>
+      Imagine if we had forgotten the base case of the recursive function and tried to run the tests:
+      </p>
+      {#code|test_fibonacci_comptime_overflow.zig#}
+
+      <p>
+      The compiler produces an error which is a stack trace from trying to evaluate the
+      function at compile-time.
+      </p>
+      <p>
+      Luckily, we used an unsigned integer, and so when we tried to subtract 1 from 0, it triggered
+      {#link|Illegal Behavior#}, which is always a compile error if the compiler knows it happened.
+      But what would have happened if we used a signed integer?
+      </p>
+      {#code|fibonacci_comptime_infinite_recursion.zig#}
+
+      <p>
+      The compiler is supposed to notice that evaluating this function at
+      compile-time took more than 1000 branches, and thus emits an error and
+      gives up. If the programmer wants to increase the budget for compile-time
+      computation, they can use a built-in function called
+      {#link|@setEvalBranchQuota#} to change the default number 1000 to
+      something else.
+      </p>
+      <p>
+      However, there is a <a href="https://github.com/ziglang/zig/issues/13724">design
+      flaw in the compiler</a> causing it to stack overflow instead of having the proper
+      behavior here. I'm terribly sorry about that. I hope to get this resolved
+      before the next release.
+      </p>
+      <p>
+      What if we fix the base case, but put the wrong value in the
+      {#syntax#}expect{#endsyntax#} line?
+      </p>
+      {#code|test_fibonacci_comptime_unreachable.zig#}
+
+
+      <p>
+      At {#link|container|Containers#} level (outside of any function), all expressions are implicitly
+      {#syntax#}comptime{#endsyntax#} expressions. This means that we can use functions to
+      initialize complex static data. For example:
+      </p>
+      {#code|test_container-level_comptime_expressions.zig#}
+
+      <p>
+      When we compile this program, Zig generates the constants
+      with the answer pre-computed. Here are the lines from the generated LLVM IR:
+      </p>
+      <pre><code class="llvm">@0 = internal unnamed_addr constant [25 x i32] [i32 2, i32 3, i32 5, i32 7, i32 11, i32 13, i32 17, i32 19, i32 23, i32 29, i32 31, i32 37, i32 41, i32 43, i32 47, i32 53, i32 59, i32 61, i32 67, i32 71, i32 73, i32 79, i32 83, i32 89, i32 97]
+@1 = internal unnamed_addr constant i32 1060</code></pre>
+      <p>
+      Note that we did not have to do anything special with the syntax of these functions. For example,
+      we could call the {#syntax#}sum{#endsyntax#} function as is with a slice of numbers whose length and values were
+      only known at run-time.
+      </p>
+      {#header_close#}
+      {#header_close#}
+      {#header_open|Generic Data Structures#}
+      <p>
+      Zig uses comptime capabilities to implement generic data structures without introducing any
+      special-case syntax.
+      </p>
+      <p>
+			Here is an example of a generic {#syntax#}List{#endsyntax#} data structure.
+      </p>
+      {#code|generic_data_structure.zig#}
+
+      <p>
+      That's it. It's a function that returns an anonymous {#syntax#}struct{#endsyntax#}.
+      For the purposes of error messages and debugging, Zig infers the name
+      {#syntax#}"List(i32)"{#endsyntax#} from the function name and parameters invoked when creating
+      the anonymous struct.
+      </p>
+      <p>
+      To explicitly give a type a name, we assign it to a constant.
+      </p>
+      {#code|anonymous_struct_name.zig#}
+
+      <p>
+      In this example, the {#syntax#}Node{#endsyntax#} struct refers to itself.
+      This works because all top level declarations are order-independent.
+      As long as the compiler can determine the size of the struct, it is free to refer to itself.
+      In this case, {#syntax#}Node{#endsyntax#} refers to itself as a pointer, which has a
+      well-defined size at compile time, so it works fine.
+      </p>
+      {#header_close#}
+      {#header_open|Case Study: print in Zig#}
+      <p>
+      Putting all of this together, let's see how {#syntax#}print{#endsyntax#} works in Zig.
+      </p>
+      {#code|print.zig#}
+
+
+      <p>
+      Let's crack open the implementation of this and see how it works:
+      </p>
+
+      {#code|poc_print_fn.zig#}
+
+      <p>
+      This is a proof of concept implementation; the actual function in the standard library has more
+      formatting capabilities.
+      </p>
+      <p>
+      Note that this is not hard-coded into the Zig compiler; this is userland code in the standard library.
+      </p>
+      <p>
+      When this function is analyzed from our example code above, Zig partially evaluates the function
+      and emits a function that actually looks like this:
+      </p>
+      {#syntax_block|zig|Emitted print Function#}
+pub fn print(self: *Writer, arg0: []const u8, arg1: i32) !void {
+    try self.write("here is a string: '");
+    try self.printValue(arg0);
+    try self.write("' here is a number: ");
+    try self.printValue(arg1);
+    try self.write("\n");
+    try self.flush();
+}
+      {#end_syntax_block#}
+      <p>
+      {#syntax#}printValue{#endsyntax#} is a function that takes a parameter of any type, and does different things depending
+      on the type:
+      </p>
+      {#code|poc_printValue_fn.zig#}
+
+      <p>
+      And now, what happens if we give too many arguments to {#syntax#}print{#endsyntax#}?
+      </p>
+      {#code|test_print_too_many_args.zig#}
+
+      <p>
+      Zig gives programmers the tools needed to protect themselves against their own mistakes.
+      </p>
+      <p>
+      Zig doesn't care whether the format argument is a string literal,
+      only that it is a compile-time known value that can be coerced to a {#syntax#}[]const u8{#endsyntax#}:
+      </p>
+      {#code|print_comptime-known_format.zig#}
+
+      <p>
+      This works fine.
+      </p>
+      <p>
+      Zig does not special case string formatting in the compiler and instead exposes enough power to accomplish this
+      task in userland. It does so without introducing another language on top of Zig, such as
+      a macro language or a preprocessor language. It's Zig all the way down.
+      </p>
+      {#header_close#}
+      {#see_also|inline while|inline for#}
+      {#header_close#}
+      {#header_open|Assembly#}
+      <p>
+      For some use cases, it may be necessary to directly control the machine code generated
+      by Zig programs, rather than relying on Zig's code generation. For these cases, one
+      can use inline assembly. Here is an example of implementing Hello, World on x86_64 Linux
+      using inline assembly:
+      </p>
+      {#code|inline_assembly.zig#}
+
+      <p>
+      Dissecting the syntax:
+      </p>
+      {#code|Assembly Syntax Explained.zig#}
+
+      <p>
+      For x86 and x86_64 targets, the syntax is AT&amp;T syntax, rather than the more
+      popular Intel syntax. This is due to technical constraints; assembly parsing is
+      provided by LLVM and its support for Intel syntax is buggy and not well tested.
+      </p>
+      <p>
+      Some day Zig may have its own assembler. This would allow it to integrate more seamlessly
+      into the language, as well as be compatible with the popular NASM syntax. This documentation
+      section will be updated before 1.0.0 is released, with a conclusive statement about the status
+      of AT&amp;T vs Intel/NASM syntax.
+      </p>
+      {#header_open|Output Constraints#}
+      <p>
+      Output constraints are still considered to be unstable in Zig, and
+      so
+      <a href="http://releases.llvm.org/10.0.0/docs/LangRef.html#inline-asm-constraint-string">LLVM documentation</a>
+      and
+      <a href="https://gcc.gnu.org/onlinedocs/gcc/Extended-Asm.html">GCC documentation</a>
+      must be used to understand the semantics.
+      </p>
+      <p>
+      Note that some breaking changes to output constraints are planned with
+      <a href="https://github.com/ziglang/zig/issues/215">issue #215</a>.
+      </p>
+      {#header_close#}
+
+      {#header_open|Input Constraints#}
+      <p>
+      Input constraints are still considered to be unstable in Zig, and
+      so
+      <a href="http://releases.llvm.org/10.0.0/docs/LangRef.html#inline-asm-constraint-string">LLVM documentation</a>
+      and
+      <a href="https://gcc.gnu.org/onlinedocs/gcc/Extended-Asm.html">GCC documentation</a>
+      must be used to understand the semantics.
+      </p>
+      <p>
+      Note that some breaking changes to input constraints are planned with
+      <a href="https://github.com/ziglang/zig/issues/215">issue #215</a>.
+      </p>
+      {#header_close#}
+
+      {#header_open|Clobbers#}
+      <p>
+      Clobbers are the set of registers whose values will not be preserved by the execution of
+      the assembly code. These do not include output or input registers. The special clobber
+      value of {#syntax#}"memory"{#endsyntax#} means that the assembly causes writes to
+      arbitrary undeclared memory locations - not only the memory pointed to by a declared
+      indirect output.
+      </p>
+      <p>
+      Failure to declare the full set of clobbers for a given inline assembly
+      expression is unchecked {#link|Illegal Behavior#}.
+      </p>
+      {#header_close#}
+
+      {#header_open|Global Assembly#}
+      <p>
+      When an assembly expression occurs in a {#link|container|Containers#} level {#link|comptime#} block, this is
+      <strong>global assembly</strong>.
+      </p>
+      <p>
+      This kind of assembly has different rules than inline assembly. First, {#syntax#}volatile{#endsyntax#}
+      is not valid because all global assembly is unconditionally included.
+      Second, there are no inputs, outputs, or clobbers. All global assembly is concatenated
+      verbatim into one long string and assembled together. There are no template substitution rules regarding
+      <code>%</code> as there are in inline assembly expressions.
+      </p>
+      {#code|test_global_assembly.zig#}
+
+      {#header_close#}
+      {#header_close#}
+
+      {#header_open|Atomics#}
+      <p>TODO: @atomic rmw</p>
+      <p>TODO: builtin atomic memory ordering enum</p>
+
+      {#see_also|@atomicLoad|@atomicStore|@atomicRmw|@cmpxchgWeak|@cmpxchgStrong#}
+
+      {#header_close#}
+
+      {#header_open|Async Functions#}
+      <p>Async functions regressed with the release of 0.11.0. Their future in
+      the Zig language is unclear due to multiple unsolved problems:</p>
+      <ul>
+        <li>LLVM's lack of ability to optimize them.</li>
+        <li>Third-party debuggers' lack of ability to debug them.</li>
+        <li><a href="https://github.com/ziglang/zig/issues/5913">The cancellation problem</a>.</li>
+        <li>Async function pointers preventing the stack size from being known.</li>
+      </ul>
+      <p>These problems are surmountable, but it will take time. The Zig team
+      is currently focused on other priorities.</p>
+      {#header_close#}
+
+      {#header_open|Builtin Functions|2col#}
+      <p>
+      Builtin functions are provided by the compiler and are prefixed with <code>@</code>.
+      The {#syntax#}comptime{#endsyntax#} keyword on a parameter means that the parameter must be known
+      at compile time.
+      </p>
+      {#header_open|@addrSpaceCast#}
+      <pre>{#syntax#}@addrSpaceCast(ptr: anytype) anytype{#endsyntax#}</pre>
+      <p>
+      Converts a pointer from one address space to another. The new address space is inferred
+			based on the result type. Depending on the current target and address spaces, this cast
+			may be a no-op, a complex operation, or illegal. If the cast is legal, then the resulting
+			pointer points to the same memory location as the pointer operand. It is always valid to
+			cast a pointer between the same address spaces.
+      </p>
+      {#header_close#}
+      {#header_open|@addWithOverflow#}
+      <pre>{#syntax#}@addWithOverflow(a: anytype, b: anytype) struct { @TypeOf(a, b), u1 }{#endsyntax#}</pre>
+      <p>
+      Performs {#syntax#}a + b{#endsyntax#} and returns a tuple with the result and a possible overflow bit.
+      </p>
+      {#header_close#}
+      {#header_open|@alignCast#}
+      <pre>{#syntax#}@alignCast(ptr: anytype) anytype{#endsyntax#}</pre>
+      <p>
+      {#syntax#}ptr{#endsyntax#} can be {#syntax#}*T{#endsyntax#}, {#syntax#}?*T{#endsyntax#}, or {#syntax#}[]T{#endsyntax#}.
+			Changes the alignment of a pointer. The alignment to use is inferred based on the result type.
+      </p>
+      <p>A {#link|pointer alignment safety check|Incorrect Pointer Alignment#} is added
+      to the generated code to make sure the pointer is aligned as promised.</p>
+
+      {#header_close#}
+      {#header_open|@alignOf#}
+      <pre>{#syntax#}@alignOf(comptime T: type) comptime_int{#endsyntax#}</pre>
+      <p>
+      This function returns the number of bytes that this type should be aligned to
+      for the current target to match the C ABI. When the child type of a pointer has
+      this alignment, the alignment can be omitted from the type.
+      </p>
+      <pre>{#syntax#}const assert = @import("std").debug.assert;
+comptime {
+    assert(*u32 == *align(@alignOf(u32)) u32);
+}{#endsyntax#}</pre>
+      <p>
+      The result is a target-specific compile time constant. It is guaranteed to be
+      less than or equal to {#link|@sizeOf(T)|@sizeOf#}.
+      </p>
+      {#see_also|Alignment#}
+      {#header_close#}
+
+      {#header_open|@as#}
+      <pre>{#syntax#}@as(comptime T: type, expression) T{#endsyntax#}</pre>
+      <p>
+      Performs {#link|Type Coercion#}. This cast is allowed when the conversion is unambiguous and safe,
+      and is the preferred way to convert between types, whenever possible.
+      </p>
+      {#header_close#}
+
+      {#header_open|@atomicLoad#}
+      <pre>{#syntax#}@atomicLoad(comptime T: type, ptr: *const T, comptime ordering: AtomicOrder) T{#endsyntax#}</pre>
+      <p>
+      This builtin function atomically dereferences a pointer to a {#syntax#}T{#endsyntax#} and returns the value.
+      </p>
+      <p>
+      {#syntax#}T{#endsyntax#} must be a pointer, a {#syntax#}bool{#endsyntax#}, a float,
+      an integer or an enum.
+      </p>
+      <p>{#syntax#}AtomicOrder{#endsyntax#} can be found with {#syntax#}@import("std").builtin.AtomicOrder{#endsyntax#}.</p>
+      {#see_also|@atomicStore|@atomicRmw||@cmpxchgWeak|@cmpxchgStrong#}
+      {#header_close#}
+
+      {#header_open|@atomicRmw#}
+      <pre>{#syntax#}@atomicRmw(comptime T: type, ptr: *T, comptime op: AtomicRmwOp, operand: T, comptime ordering: AtomicOrder) T{#endsyntax#}</pre>
+      <p>
+      This builtin function dereferences a pointer to a {#syntax#}T{#endsyntax#} and atomically
+      modifies the value and returns the previous value.
+      </p>
+      <p>
+      {#syntax#}T{#endsyntax#} must be a pointer, a {#syntax#}bool{#endsyntax#}, a float,
+      an integer or an enum.
+      </p>
+      <p>{#syntax#}AtomicOrder{#endsyntax#} can be found with {#syntax#}@import("std").builtin.AtomicOrder{#endsyntax#}.</p>
+      <p>{#syntax#}AtomicRmwOp{#endsyntax#} can be found with {#syntax#}@import("std").builtin.AtomicRmwOp{#endsyntax#}.</p>
+      {#see_also|@atomicStore|@atomicLoad|@cmpxchgWeak|@cmpxchgStrong#}
+      {#header_close#}
+
+      {#header_open|@atomicStore#}
+      <pre>{#syntax#}@atomicStore(comptime T: type, ptr: *T, value: T, comptime ordering: AtomicOrder) void{#endsyntax#}</pre>
+      <p>
+      This builtin function dereferences a pointer to a {#syntax#}T{#endsyntax#} and atomically stores the given value.
+      </p>
+      <p>
+      {#syntax#}T{#endsyntax#} must be a pointer, a {#syntax#}bool{#endsyntax#}, a float,
+      an integer or an enum.
+      </p>
+      <p>{#syntax#}AtomicOrder{#endsyntax#} can be found with {#syntax#}@import("std").builtin.AtomicOrder{#endsyntax#}.</p>
+      {#see_also|@atomicLoad|@atomicRmw|@cmpxchgWeak|@cmpxchgStrong#}
+      {#header_close#}
+
+      {#header_open|@bitCast#}
+      <pre>{#syntax#}@bitCast(value: anytype) anytype{#endsyntax#}</pre>
+      <p>
+      Converts a value of one type to another type. The return type is the
+			inferred result type.
+      </p>
+      <p>
+      Asserts that {#syntax#}@sizeOf(@TypeOf(value)) == @sizeOf(DestType){#endsyntax#}.
+      </p>
+      <p>
+      Asserts that {#syntax#}@typeInfo(DestType) != .pointer{#endsyntax#}. Use {#syntax#}@ptrCast{#endsyntax#} or {#syntax#}@ptrFromInt{#endsyntax#} if you need this.
+      </p>
+      <p>
+      Can be used for these things for example:
+      </p>
+      <ul>
+          <li>Convert {#syntax#}f32{#endsyntax#} to {#syntax#}u32{#endsyntax#} bits</li>
+          <li>Convert {#syntax#}i32{#endsyntax#} to {#syntax#}u32{#endsyntax#} preserving twos complement</li>
+      </ul>
+      <p>
+      Works at compile-time if {#syntax#}value{#endsyntax#} is known at compile time. It's a compile error to bitcast a value of undefined layout; this means that, besides the restriction from types which possess dedicated casting builtins (enums, pointers, error sets), bare structs, error unions, slices, optionals, and any other type without a well-defined memory layout, also cannot be used in this operation.
+      </p>
+      {#header_close#}
+
+      {#header_open|@bitOffsetOf#}
+      <pre>{#syntax#}@bitOffsetOf(comptime T: type, comptime field_name: []const u8) comptime_int{#endsyntax#}</pre>
+      <p>
+      Returns the bit offset of a field relative to its containing struct.
+      </p>
+      <p>
+      For non {#link|packed structs|packed struct#}, this will always be divisible by {#syntax#}8{#endsyntax#}.
+      For packed structs, non-byte-aligned fields will share a byte offset, but they will have different
+      bit offsets.
+      </p>
+      {#see_also|@offsetOf#}
+      {#header_close#}
+
+      {#header_open|@bitSizeOf#}
+      <pre>{#syntax#}@bitSizeOf(comptime T: type) comptime_int{#endsyntax#}</pre>
+      <p>
+      This function returns the number of bits it takes to store {#syntax#}T{#endsyntax#} in memory if the type
+      were a field in a packed struct/union.
+      The result is a target-specific compile time constant.
+      </p>
+      <p>
+      This function measures the size at runtime. For types that are disallowed at runtime, such as
+      {#syntax#}comptime_int{#endsyntax#} and {#syntax#}type{#endsyntax#}, the result is {#syntax#}0{#endsyntax#}.
+      </p>
+      {#see_also|@sizeOf|@typeInfo#}
+      {#header_close#}
+
+      {#header_open|@branchHint#}
+      <pre>{#syntax#}@branchHint(hint: BranchHint) void{#endsyntax#}</pre>
+      <p>Hints to the optimizer how likely a given branch of control flow is to be reached.</p>
+      <p>{#syntax#}BranchHint{#endsyntax#} can be found with {#syntax#}@import("std").builtin.BranchHint{#endsyntax#}.</p>
+      <p>This function is only valid as the first statement in a control flow branch, or the first statement in a function.</p>
+      {#header_close#}
+
+      {#header_open|@breakpoint#}
+      <pre>{#syntax#}@breakpoint() void{#endsyntax#}</pre>
+      <p>
+      This function inserts a platform-specific debug trap instruction which causes
+      debuggers to break there.
+      Unlike for {#syntax#}@trap(){#endsyntax#}, execution may continue after this point if the program is resumed.
+      </p>
+      <p>
+      This function is only valid within function scope.
+      </p>
+      {#see_also|@trap#}
+      {#header_close#}
+
+      {#header_open|@mulAdd#}
+      <pre>{#syntax#}@mulAdd(comptime T: type, a: T, b: T, c: T) T{#endsyntax#}</pre>
+      <p>
+      Fused multiply-add, similar to {#syntax#}(a * b) + c{#endsyntax#}, except
+      only rounds once, and is thus more accurate.
+      </p>
+      <p>
+      Supports {#link|Floats#} and {#link|Vectors#} of floats.
+      </p>
+      {#header_close#}
+
+      {#header_open|@byteSwap#}
+      <pre>{#syntax#}@byteSwap(operand: anytype) T{#endsyntax#}</pre>
+      <p>{#syntax#}@TypeOf(operand){#endsyntax#} must be an integer type or an integer vector type with bit count evenly divisible by 8.</p>
+      <p>{#syntax#}operand{#endsyntax#} may be an {#link|integer|Integers#} or {#link|vector|Vectors#}.</p>
+      <p>
+      Swaps the byte order of the integer. This converts a big endian integer to a little endian integer,
+      and converts a little endian integer to a big endian integer.
+      </p>
+      <p>
+      Note that for the purposes of memory layout with respect to endianness, the integer type should be
+      related to the number of bytes reported by {#link|@sizeOf#} bytes. This is demonstrated with
+      {#syntax#}u24{#endsyntax#}. {#syntax#}@sizeOf(u24) == 4{#endsyntax#}, which means that a
+      {#syntax#}u24{#endsyntax#} stored in memory takes 4 bytes, and those 4 bytes are what are swapped on
+      a little vs big endian system. On the other hand, if {#syntax#}T{#endsyntax#} is specified to
+      be {#syntax#}u24{#endsyntax#}, then only 3 bytes are reversed.
+      </p>
+      {#header_close#}
+
+      {#header_open|@bitReverse#}
+      <pre>{#syntax#}@bitReverse(integer: anytype) T{#endsyntax#}</pre>
+      <p>{#syntax#}@TypeOf(anytype){#endsyntax#} accepts any integer type or integer vector type.</p>
+      <p>
+      Reverses the bitpattern of an integer value, including the sign bit if applicable.
+      </p>
+      <p>
+      For example 0b10110110 ({#syntax#}u8 = 182{#endsyntax#}, {#syntax#}i8 = -74{#endsyntax#})
+      becomes 0b01101101 ({#syntax#}u8 = 109{#endsyntax#}, {#syntax#}i8 = 109{#endsyntax#}).
+      </p>
+      {#header_close#}
+
+      {#header_open|@offsetOf#}
+      <pre>{#syntax#}@offsetOf(comptime T: type, comptime field_name: []const u8) comptime_int{#endsyntax#}</pre>
+      <p>
+      Returns the byte offset of a field relative to its containing struct.
+      </p>
+      {#see_also|@bitOffsetOf#}
+      {#header_close#}
+
+      {#header_open|@call#}
+      <pre>{#syntax#}@call(modifier: std.builtin.CallModifier, function: anytype, args: anytype) anytype{#endsyntax#}</pre>
+      <p>
+      Calls a function, in the same way that invoking an expression with parentheses does:
+      </p>
+      {#code|test_call_builtin.zig#}
+
+      <p>
+      {#syntax#}@call{#endsyntax#} allows more flexibility than normal function call syntax does. The
+      {#syntax#}CallModifier{#endsyntax#} enum is reproduced here:
+      </p>
+      {#code|builtin.CallModifier struct.zig#}
+
+      {#header_close#}
+
+      {#header_open|@cDefine#}
+      <pre>{#syntax#}@cDefine(comptime name: []const u8, value) void{#endsyntax#}</pre>
+      <p>
+      This function can only occur inside {#syntax#}@cImport{#endsyntax#}.
+      </p>
+      <p>
+      This appends <code>#define $name $value</code> to the {#syntax#}@cImport{#endsyntax#}
+      temporary buffer.
+      </p>
+      <p>
+      To define without a value, like this:
+      </p>
+      <pre><code class="c">#define _GNU_SOURCE</code></pre>
+      <p>
+      Use the void value, like this:
+      </p>
+      <pre>{#syntax#}@cDefine("_GNU_SOURCE", {}){#endsyntax#}</pre>
+      {#see_also|Import from C Header File|@cInclude|@cImport|@cUndef|void#}
+      {#header_close#}
+      {#header_open|@cImport#}
+      <pre>{#syntax#}@cImport(expression) type{#endsyntax#}</pre>
+      <p>
+      This function parses C code and imports the functions, types, variables,
+      and compatible macro definitions into a new empty struct type, and then
+      returns that type.
+      </p>
+      <p>
+      {#syntax#}expression{#endsyntax#} is interpreted at compile time. The builtin functions
+          {#syntax#}@cInclude{#endsyntax#}, {#syntax#}@cDefine{#endsyntax#}, and {#syntax#}@cUndef{#endsyntax#} work
+      within this expression, appending to a temporary buffer which is then parsed as C code.
+      </p>
+      <p>
+      Usually you should only have one {#syntax#}@cImport{#endsyntax#} in your entire application, because it saves the compiler
+      from invoking clang multiple times, and prevents inline functions from being duplicated.
+      </p>
+      <p>
+      Reasons for having multiple {#syntax#}@cImport{#endsyntax#} expressions would be:
+      </p>
+      <ul>
+          <li>To avoid a symbol collision, for example if foo.h and bar.h both <code>#define CONNECTION_COUNT</code></li>
+        <li>To analyze the C code with different preprocessor defines</li>
+      </ul>
+      {#see_also|Import from C Header File|@cInclude|@cDefine|@cUndef#}
+      {#header_close#}
+      {#header_open|@cInclude#}
+      <pre>{#syntax#}@cInclude(comptime path: []const u8) void{#endsyntax#}</pre>
+      <p>
+      This function can only occur inside {#syntax#}@cImport{#endsyntax#}.
+      </p>
+      <p>
+      This appends <code>#include &lt;$path&gt;\n</code> to the {#syntax#}c_import{#endsyntax#}
+      temporary buffer.
+      </p>
+      {#see_also|Import from C Header File|@cImport|@cDefine|@cUndef#}
+      {#header_close#}
+
+      {#header_open|@clz#}
+      <pre>{#syntax#}@clz(operand: anytype) anytype{#endsyntax#}</pre>
+      <p>{#syntax#}@TypeOf(operand){#endsyntax#} must be an integer type or an integer vector type.</p>
+      <p>{#syntax#}operand{#endsyntax#} may be an {#link|integer|Integers#} or {#link|vector|Vectors#}.</p>
+      <p>
+      Counts the number of most-significant (leading in a big-endian sense) zeroes in an integer - "count leading zeroes".
+      </p>
+      <p>
+      The return type is an unsigned integer or vector of unsigned integers with the minimum number
+      of bits that can represent the bit count of the integer type.
+      </p>
+      <p>
+      If {#syntax#}operand{#endsyntax#} is zero, {#syntax#}@clz{#endsyntax#} returns the bit width
+      of integer type {#syntax#}T{#endsyntax#}.
+      </p>
+      {#see_also|@ctz|@popCount#}
+      {#header_close#}
+
+      {#header_open|@cmpxchgStrong#}
+      <pre>{#syntax#}@cmpxchgStrong(comptime T: type, ptr: *T, expected_value: T, new_value: T, success_order: AtomicOrder, fail_order: AtomicOrder) ?T{#endsyntax#}</pre>
+      <p>
+      This function performs a strong atomic compare-and-exchange operation, returning {#syntax#}null{#endsyntax#}
+      if the current value is the given expected value. It's the equivalent of this code,
+      except atomic:
+      </p>
+      {#code|not_atomic_cmpxchgStrong.zig#}
+
+      <p>
+      If you are using cmpxchg in a retry loop, {#link|@cmpxchgWeak#} is the better choice, because it can be implemented
+      more efficiently in machine instructions.
+      </p>
+      <p>
+      {#syntax#}T{#endsyntax#} must be a pointer, a {#syntax#}bool{#endsyntax#}, a float,
+      an integer or an enum.
+      </p>
+      <p>{#syntax#}@typeInfo(@TypeOf(ptr)).pointer.alignment{#endsyntax#} must be {#syntax#}>= @sizeOf(T).{#endsyntax#}</p>
+      <p>{#syntax#}AtomicOrder{#endsyntax#} can be found with {#syntax#}@import("std").builtin.AtomicOrder{#endsyntax#}.</p>
+      {#see_also|@atomicStore|@atomicLoad|@atomicRmw|@cmpxchgWeak#}
+      {#header_close#}
+
+      {#header_open|@cmpxchgWeak#}
+      <pre>{#syntax#}@cmpxchgWeak(comptime T: type, ptr: *T, expected_value: T, new_value: T, success_order: AtomicOrder, fail_order: AtomicOrder) ?T{#endsyntax#}</pre>
+      <p>
+      This function performs a weak atomic compare-and-exchange operation, returning {#syntax#}null{#endsyntax#}
+      if the current value is the given expected value. It's the equivalent of this code,
+      except atomic:
+      </p>
+      {#syntax_block|zig|cmpxchgWeakButNotAtomic#}
+fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_value: T) ?T {
+    const old_value = ptr.*;
+    if (old_value == expected_value and usuallyTrueButSometimesFalse()) {
+        ptr.* = new_value;
+        return null;
+    } else {
+        return old_value;
+    }
+}
+      {#end_syntax_block#}
+      <p>
+      If you are using cmpxchg in a retry loop, the sporadic failure will be no problem, and {#syntax#}cmpxchgWeak{#endsyntax#}
+      is the better choice, because it can be implemented more efficiently in machine instructions.
+      However if you need a stronger guarantee, use {#link|@cmpxchgStrong#}.
+      </p>
+      <p>
+      {#syntax#}T{#endsyntax#} must be a pointer, a {#syntax#}bool{#endsyntax#}, a float,
+      an integer or an enum.
+      </p>
+      <p>{#syntax#}@typeInfo(@TypeOf(ptr)).pointer.alignment{#endsyntax#} must be {#syntax#}>= @sizeOf(T).{#endsyntax#}</p>
+      <p>{#syntax#}AtomicOrder{#endsyntax#} can be found with {#syntax#}@import("std").builtin.AtomicOrder{#endsyntax#}.</p>
+      {#see_also|@atomicStore|@atomicLoad|@atomicRmw|@cmpxchgStrong#}
+      {#header_close#}
+
+      {#header_open|@compileError#}
+      <pre>{#syntax#}@compileError(comptime msg: []const u8) noreturn{#endsyntax#}</pre>
+      <p>
+      This function, when semantically analyzed, causes a compile error with the
+      message {#syntax#}msg{#endsyntax#}.
+      </p>
+      <p>
+      There are several ways that code avoids being semantically checked, such as
+      using {#syntax#}if{#endsyntax#} or {#syntax#}switch{#endsyntax#} with compile time constants,
+              and {#syntax#}comptime{#endsyntax#} functions.
+      </p>
+      {#header_close#}
+
+      {#header_open|@compileLog#}
+      <pre>{#syntax#}@compileLog(...) void{#endsyntax#}</pre>
+      <p>
+      This function prints the arguments passed to it at compile-time.
+      </p>
+      <p>
+      To prevent accidentally leaving compile log statements in a codebase,
+      a compilation error is added to the build, pointing to the compile
+      log statement. This error prevents code from being generated, but
+      does not otherwise interfere with analysis.
+      </p>
+      <p>
+      This function can be used to do "printf debugging" on
+      compile-time executing code.
+      </p>
+      {#code|test_compileLog_builtin.zig#}
+
+      {#header_close#}
+
+      {#header_open|@constCast#}
+      <pre>{#syntax#}@constCast(value: anytype) DestType{#endsyntax#}</pre>
+      <p>
+      Remove {#syntax#}const{#endsyntax#} qualifier from a pointer.
+      </p>
+      {#header_close#}
+
+      {#header_open|@ctz#}
+      <pre>{#syntax#}@ctz(operand: anytype) anytype{#endsyntax#}</pre>
+      <p>{#syntax#}@TypeOf(operand){#endsyntax#} must be an integer type or an integer vector type.</p>
+      <p>{#syntax#}operand{#endsyntax#} may be an {#link|integer|Integers#} or {#link|vector|Vectors#}.</p>
+      <p>
+      Counts the number of least-significant (trailing in a big-endian sense) zeroes in an integer - "count trailing zeroes".
+      </p>
+      <p>
+      The return type is an unsigned integer or vector of unsigned integers with the minimum number
+      of bits that can represent the bit count of the integer type.
+      </p>
+      <p>
+      If {#syntax#}operand{#endsyntax#} is zero, {#syntax#}@ctz{#endsyntax#} returns
+      the bit width of integer type {#syntax#}T{#endsyntax#}.
+      </p>
+      {#see_also|@clz|@popCount#}
+      {#header_close#}
+
+      {#header_open|@cUndef#}
+      <pre>{#syntax#}@cUndef(comptime name: []const u8) void{#endsyntax#}</pre>
+      <p>
+      This function can only occur inside {#syntax#}@cImport{#endsyntax#}.
+      </p>
+      <p>
+      This appends <code>#undef $name</code> to the {#syntax#}@cImport{#endsyntax#}
+      temporary buffer.
+      </p>
+      {#see_also|Import from C Header File|@cImport|@cDefine|@cInclude#}
+      {#header_close#}
+
+      {#header_open|@cVaArg#}
+      <pre>{#syntax#}@cVaArg(operand: *std.builtin.VaList, comptime T: type) T{#endsyntax#}</pre>
+      <p>
+      Implements the C macro {#syntax#}va_arg{#endsyntax#}.
+      </p>
+      {#see_also|@cVaCopy|@cVaEnd|@cVaStart#}
+      {#header_close#}
+      {#header_open|@cVaCopy#}
+      <pre>{#syntax#}@cVaCopy(src: *std.builtin.VaList) std.builtin.VaList{#endsyntax#}</pre>
+      <p>
+      Implements the C macro {#syntax#}va_copy{#endsyntax#}.
+      </p>
+      {#see_also|@cVaArg|@cVaEnd|@cVaStart#}
+      {#header_close#}
+      {#header_open|@cVaEnd#}
+      <pre>{#syntax#}@cVaEnd(src: *std.builtin.VaList) void{#endsyntax#}</pre>
+      <p>
+      Implements the C macro {#syntax#}va_end{#endsyntax#}.
+      </p>
+      {#see_also|@cVaArg|@cVaCopy|@cVaStart#}
+      {#header_close#}
+      {#header_open|@cVaStart#}
+      <pre>{#syntax#}@cVaStart() std.builtin.VaList{#endsyntax#}</pre>
+      <p>
+      Implements the C macro {#syntax#}va_start{#endsyntax#}. Only valid inside a variadic function.
+      </p>
+      {#see_also|@cVaArg|@cVaCopy|@cVaEnd#}
+      {#header_close#}
+
+      {#header_open|@divExact#}
+      <pre>{#syntax#}@divExact(numerator: T, denominator: T) T{#endsyntax#}</pre>
+      <p>
+      Exact division. Caller guarantees {#syntax#}denominator != 0{#endsyntax#} and
+          {#syntax#}@divTrunc(numerator, denominator) * denominator == numerator{#endsyntax#}.
+      </p>
+      <ul>
+          <li>{#syntax#}@divExact(6, 3) == 2{#endsyntax#}</li>
+          <li>{#syntax#}@divExact(a, b) * b == a{#endsyntax#}</li>
+      </ul>
+      <p>For a function that returns a possible error code, use {#syntax#}@import("std").math.divExact{#endsyntax#}.</p>
+      {#see_also|@divTrunc|@divFloor#}
+      {#header_close#}
+      {#header_open|@divFloor#}
+      <pre>{#syntax#}@divFloor(numerator: T, denominator: T) T{#endsyntax#}</pre>
+      <p>
+      Floored division. Rounds toward negative infinity. For unsigned integers it is
+      the same as {#syntax#}numerator / denominator{#endsyntax#}. Caller guarantees {#syntax#}denominator != 0{#endsyntax#} and
+              {#syntax#}!(@typeInfo(T) == .int and T.is_signed and numerator == std.math.minInt(T) and denominator == -1){#endsyntax#}.
+      </p>
+      <ul>
+          <li>{#syntax#}@divFloor(-5, 3) == -2{#endsyntax#}</li>
+          <li>{#syntax#}(@divFloor(a, b) * b) + @mod(a, b) == a{#endsyntax#}</li>
+      </ul>
+      <p>For a function that returns a possible error code, use {#syntax#}@import("std").math.divFloor{#endsyntax#}.</p>
+      {#see_also|@divTrunc|@divExact#}
+      {#header_close#}
+      {#header_open|@divTrunc#}
+      <pre>{#syntax#}@divTrunc(numerator: T, denominator: T) T{#endsyntax#}</pre>
+      <p>
+      Truncated division. Rounds toward zero. For unsigned integers it is
+      the same as {#syntax#}numerator / denominator{#endsyntax#}. Caller guarantees {#syntax#}denominator != 0{#endsyntax#} and
+              {#syntax#}!(@typeInfo(T) == .int and T.is_signed and numerator == std.math.minInt(T) and denominator == -1){#endsyntax#}.
+      </p>
+      <ul>
+          <li>{#syntax#}@divTrunc(-5, 3) == -1{#endsyntax#}</li>
+          <li>{#syntax#}(@divTrunc(a, b) * b) + @rem(a, b) == a{#endsyntax#}</li>
+      </ul>
+      <p>For a function that returns a possible error code, use {#syntax#}@import("std").math.divTrunc{#endsyntax#}.</p>
+      {#see_also|@divFloor|@divExact#}
+      {#header_close#}
+
+      {#header_open|@embedFile#}
+      <pre>{#syntax#}@embedFile(comptime path: []const u8) *const [N:0]u8{#endsyntax#}</pre>
+      <p>
+      This function returns a compile time constant pointer to null-terminated,
+      fixed-size array with length equal to the byte count of the file given by
+      {#syntax#}path{#endsyntax#}. The contents of the array are the contents of the file.
+      This is equivalent to a {#link|string literal|String Literals and Unicode Code Point Literals#}
+      with the file contents.
+      </p>
+      <p>
+      {#syntax#}path{#endsyntax#} is absolute or relative to the current file, just like {#syntax#}@import{#endsyntax#}.
+      </p>
+      {#see_also|@import#}
+      {#header_close#}
+
+      {#header_open|@enumFromInt#}
+      <pre>{#syntax#}@enumFromInt(integer: anytype) anytype{#endsyntax#}</pre>
+      <p>
+      Converts an integer into an {#link|enum#} value. The return type is the inferred result type.
+      </p>
+      <p>
+      Attempting to convert an integer with no corresponding value in the enum invokes
+      safety-checked {#link|Illegal Behavior#}.
+      Note that a {#link|non-exhaustive enum|Non-exhaustive enum#} has corresponding values for all
+      integers in the enum's integer tag type: the {#syntax#}_{#endsyntax#} value represents all
+      the remaining unnamed integers in the enum's tag type.
+      </p>
+      {#see_also|@intFromEnum#}
+      {#header_close#}
+
+      {#header_open|@errorFromInt#}
+      <pre>{#syntax#}@errorFromInt(value: std.meta.Int(.unsigned, @bitSizeOf(anyerror))) anyerror{#endsyntax#}</pre>
+      <p>
+      Converts from the integer representation of an error into {#link|The Global Error Set#} type.
+      </p>
+      <p>
+      It is generally recommended to avoid this
+      cast, as the integer representation of an error is not stable across source code changes.
+      </p>
+      <p>
+      Attempting to convert an integer that does not correspond to any error results in
+      safety-checked {#link|Illegal Behavior#}.
+      </p>
+      {#see_also|@intFromError#}
+      {#header_close#}
+
+      {#header_open|@errorName#}
+      <pre>{#syntax#}@errorName(err: anyerror) [:0]const u8{#endsyntax#}</pre>
+      <p>
+      This function returns the string representation of an error. The string representation
+      of {#syntax#}error.OutOfMem{#endsyntax#} is {#syntax#}"OutOfMem"{#endsyntax#}.
+      </p>
+      <p>
+      If there are no calls to {#syntax#}@errorName{#endsyntax#} in an entire application,
+      or all calls have a compile-time known value for {#syntax#}err{#endsyntax#}, then no
+      error name table will be generated.
+      </p>
+      {#header_close#}
+
+      {#header_open|@errorReturnTrace#}
+      <pre>{#syntax#}@errorReturnTrace() ?*builtin.StackTrace{#endsyntax#}</pre>
+      <p>
+      If the binary is built with error return tracing, and this function is invoked in a
+      function that calls a function with an error or error union return type, returns a
+      stack trace object. Otherwise returns {#link|null#}.
+      </p>
+      {#header_close#}
+
+      {#header_open|@errorCast#}
+      <pre>{#syntax#}@errorCast(value: anytype) anytype{#endsyntax#}</pre>
+      <p>
+      Converts an error set or error union value from one error set to another error set. The return type is the
+			inferred result type. Attempting to convert an error which is not in the destination error
+			set results in safety-checked {#link|Illegal Behavior#}.
+      </p>
+      {#header_close#}
+
+      {#header_open|@export#}
+      <pre>{#syntax#}@export(comptime ptr: *const anyopaque, comptime options: std.builtin.ExportOptions) void{#endsyntax#}</pre>
+      <p>Creates a symbol in the output object file which refers to the target of <code>ptr</code>.</p>
+      <p><code>ptr</code> must point to a global variable or a comptime-known constant.</p>
+      <p>
+      This builtin can be called from a {#link|comptime#} block to conditionally export symbols.
+      When <code>ptr</code> points to a function with the C calling convention and
+      {#syntax#}options.linkage{#endsyntax#} is {#syntax#}.Strong{#endsyntax#}, this is equivalent to
+      the {#syntax#}export{#endsyntax#} keyword used on a function:
+      </p>
+      {#code|export_builtin.zig#}
+
+      <p>This is equivalent to:</p>
+      {#code|export_builtin_equivalent_code.zig#}
+
+      <p>Note that even when using {#syntax#}export{#endsyntax#}, the {#syntax#}@"foo"{#endsyntax#} syntax for
+      {#link|identifiers|Identifiers#} can be used to choose any string for the symbol name:</p>
+      {#code|export_any_symbol_name.zig#}
+
+      <p>
+      When looking at the resulting object, you can see the symbol is used verbatim:
+      </p>
+      <pre><code>00000000000001f0 T A function name that is a complete sentence.</code></pre>
+      {#see_also|Exporting a C Library#}
+      {#header_close#}
+
+      {#header_open|@extern#}
+      <pre>{#syntax#}@extern(T: type, comptime options: std.builtin.ExternOptions) T{#endsyntax#}</pre>
+      <p>
+      Creates a reference to an external symbol in the output object file.
+      T must be a pointer type.
+      </p>
+      {#see_also|@export#}
+      {#header_close#}
+
+      {#header_open|@field#}
+      <pre>{#syntax#}@field(lhs: anytype, comptime field_name: []const u8) (field){#endsyntax#}</pre>
+      <p>Performs field access by a compile-time string. Works on both fields and declarations.
+      </p>
+      {#code|test_field_builtin.zig#}
+
+
+      {#header_close#}
+
+      {#header_open|@fieldParentPtr#}
+      <pre>{#syntax#}@fieldParentPtr(comptime field_name: []const u8, field_ptr: *T) anytype{#endsyntax#}</pre>
+      <p>
+      Given a pointer to a struct field, returns a pointer to the struct containing that field.
+      The return type (and struct in question) is the inferred result type.
+      </p>
+      <p>
+      If {#syntax#}field_ptr{#endsyntax#} does not point to the {#syntax#}field_name{#endsyntax#} field of an instance of
+      the result type, and the result type has ill-defined layout, invokes unchecked {#link|Illegal Behavior#}.
+      </p>
+      {#header_close#}
+
+      {#header_open|@FieldType#}
+      <pre>{#syntax#}@FieldType(comptime Type: type, comptime field_name: []const u8) type{#endsyntax#}</pre>
+      <p>
+      Given a type and the name of one of its fields, returns the type of that field.
+      </p>
+      {#header_close#}
+
+      {#header_open|@floatCast#}
+      <pre>{#syntax#}@floatCast(value: anytype) anytype{#endsyntax#}</pre>
+      <p>
+      Convert from one float type to another. This cast is safe, but may cause the
+      numeric value to lose precision. The return type is the inferred result type.
+      </p>
+      {#header_close#}
+
+      {#header_open|@floatFromInt#}
+      <pre>{#syntax#}@floatFromInt(int: anytype) anytype{#endsyntax#}</pre>
+      <p>
+      Converts an integer to the closest floating point representation. The return type is the inferred result type.
+			To convert the other way, use {#link|@intFromFloat#}. This operation is legal
+      for all values of all integer types.
+      </p>
+      {#header_close#}
+
+      {#header_open|@frameAddress#}
+      <pre>{#syntax#}@frameAddress() usize{#endsyntax#}</pre>
+      <p>
+      This function returns the base pointer of the current stack frame.
+      </p>
+      <p>
+      The implications of this are target-specific and not consistent across all
+      platforms. The frame address may not be available in release mode due to
+      aggressive optimizations.
+      </p>
+      <p>
+      This function is only valid within function scope.
+      </p>
+      {#header_close#}
+
+      {#header_open|@hasDecl#}
+      <pre>{#syntax#}@hasDecl(comptime Container: type, comptime name: []const u8) bool{#endsyntax#}</pre>
+      <p>
+      Returns whether or not a {#link|container|Containers#} has a declaration
+      matching {#syntax#}name{#endsyntax#}.
+      </p>
+      {#code|test_hasDecl_builtin.zig#}
+
+      {#see_also|@hasField#}
+      {#header_close#}
+
+      {#header_open|@hasField#}
+      <pre>{#syntax#}@hasField(comptime Container: type, comptime name: []const u8) bool{#endsyntax#}</pre>
+      <p>Returns whether the field name of a struct, union, or enum exists.</p>
+      <p>
+      The result is a compile time constant.
+      </p>
+      <p>
+      It does not include functions, variables, or constants.
+      </p>
+      {#see_also|@hasDecl#}
+      {#header_close#}
+
+      {#header_open|@import#}
+      <pre>{#syntax#}@import(comptime path: []const u8) type{#endsyntax#}</pre>
+      <p>
+      This function finds a zig file corresponding to {#syntax#}path{#endsyntax#} and adds it to the build,
+      if it is not already added.
+      </p>
+      <p>
+      Zig source files are implicitly structs, with a name equal to the file's basename with the extension
+      truncated. {#syntax#}@import{#endsyntax#} returns the struct type corresponding to the file.
+      </p>
+      <p>
+      Declarations which have the {#syntax#}pub{#endsyntax#} keyword may be referenced from a different
+      source file than the one they are declared in.
+      </p>
+      <p>
+      {#syntax#}path{#endsyntax#} can be a relative path or it can be the name of a package.
+      If it is a relative path, it is relative to the file that contains the {#syntax#}@import{#endsyntax#}
+      function call.
+      </p>
+      <p>
+      The following packages are always available:
+      </p>
+      <ul>
+          <li>{#syntax#}@import("std"){#endsyntax#} - Zig Standard Library</li>
+          <li>{#syntax#}@import("builtin"){#endsyntax#} - Target-specific information
+              The command <code>zig build-exe --show-builtin</code> outputs the source to stdout for reference.
+          </li>
+          <li>{#syntax#}@import("root"){#endsyntax#} - Root source file
+              This is usually <code>src/main.zig</code> but depends on what file is built.
+          </li>
+      </ul>
+      {#see_also|Compile Variables|@embedFile#}
+      {#header_close#}
+
+      {#header_open|@inComptime#}
+      <pre>{#syntax#}@inComptime() bool{#endsyntax#}</pre>
+      <p>
+      Returns whether the builtin was run in a {#syntax#}comptime{#endsyntax#} context. The result is a compile-time constant.
+      </p>
+      <p>
+      This can be used to provide alternative, comptime-friendly implementations of functions. It should not be used, for instance, to exclude certain functions from being evaluated at comptime.
+      </p>
+      {#see_also|comptime#}
+      {#header_close#}
+
+      {#header_open|@intCast#}
+      <pre>{#syntax#}@intCast(int: anytype) anytype{#endsyntax#}</pre>
+      <p>
+      Converts an integer to another integer while keeping the same numerical value.
+			The return type is the inferred result type.
+      Attempting to convert a number which is out of range of the destination type results in
+      safety-checked {#link|Illegal Behavior#}.
+      </p>
+      {#code|test_intCast_builtin.zig#}
+
+      <p>
+      To truncate the significant bits of a number out of range of the destination type, use {#link|@truncate#}.
+      </p>
+      <p>
+      If {#syntax#}T{#endsyntax#} is {#syntax#}comptime_int{#endsyntax#},
+      then this is semantically equivalent to {#link|Type Coercion#}.
+      </p>
+      {#header_close#}
+
+      {#header_open|@intFromBool#}
+      <pre>{#syntax#}@intFromBool(value: bool) u1{#endsyntax#}</pre>
+      <p>
+      Converts {#syntax#}true{#endsyntax#} to {#syntax#}@as(u1, 1){#endsyntax#} and {#syntax#}false{#endsyntax#} to
+                  {#syntax#}@as(u1, 0){#endsyntax#}.
+      </p>
+      {#header_close#}
+
+      {#header_open|@intFromEnum#}
+      <pre>{#syntax#}@intFromEnum(enum_or_tagged_union: anytype) anytype{#endsyntax#}</pre>
+      <p>
+      Converts an enumeration value into its integer tag type. When a tagged union is passed,
+      the tag value is used as the enumeration value.
+      </p>
+      <p>
+      If there is only one possible enum value, the result is a {#syntax#}comptime_int{#endsyntax#}
+      known at {#link|comptime#}.
+      </p>
+      {#see_also|@enumFromInt#}
+      {#header_close#}
+
+      {#header_open|@intFromError#}
+      <pre>{#syntax#}@intFromError(err: anytype) std.meta.Int(.unsigned, @bitSizeOf(anyerror)){#endsyntax#}</pre>
+      <p>
+      Supports the following types:
+      </p>
+      <ul>
+          <li>{#link|The Global Error Set#}</li>
+          <li>{#link|Error Set Type#}</li>
+          <li>{#link|Error Union Type#}</li>
+      </ul>
+      <p>
+      Converts an error to the integer representation of an error.
+      </p>
+      <p>
+      It is generally recommended to avoid this
+      cast, as the integer representation of an error is not stable across source code changes.
+      </p>
+      {#see_also|@errorFromInt#}
+      {#header_close#}
+
+      {#header_open|@intFromFloat#}
+      <pre>{#syntax#}@intFromFloat(float: anytype) anytype{#endsyntax#}</pre>
+      <p>
+      Converts the integer part of a floating point number to the inferred result type.
+      </p>
+      <p>
+      If the integer part of the floating point number cannot fit in the destination type,
+      it invokes safety-checked {#link|Illegal Behavior#}.
+      </p>
+      {#see_also|@floatFromInt#}
+      {#header_close#}
+
+      {#header_open|@intFromPtr#}
+      <pre>{#syntax#}@intFromPtr(value: anytype) usize{#endsyntax#}</pre>
+      <p>
+      Converts {#syntax#}value{#endsyntax#} to a {#syntax#}usize{#endsyntax#} which is the address of the pointer.
+      {#syntax#}value{#endsyntax#} can be {#syntax#}*T{#endsyntax#} or {#syntax#}?*T{#endsyntax#}.
+      </p>
+      <p>To convert the other way, use {#link|@ptrFromInt#}</p>
+      {#header_close#}
+
+      {#header_open|@max#}
+      <pre>{#syntax#}@max(...) T{#endsyntax#}</pre>
+      <p>
+      Takes two or more arguments and returns the biggest value included (the maximum). This builtin accepts integers, floats, and vectors of either. In the latter case, the operation is performed element wise.
+      </p>
+      <p>
+      NaNs are handled as follows: return the biggest non-NaN value included. If all operands are NaN, return NaN.
+      </p>
+      {#see_also|@min|Vectors#}
+      {#header_close#}
+
+      {#header_open|@memcpy#}
+      <pre>{#syntax#}@memcpy(noalias dest, noalias source) void{#endsyntax#}</pre>
+      <p>This function copies bytes from one region of memory to another.</p>
+      <p>{#syntax#}dest{#endsyntax#} must be a mutable slice, a mutable pointer to an array, or
+        a mutable many-item {#link|pointer|Pointers#}. It may have any
+        alignment, and it may have any element type.</p>
+      <p>{#syntax#}source{#endsyntax#} must be a slice, a pointer to
+        an array, or a many-item {#link|pointer|Pointers#}. It may
+        have any alignment, and it may have any element type.</p>
+      <p>The {#syntax#}source{#endsyntax#} element type must have the same in-memory
+        representation as the {#syntax#}dest{#endsyntax#} element type.</p>
+      <p>Similar to {#link|for#} loops, at least one of {#syntax#}source{#endsyntax#} and
+        {#syntax#}dest{#endsyntax#} must provide a length, and if two lengths are provided,
+        they must be equal.</p>
+      <p>Finally, the two memory regions must not overlap.</p>
+      {#header_close#}
+
+      {#header_open|@memset#}
+      <pre>{#syntax#}@memset(dest, elem) void{#endsyntax#}</pre>
+      <p>This function sets all the elements of a memory region to {#syntax#}elem{#endsyntax#}.</p>
+      <p>{#syntax#}dest{#endsyntax#} must be a mutable slice or a mutable pointer to an array.
+      It may have any alignment, and it may have any element type.</p>
+      <p>{#syntax#}elem{#endsyntax#} is coerced to the element type of {#syntax#}dest{#endsyntax#}.</p>
+      <p>For securely zeroing out sensitive contents from memory, you should use
+      {#syntax#}std.crypto.secureZero{#endsyntax#}</p>
+      {#header_close#}
+
+      {#header_open|@min#}
+      <pre>{#syntax#}@min(...) T{#endsyntax#}</pre>
+      <p>
+      Takes two or more arguments and returns the smallest value included (the minimum). This builtin accepts integers, floats, and vectors of either. In the latter case, the operation is performed element wise.
+      </p>
+      <p>
+      NaNs are handled as follows: return the smallest non-NaN value included. If all operands are NaN, return NaN.
+      </p>
+      {#see_also|@max|Vectors#}
+      {#header_close#}
+
+      {#header_open|@wasmMemorySize#}
+      <pre>{#syntax#}@wasmMemorySize(index: u32) usize{#endsyntax#}</pre>
+      <p>
+      This function returns the size of the Wasm memory identified by {#syntax#}index{#endsyntax#} as
+      an unsigned value in units of Wasm pages. Note that each Wasm page is 64KB in size.
+      </p>
+      <p>
+      This function is a low level intrinsic with no safety mechanisms usually useful for allocator
+      designers targeting Wasm. So unless you are writing a new allocator from scratch, you should use
+      something like {#syntax#}@import("std").heap.WasmPageAllocator{#endsyntax#}.
+      </p>
+      {#see_also|@wasmMemoryGrow#}
+      {#header_close#}
+
+      {#header_open|@wasmMemoryGrow#}
+      <pre>{#syntax#}@wasmMemoryGrow(index: u32, delta: usize) isize{#endsyntax#}</pre>
+      <p>
+      This function increases the size of the Wasm memory identified by {#syntax#}index{#endsyntax#} by
+      {#syntax#}delta{#endsyntax#} in units of unsigned number of Wasm pages. Note that each Wasm page
+      is 64KB in size. On success, returns previous memory size; on failure, if the allocation fails,
+      returns -1.
+      </p>
+      <p>
+      This function is a low level intrinsic with no safety mechanisms usually useful for allocator
+      designers targeting Wasm. So unless you are writing a new allocator from scratch, you should use
+      something like {#syntax#}@import("std").heap.WasmPageAllocator{#endsyntax#}.
+      </p>
+      {#code|test_wasmMemoryGrow_builtin.zig#}
+
+      {#see_also|@wasmMemorySize#}
+      {#header_close#}
+
+      {#header_open|@mod#}
+      <pre>{#syntax#}@mod(numerator: T, denominator: T) T{#endsyntax#}</pre>
+      <p>
+      Modulus division. For unsigned integers this is the same as
+      {#syntax#}numerator % denominator{#endsyntax#}. Caller guarantees {#syntax#}denominator > 0{#endsyntax#}, otherwise the
+      operation will result in a {#link|Remainder Division by Zero#} when runtime safety checks are enabled.
+      </p>
+      <ul>
+          <li>{#syntax#}@mod(-5, 3) == 1{#endsyntax#}</li>
+          <li>{#syntax#}(@divFloor(a, b) * b) + @mod(a, b) == a{#endsyntax#}</li>
+      </ul>
+      <p>For a function that returns an error code, see {#syntax#}@import("std").math.mod{#endsyntax#}.</p>
+      {#see_also|@rem#}
+      {#header_close#}
+
+      {#header_open|@mulWithOverflow#}
+      <pre>{#syntax#}@mulWithOverflow(a: anytype, b: anytype) struct { @TypeOf(a, b), u1 }{#endsyntax#}</pre>
+      <p>
+      Performs {#syntax#}a * b{#endsyntax#} and returns a tuple with the result and a possible overflow bit.
+      </p>
+      {#header_close#}
+
+      {#header_open|@panic#}
+      <pre>{#syntax#}@panic(message: []const u8) noreturn{#endsyntax#}</pre>
+      <p>
+      Invokes the panic handler function. By default the panic handler function
+      calls the public {#syntax#}panic{#endsyntax#} function exposed in the root source file, or
+      if there is not one specified, the {#syntax#}std.builtin.default_panic{#endsyntax#}
+      function from {#syntax#}std/builtin.zig{#endsyntax#}.
+      </p>
+      <p>Generally it is better to use {#syntax#}@import("std").debug.panic{#endsyntax#}.
+          However, {#syntax#}@panic{#endsyntax#} can be useful for 2 scenarios:
+      </p>
+      <ul>
+        <li>From library code, calling the programmer's panic function if they exposed one in the root source file.</li>
+        <li>When mixing C and Zig code, calling the canonical panic implementation across multiple .o files.</li>
+      </ul>
+      {#see_also|Panic Handler#}
+      {#header_close#}
+
+      {#header_open|@popCount#}
+      <pre>{#syntax#}@popCount(operand: anytype) anytype{#endsyntax#}</pre>
+      <p>{#syntax#}@TypeOf(operand){#endsyntax#} must be an integer type.</p>
+      <p>{#syntax#}operand{#endsyntax#} may be an {#link|integer|Integers#} or {#link|vector|Vectors#}.</p>
+      <p>
+      Counts the number of bits set in an integer - "population count".
+      </p>
+      <p>
+      The return type is an unsigned integer or vector of unsigned integers with the minimum number
+      of bits that can represent the bit count of the integer type.
+      </p>
+      {#see_also|@ctz|@clz#}
+      {#header_close#}
+
+      {#header_open|@prefetch#}
+      <pre>{#syntax#}@prefetch(ptr: anytype, comptime options: PrefetchOptions) void{#endsyntax#}</pre>
+      <p>
+      This builtin tells the compiler to emit a prefetch instruction if supported by the
+      target CPU. If the target CPU does not support the requested prefetch instruction,
+      this builtin is a no-op. This function has no effect on the behavior of the program,
+      only on the performance characteristics.
+      </p>
+      <p>
+      The {#syntax#}ptr{#endsyntax#} argument may be any pointer type and determines the memory
+      address to prefetch. This function does not dereference the pointer, it is perfectly legal
+      to pass a pointer to invalid memory to this function and no Illegal Behavior will result.
+      </p>
+      <p>{#syntax#}PrefetchOptions{#endsyntax#} can be found with {#syntax#}@import("std").builtin.PrefetchOptions{#endsyntax#}.</p>
+      {#header_close#}
+
+      {#header_open|@ptrCast#}
+      <pre>{#syntax#}@ptrCast(value: anytype) anytype{#endsyntax#}</pre>
+      <p>
+      Converts a pointer of one type to a pointer of another type. The return type is the inferred result type.
+      </p>
+      <p>
+      {#link|Optional Pointers#} are allowed. Casting an optional pointer which is {#link|null#}
+      to a non-optional pointer invokes safety-checked {#link|Illegal Behavior#}.
+      </p>
+      <p>
+      {#syntax#}@ptrCast{#endsyntax#} cannot be used for:
+      </p>
+      <ul>
+          <li>Removing {#syntax#}const{#endsyntax#} qualifier, use {#link|@constCast#}.</li>
+          <li>Removing {#syntax#}volatile{#endsyntax#} qualifier, use {#link|@volatileCast#}.</li>
+          <li>Changing pointer address space, use {#link|@addrSpaceCast#}.</li>
+          <li>Increasing pointer alignment, use {#link|@alignCast#}.</li>
+          <li>Casting a non-slice pointer to a slice, use slicing syntax {#syntax#}ptr[start..end]{#endsyntax#}.</li>
+      </ul>
+      {#header_close#}
+
+      {#header_open|@ptrFromInt#}
+      <pre>{#syntax#}@ptrFromInt(address: usize) anytype{#endsyntax#}</pre>
+      <p>
+      Converts an integer to a {#link|pointer|Pointers#}. The return type is the inferred result type.
+			To convert the other way, use {#link|@intFromPtr#}. Casting an address of 0 to a destination type
+      which in not {#link|optional|Optional Pointers#} and does not have the {#syntax#}allowzero{#endsyntax#} attribute will result in a
+      {#link|Pointer Cast Invalid Null#} panic when runtime safety checks are enabled.
+      </p>
+      <p>
+      If the destination pointer type does not allow address zero and {#syntax#}address{#endsyntax#}
+      is zero, this invokes safety-checked {#link|Illegal Behavior#}.
+      </p>
+      {#header_close#}
+
+      {#header_open|@rem#}
+      <pre>{#syntax#}@rem(numerator: T, denominator: T) T{#endsyntax#}</pre>
+      <p>
+      Remainder division. For unsigned integers this is the same as
+      {#syntax#}numerator % denominator{#endsyntax#}. Caller guarantees {#syntax#}denominator > 0{#endsyntax#}, otherwise the
+      operation will result in a {#link|Remainder Division by Zero#} when runtime safety checks are enabled.
+      </p>
+      <ul>
+          <li>{#syntax#}@rem(-5, 3) == -2{#endsyntax#}</li>
+          <li>{#syntax#}(@divTrunc(a, b) * b) + @rem(a, b) == a{#endsyntax#}</li>
+      </ul>
+      <p>For a function that returns an error code, see {#syntax#}@import("std").math.rem{#endsyntax#}.</p>
+      {#see_also|@mod#}
+      {#header_close#}
+
+      {#header_open|@returnAddress#}
+      <pre>{#syntax#}@returnAddress() usize{#endsyntax#}</pre>
+      <p>
+      This function returns the address of the next machine code instruction that will be executed
+      when the current function returns.
+      </p>
+      <p>
+      The implications of this are target-specific and not consistent across
+      all platforms.
+      </p>
+      <p>
+      This function is only valid within function scope. If the function gets inlined into
+      a calling function, the returned address will apply to the calling function.
+      </p>
+      {#header_close#}
+
+      {#header_open|@select#}
+      <pre>{#syntax#}@select(comptime T: type, pred: @Vector(len, bool), a: @Vector(len, T), b: @Vector(len, T)) @Vector(len, T){#endsyntax#}</pre>
+      <p>
+      Selects values element-wise from {#syntax#}a{#endsyntax#} or {#syntax#}b{#endsyntax#} based on {#syntax#}pred{#endsyntax#}. If {#syntax#}pred[i]{#endsyntax#} is {#syntax#}true{#endsyntax#}, the corresponding element in the result will be {#syntax#}a[i]{#endsyntax#} and otherwise {#syntax#}b[i]{#endsyntax#}.
+      </p>
+      {#see_also|Vectors#}
+      {#header_close#}
+
+      {#header_open|@setEvalBranchQuota#}
+      <pre>{#syntax#}@setEvalBranchQuota(comptime new_quota: u32) void{#endsyntax#}</pre>
+      <p>
+      Increase the maximum number of backwards branches that compile-time code
+      execution can use before giving up and making a compile error.
+      </p>
+      <p>
+      If the {#syntax#}new_quota{#endsyntax#} is smaller than the default quota ({#syntax#}1000{#endsyntax#}) or
+      a previously explicitly set quota, it is ignored.
+      </p>
+      <p>
+      Example:
+      </p>
+      {#code|test_without_setEvalBranchQuota_builtin.zig#}
+
+      <p>Now we use {#syntax#}@setEvalBranchQuota{#endsyntax#}:</p>
+      {#code|test_setEvalBranchQuota_builtin.zig#}
+
+
+      {#see_also|comptime#}
+      {#header_close#}
+
+      {#header_open|@setFloatMode#}
+      <pre>{#syntax#}@setFloatMode(comptime mode: FloatMode) void{#endsyntax#}</pre>
+      <p>Changes the current scope's rules about how floating point operations are defined.</p>
+      <ul>
+        <li>
+            {#syntax#}Strict{#endsyntax#} (default) - Floating point operations follow strict IEEE compliance.
+        </li>
+        <li>
+            {#syntax#}Optimized{#endsyntax#} - Floating point operations may do all of the following:
+          <ul>
+            <li>Assume the arguments and result are not NaN. Optimizations are required to retain legal behavior over NaNs, but the value of the result is undefined.</li>
+            <li>Assume the arguments and result are not +/-Inf. Optimizations are required to retain legal behavior over +/-Inf, but the value of the result is undefined.</li>
+            <li>Treat the sign of a zero argument or result as insignificant.</li>
+            <li>Use the reciprocal of an argument rather than perform division.</li>
+            <li>Perform floating-point contraction (e.g. fusing a multiply followed by an addition into a fused multiply-add).</li>
+            <li>Perform algebraically equivalent transformations that may change results in floating point (e.g. reassociate).</li>
+          </ul>
+          This is equivalent to <code>-ffast-math</code> in GCC.
+        </li>
+      </ul>
+      <p>
+      The floating point mode is inherited by child scopes, and can be overridden in any scope.
+      You can set the floating point mode in a struct or module scope by using a comptime block.
+      </p>
+      <p>{#syntax#}FloatMode{#endsyntax#} can be found with {#syntax#}@import("std").builtin.FloatMode{#endsyntax#}.</p>
+      {#see_also|Floating Point Operations#}
+      {#header_close#}
+
+      {#header_open|@setRuntimeSafety#}
+      <pre>{#syntax#}@setRuntimeSafety(comptime safety_on: bool) void{#endsyntax#}</pre>
+      <p>
+      Sets whether runtime safety checks are enabled for the scope that contains the function call.
+      </p>
+      {#code|test_setRuntimeSafety_builtin.zig#}
+
+      <p>Note: it is <a href="https://github.com/ziglang/zig/issues/978">planned</a> to replace
+      {#syntax#}@setRuntimeSafety{#endsyntax#} with <code>@optimizeFor</code></p>
+
+      {#header_close#}
+
+      {#header_open|@shlExact#}
+      <pre>{#syntax#}@shlExact(value: T, shift_amt: Log2T) T{#endsyntax#}</pre>
+      <p>
+      Performs the left shift operation ({#syntax#}<<{#endsyntax#}).
+      For unsigned integers, the result is {#link|undefined#} if any 1 bits
+      are shifted out. For signed integers, the result is {#link|undefined#} if
+      any bits that disagree with the resultant sign bit are shifted out.
+      </p>
+      <p>
+      The type of {#syntax#}shift_amt{#endsyntax#} is an unsigned integer with {#syntax#}log2(@typeInfo(T).int.bits){#endsyntax#} bits.
+      This is because {#syntax#}shift_amt >= @typeInfo(T).int.bits{#endsyntax#} triggers safety-checked {#link|Illegal Behavior#}.
+      </p>
+      <p>
+      {#syntax#}comptime_int{#endsyntax#} is modeled as an integer with an infinite number of bits,
+      meaning that in such case, {#syntax#}@shlExact{#endsyntax#} always produces a result and
+      cannot produce a compile error.
+      </p>
+      {#see_also|@shrExact|@shlWithOverflow#}
+      {#header_close#}
+
+      {#header_open|@shlWithOverflow#}
+      <pre>{#syntax#}@shlWithOverflow(a: anytype, shift_amt: Log2T) struct { @TypeOf(a), u1 }{#endsyntax#}</pre>
+      <p>
+      Performs {#syntax#}a << b{#endsyntax#} and returns a tuple with the result and a possible overflow bit.
+      </p>
+      <p>
+      The type of {#syntax#}shift_amt{#endsyntax#} is an unsigned integer with {#syntax#}log2(@typeInfo(@TypeOf(a)).int.bits){#endsyntax#} bits.
+      This is because {#syntax#}shift_amt >= @typeInfo(@TypeOf(a)).int.bits{#endsyntax#} triggers safety-checked {#link|Illegal Behavior#}.
+      </p>
+      {#see_also|@shlExact|@shrExact#}
+      {#header_close#}
+
+      {#header_open|@shrExact#}
+      <pre>{#syntax#}@shrExact(value: T, shift_amt: Log2T) T{#endsyntax#}</pre>
+      <p>
+      Performs the right shift operation ({#syntax#}>>{#endsyntax#}). Caller guarantees
+      that the shift will not shift any 1 bits out.
+      </p>
+      <p>
+      The type of {#syntax#}shift_amt{#endsyntax#} is an unsigned integer with {#syntax#}log2(@typeInfo(T).int.bits){#endsyntax#} bits.
+      This is because {#syntax#}shift_amt >= @typeInfo(T).int.bits{#endsyntax#} triggers safety-checked {#link|Illegal Behavior#}.
+      </p>
+      {#see_also|@shlExact|@shlWithOverflow#}
+      {#header_close#}
+
+      {#header_open|@shuffle#}
+      <pre>{#syntax#}@shuffle(comptime E: type, a: @Vector(a_len, E), b: @Vector(b_len, E), comptime mask: @Vector(mask_len, i32)) @Vector(mask_len, E){#endsyntax#}</pre>
+      <p>
+      Constructs a new {#link|vector|Vectors#} by selecting elements from {#syntax#}a{#endsyntax#} and
+      {#syntax#}b{#endsyntax#} based on {#syntax#}mask{#endsyntax#}.
+      </p>
+      <p>
+      Each element in {#syntax#}mask{#endsyntax#} selects an element from either {#syntax#}a{#endsyntax#} or
+      {#syntax#}b{#endsyntax#}. Positive numbers select from {#syntax#}a{#endsyntax#} starting at 0.
+      Negative values select from {#syntax#}b{#endsyntax#}, starting at {#syntax#}-1{#endsyntax#} and going down.
+      It is recommended to use the {#syntax#}~{#endsyntax#} operator for indexes from {#syntax#}b{#endsyntax#}
+      so that both indexes can start from {#syntax#}0{#endsyntax#} (i.e. {#syntax#}~@as(i32, 0){#endsyntax#} is
+      {#syntax#}-1{#endsyntax#}).
+      </p>
+      <p>
+      For each element of {#syntax#}mask{#endsyntax#}, if it or the selected value from
+      {#syntax#}a{#endsyntax#} or {#syntax#}b{#endsyntax#} is {#syntax#}undefined{#endsyntax#},
+      then the resulting element is {#syntax#}undefined{#endsyntax#}.
+      </p>
+      <p>
+      {#syntax#}a_len{#endsyntax#} and {#syntax#}b_len{#endsyntax#} may differ in length. Out-of-bounds element
+      indexes in {#syntax#}mask{#endsyntax#} result in compile errors.
+      </p>
+      <p>
+      If {#syntax#}a{#endsyntax#} or {#syntax#}b{#endsyntax#} is {#syntax#}undefined{#endsyntax#}, it
+      is equivalent to a vector of all {#syntax#}undefined{#endsyntax#} with the same length as the other vector.
+      If both vectors are {#syntax#}undefined{#endsyntax#}, {#syntax#}@shuffle{#endsyntax#} returns
+      a vector with all elements {#syntax#}undefined{#endsyntax#}.
+      </p>
+      <p>
+      {#syntax#}E{#endsyntax#} must be an {#link|integer|Integers#}, {#link|float|Floats#},
+      {#link|pointer|Pointers#}, or {#syntax#}bool{#endsyntax#}. The mask may be any vector length, and its
+      length determines the result length.
+      </p>
+      {#code|test_shuffle_builtin.zig#}
+
+      {#see_also|Vectors#}
+      {#header_close#}
+
+      {#header_open|@sizeOf#}
+      <pre>{#syntax#}@sizeOf(comptime T: type) comptime_int{#endsyntax#}</pre>
+      <p>
+      This function returns the number of bytes it takes to store {#syntax#}T{#endsyntax#} in memory.
+      The result is a target-specific compile time constant.
+      </p>
+      <p>
+      This size may contain padding bytes. If there were two consecutive T in memory, the padding would be the offset
+      in bytes between element at index 0 and the element at index 1. For {#link|integer|Integers#},
+      consider whether you want to use {#syntax#}@sizeOf(T){#endsyntax#} or
+      {#syntax#}@typeInfo(T).int.bits{#endsyntax#}.
+      </p>
+      <p>
+      This function measures the size at runtime. For types that are disallowed at runtime, such as
+      {#syntax#}comptime_int{#endsyntax#} and {#syntax#}type{#endsyntax#}, the result is {#syntax#}0{#endsyntax#}.
+      </p>
+      {#see_also|@bitSizeOf|@typeInfo#}
+      {#header_close#}
+
+      {#header_open|@splat#}
+      <pre>{#syntax#}@splat(scalar: anytype) anytype{#endsyntax#}</pre>
+      <p>
+      Produces a vector where each element is the value {#syntax#}scalar{#endsyntax#}.
+      The return type and thus the length of the vector is inferred.
+      </p>
+      {#code|test_splat_builtin.zig#}
+
+      <p>
+      {#syntax#}scalar{#endsyntax#} must be an {#link|integer|Integers#}, {#link|bool|Primitive Types#},
+      {#link|float|Floats#}, or {#link|pointer|Pointers#}.
+      </p>
+      {#see_also|Vectors|@shuffle#}
+      {#header_close#}
+
+      {#header_open|@reduce#}
+      <pre>{#syntax#}@reduce(comptime op: std.builtin.ReduceOp, value: anytype) E{#endsyntax#}</pre>
+      <p>
+      Transforms a {#link|vector|Vectors#} into a scalar value (of type <code>E</code>)
+      by performing a sequential horizontal reduction of its elements using the
+      specified operator {#syntax#}op{#endsyntax#}.
+      </p>
+      <p>
+      Not every operator is available for every vector element type:
+      </p>
+      <ul>
+          <li>Every operator is available for {#link|integer|Integers#} vectors.</li>
+          <li>{#syntax#}.And{#endsyntax#}, {#syntax#}.Or{#endsyntax#},
+            {#syntax#}.Xor{#endsyntax#} are additionally available for
+            {#syntax#}bool{#endsyntax#} vectors,</li>
+          <li>{#syntax#}.Min{#endsyntax#}, {#syntax#}.Max{#endsyntax#},
+            {#syntax#}.Add{#endsyntax#}, {#syntax#}.Mul{#endsyntax#} are
+            additionally available for {#link|floating point|Floats#} vectors,</li>
+      </ul>
+      <p>
+      Note that {#syntax#}.Add{#endsyntax#} and {#syntax#}.Mul{#endsyntax#}
+      reductions on integral types are wrapping; when applied on floating point
+      types the operation associativity is preserved, unless the float mode is
+      set to {#syntax#}Optimized{#endsyntax#}.
+      </p>
+      {#code|test_reduce_builtin.zig#}
+
+      {#see_also|Vectors|@setFloatMode#}
+      {#header_close#}
+
+      {#header_open|@src#}
+      <pre>{#syntax#}@src() std.builtin.SourceLocation{#endsyntax#}</pre>
+      <p>
+      Returns a {#syntax#}SourceLocation{#endsyntax#} struct representing the function's name and location in the source code. This must be called in a function.
+      </p>
+      {#code|test_src_builtin.zig#}
+
+      {#header_close#}
+      {#header_open|@sqrt#}
+      <pre>{#syntax#}@sqrt(value: anytype) @TypeOf(value){#endsyntax#}</pre>
+      <p>
+      Performs the square root of a floating point number. Uses a dedicated hardware instruction
+      when available.
+      </p>
+      <p>
+      Supports {#link|Floats#} and {#link|Vectors#} of floats.
+      </p>
+      {#header_close#}
+      {#header_open|@sin#}
+      <pre>{#syntax#}@sin(value: anytype) @TypeOf(value){#endsyntax#}</pre>
+      <p>
+      Sine trigonometric function on a floating point number in radians. Uses a dedicated hardware instruction
+      when available.
+      </p>
+      <p>
+      Supports {#link|Floats#} and {#link|Vectors#} of floats.
+      </p>
+      {#header_close#}
+
+      {#header_open|@cos#}
+      <pre>{#syntax#}@cos(value: anytype) @TypeOf(value){#endsyntax#}</pre>
+      <p>
+      Cosine trigonometric function on a floating point number in radians. Uses a dedicated hardware instruction
+      when available.
+      </p>
+      <p>
+      Supports {#link|Floats#} and {#link|Vectors#} of floats.
+      </p>
+      {#header_close#}
+
+      {#header_open|@tan#}
+      <pre>{#syntax#}@tan(value: anytype) @TypeOf(value){#endsyntax#}</pre>
+      <p>
+      Tangent trigonometric function on a floating point number in radians.
+      Uses a dedicated hardware instruction when available.
+      </p>
+      <p>
+      Supports {#link|Floats#} and {#link|Vectors#} of floats.
+      </p>
+      {#header_close#}
+
+      {#header_open|@exp#}
+      <pre>{#syntax#}@exp(value: anytype) @TypeOf(value){#endsyntax#}</pre>
+      <p>
+      Base-e exponential function on a floating point number. Uses a dedicated hardware instruction
+      when available.
+      </p>
+      <p>
+      Supports {#link|Floats#} and {#link|Vectors#} of floats.
+      </p>
+      {#header_close#}
+      {#header_open|@exp2#}
+      <pre>{#syntax#}@exp2(value: anytype) @TypeOf(value){#endsyntax#}</pre>
+      <p>
+      Base-2 exponential function on a floating point number. Uses a dedicated hardware instruction
+      when available.
+      </p>
+      <p>
+      Supports {#link|Floats#} and {#link|Vectors#} of floats.
+      </p>
+      {#header_close#}
+      {#header_open|@log#}
+      <pre>{#syntax#}@log(value: anytype) @TypeOf(value){#endsyntax#}</pre>
+      <p>
+      Returns the natural logarithm of a floating point number. Uses a dedicated hardware instruction
+      when available.
+      </p>
+      <p>
+      Supports {#link|Floats#} and {#link|Vectors#} of floats.
+      </p>
+      {#header_close#}
+      {#header_open|@log2#}
+      <pre>{#syntax#}@log2(value: anytype) @TypeOf(value){#endsyntax#}</pre>
+      <p>
+      Returns the logarithm to the base 2 of a floating point number. Uses a dedicated hardware instruction
+      when available.
+      </p>
+      <p>
+      Supports {#link|Floats#} and {#link|Vectors#} of floats.
+      </p>
+      {#header_close#}
+      {#header_open|@log10#}
+      <pre>{#syntax#}@log10(value: anytype) @TypeOf(value){#endsyntax#}</pre>
+      <p>
+      Returns the logarithm to the base 10 of a floating point number. Uses a dedicated hardware instruction
+      when available.
+      </p>
+      <p>
+      Supports {#link|Floats#} and {#link|Vectors#} of floats.
+      </p>
+      {#header_close#}
+      {#header_open|@abs#}
+      <pre>{#syntax#}@abs(value: anytype) anytype{#endsyntax#}</pre>
+      <p>
+      Returns the absolute value of an integer or a floating point number. Uses a dedicated hardware instruction
+      when available.
+
+      The return type is always an unsigned integer of the same bit width as the operand if the operand is an integer.
+      Unsigned integer operands are supported. The builtin cannot overflow for signed integer operands.
+      </p>
+      <p>
+      Supports {#link|Floats#}, {#link|Integers#} and {#link|Vectors#} of floats or integers.
+      </p>
+      {#header_close#}
+      {#header_open|@floor#}
+      <pre>{#syntax#}@floor(value: anytype) @TypeOf(value){#endsyntax#}</pre>
+      <p>
+      Returns the largest integral value not greater than the given floating point number.
+      Uses a dedicated hardware instruction when available.
+      </p>
+      <p>
+      Supports {#link|Floats#} and {#link|Vectors#} of floats.
+      </p>
+      {#header_close#}
+      {#header_open|@ceil#}
+      <pre>{#syntax#}@ceil(value: anytype) @TypeOf(value){#endsyntax#}</pre>
+      <p>
+      Returns the smallest integral value not less than the given floating point number.
+      Uses a dedicated hardware instruction when available.
+      </p>
+      <p>
+      Supports {#link|Floats#} and {#link|Vectors#} of floats.
+      </p>
+      {#header_close#}
+      {#header_open|@trunc#}
+      <pre>{#syntax#}@trunc(value: anytype) @TypeOf(value){#endsyntax#}</pre>
+      <p>
+      Rounds the given floating point number to an integer, towards zero.
+      Uses a dedicated hardware instruction when available.
+      </p>
+      <p>
+      Supports {#link|Floats#} and {#link|Vectors#} of floats.
+      </p>
+      {#header_close#}
+      {#header_open|@round#}
+      <pre>{#syntax#}@round(value: anytype) @TypeOf(value){#endsyntax#}</pre>
+      <p>
+      Rounds the given floating point number to the nearest integer. If two integers are equally close, rounds away from zero.
+      Uses a dedicated hardware instruction when available.
+      </p>
+      {#code|test_round_builtin.zig#}
+
+      <p>
+      Supports {#link|Floats#} and {#link|Vectors#} of floats.
+      </p>
+      {#header_close#}
+
+      {#header_open|@subWithOverflow#}
+      <pre>{#syntax#}@subWithOverflow(a: anytype, b: anytype) struct { @TypeOf(a, b), u1 }{#endsyntax#}</pre>
+      <p>
+      Performs {#syntax#}a - b{#endsyntax#} and returns a tuple with the result and a possible overflow bit.
+      </p>
+      {#header_close#}
+
+      {#header_open|@tagName#}
+      <pre>{#syntax#}@tagName(value: anytype) [:0]const u8{#endsyntax#}</pre>
+      <p>
+      Converts an enum value or union value to a string literal representing the name.</p><p>If the enum is non-exhaustive and the tag value does not map to a name, it invokes safety-checked {#link|Illegal Behavior#}.
+      </p>
+      {#header_close#}
+
+      {#header_open|@This#}
+      <pre>{#syntax#}@This() type{#endsyntax#}</pre>
+      <p>
+      Returns the innermost struct, enum, or union that this function call is inside.
+      This can be useful for an anonymous struct that needs to refer to itself:
+      </p>
+      {#code|test_this_builtin.zig#}
+
+      <p>
+      When {#syntax#}@This(){#endsyntax#} is used at file scope, it returns a reference to the
+      struct that corresponds to the current file.
+      </p>
+      {#header_close#}
+
+      {#header_open|@trap#}
+      <pre>{#syntax#}@trap() noreturn{#endsyntax#}</pre>
+      <p>
+      This function inserts a platform-specific trap/jam instruction which can be used to exit the program abnormally.
+      This may be implemented by explicitly emitting an invalid instruction which may cause an illegal instruction exception of some sort.
+      Unlike for {#syntax#}@breakpoint(){#endsyntax#}, execution does not continue after this point.
+      </p>
+      <p>
+      Outside function scope, this builtin causes a compile error.
+      </p>
+      {#see_also|@breakpoint#}
+      {#header_close#}
+
+      {#header_open|@truncate#}
+      <pre>{#syntax#}@truncate(integer: anytype) anytype{#endsyntax#}</pre>
+      <p>
+      This function truncates bits from an integer type, resulting in a smaller
+      or same-sized integer type. The return type is the inferred result type.
+      </p>
+      <p>
+      This function always truncates the significant bits of the integer, regardless
+      of endianness on the target platform.
+      </p>
+      <p>
+      Calling {#syntax#}@truncate{#endsyntax#} on a number out of range of the destination type is well defined and working code:
+      </p>
+      {#code|test_truncate_builtin.zig#}
+
+      <p>
+      Use {#link|@intCast#} to convert numbers guaranteed to fit the destination type.
+      </p>
+      {#header_close#}
+
+      {#header_open|@Type#}
+      <pre>{#syntax#}@Type(comptime info: std.builtin.Type) type{#endsyntax#}</pre>
+      <p>
+      This function is the inverse of {#link|@typeInfo#}. It reifies type information
+      into a {#syntax#}type{#endsyntax#}.
+      </p>
+      <p>
+      It is available for the following types:
+      </p>
+      <ul>
+          <li>{#syntax#}type{#endsyntax#}</li>
+          <li>{#syntax#}noreturn{#endsyntax#}</li>
+          <li>{#syntax#}void{#endsyntax#}</li>
+          <li>{#syntax#}bool{#endsyntax#}</li>
+          <li>{#link|Integers#} - The maximum bit count for an integer type is {#syntax#}65535{#endsyntax#}.</li>
+          <li>{#link|Floats#}</li>
+          <li>{#link|Pointers#}</li>
+          <li>{#syntax#}comptime_int{#endsyntax#}</li>
+          <li>{#syntax#}comptime_float{#endsyntax#}</li>
+          <li>{#syntax#}@TypeOf(undefined){#endsyntax#}</li>
+          <li>{#syntax#}@TypeOf(null){#endsyntax#}</li>
+          <li>{#link|Arrays#}</li>
+          <li>{#link|Optionals#}</li>
+          <li>{#link|Error Set Type#}</li>
+          <li>{#link|Error Union Type#}</li>
+          <li>{#link|Vectors#}</li>
+          <li>{#link|opaque#}</li>
+          <li>{#syntax#}anyframe{#endsyntax#}</li>
+          <li>{#link|struct#}</li>
+          <li>{#link|enum#}</li>
+          <li>{#link|Enum Literals#}</li>
+          <li>{#link|union#}</li>
+          <li>{#link|Functions#}</li>
+      </ul>
+      {#header_close#}
+      {#header_open|@typeInfo#}
+      <pre>{#syntax#}@typeInfo(comptime T: type) std.builtin.Type{#endsyntax#}</pre>
+      <p>
+      Provides type reflection.
+      </p>
+      <p>
+      Type information of {#link|structs|struct#}, {#link|unions|union#}, {#link|enums|enum#}, and
+      {#link|error sets|Error Set Type#} has fields which are guaranteed to be in the same
+      order as appearance in the source file.
+      </p>
+      <p>
+      Type information of {#link|structs|struct#}, {#link|unions|union#}, {#link|enums|enum#}, and
+      {#link|opaques|opaque#} has declarations, which are also guaranteed to be in the same
+      order as appearance in the source file.
+      </p>
+      {#header_close#}
+
+      {#header_open|@typeName#}
+      <pre>{#syntax#}@typeName(T: type) *const [N:0]u8{#endsyntax#}</pre>
+      <p>
+      This function returns the string representation of a type, as
+      an array. It is equivalent to a string literal of the type name.
+      The returned type name is fully qualified with the parent namespace included
+      as part of the type name with a series of dots.
+      </p>
+      {#header_close#}
+
+      {#header_open|@TypeOf#}
+      <pre>{#syntax#}@TypeOf(...) type{#endsyntax#}</pre>
+      <p>
+      {#syntax#}@TypeOf{#endsyntax#} is a special builtin function that takes any (non-zero) number of expressions
+      as parameters and returns the type of the result, using {#link|Peer Type Resolution#}.
+      </p>
+      <p>
+      The expressions are evaluated, however they are guaranteed to have no <em>runtime</em> side-effects:
+      </p>
+      {#code|test_TypeOf_builtin.zig#}
+
+      {#header_close#}
+
+      {#header_open|@unionInit#}
+      <pre>{#syntax#}@unionInit(comptime Union: type, comptime active_field_name: []const u8, init_expr) Union{#endsyntax#}</pre>
+      <p>
+      This is the same thing as {#link|union#} initialization syntax, except that the field name is a
+      {#link|comptime#}-known value rather than an identifier token.
+      </p>
+      <p>
+      {#syntax#}@unionInit{#endsyntax#} forwards its {#link|result location|Result Location Semantics#} to {#syntax#}init_expr{#endsyntax#}.
+      </p>
+      {#header_close#}
+
+
+      {#header_open|@Vector#}
+      <pre>{#syntax#}@Vector(len: comptime_int, Element: type) type{#endsyntax#}</pre>
+      <p>Creates {#link|Vectors#}.</p>
+      {#header_close#}
+
+      {#header_open|@volatileCast#}
+      <pre>{#syntax#}@volatileCast(value: anytype) DestType{#endsyntax#}</pre>
+      <p>
+      Remove {#syntax#}volatile{#endsyntax#} qualifier from a pointer.
+      </p>
+      {#header_close#}
+
+      {#header_open|@workGroupId#}
+      <pre>{#syntax#}@workGroupId(comptime dimension: u32) u32{#endsyntax#}</pre>
+      <p>
+      Returns the index of the work group in the current kernel invocation in dimension {#syntax#}dimension{#endsyntax#}.
+      </p>
+      {#header_close#}
+
+      {#header_open|@workGroupSize#}
+      <pre>{#syntax#}@workGroupSize(comptime dimension: u32) u32{#endsyntax#}</pre>
+      <p>
+      Returns the number of work items that a work group has in dimension {#syntax#}dimension{#endsyntax#}.
+      </p>
+      {#header_close#}
+
+      {#header_open|@workItemId#}
+      <pre>{#syntax#}@workItemId(comptime dimension: u32) u32{#endsyntax#}</pre>
+      <p>
+      Returns the index of the work item in the work group in dimension {#syntax#}dimension{#endsyntax#}. This function returns values between {#syntax#}0{#endsyntax#} (inclusive) and {#syntax#}@workGroupSize(dimension){#endsyntax#} (exclusive).
+      </p>
+      {#header_close#}
+
+      {#header_close#}
+
+      {#header_open|Build Mode#}
+      <p>
+      Zig has four build modes:
+      </p>
+      <ul>
+        <li>{#link|Debug#} (default)</li>
+        <li>{#link|ReleaseFast#}</li>
+        <li>{#link|ReleaseSafe#}</li>
+        <li>{#link|ReleaseSmall#}</li>
+      </ul>
+      <p>
+      To add standard build options to a <code class="file">build.zig</code> file:
+      </p>
+      {#code|build.zig#}
+
+      <p>
+      This causes these options to be available:
+      </p>
+      <dl>
+        <dt><kbd>-Doptimize=Debug</kbd></dt><dd>Optimizations off and safety on (default)</dd>
+        <dt><kbd>-Doptimize=ReleaseSafe</kbd></dt><dd>Optimizations on and safety on</dd>
+        <dt><kbd>-Doptimize=ReleaseFast</kbd></dt><dd>Optimizations on and safety off</dd>
+        <dt><kbd>-Doptimize=ReleaseSmall</kbd></dt><dd>Size optimizations on and safety off</dd>
+      </dl>
+      {#header_open|Debug#}
+      {#shell_samp#}$ zig build-exe example.zig{#end_shell_samp#}
+      <ul>
+        <li>Fast compilation speed</li>
+        <li>Safety checks enabled</li>
+        <li>Slow runtime performance</li>
+        <li>Large binary size</li>
+        <li>No reproducible build requirement</li>
+      </ul>
+      {#header_close#}
+      {#header_open|ReleaseFast#}
+      {#shell_samp#}$ zig build-exe example.zig -O ReleaseFast{#end_shell_samp#}
+      <ul>
+        <li>Fast runtime performance</li>
+        <li>Safety checks disabled</li>
+        <li>Slow compilation speed</li>
+        <li>Large binary size</li>
+        <li>Reproducible build</li>
+      </ul>
+      {#header_close#}
+      {#header_open|ReleaseSafe#}
+      {#shell_samp#}$ zig build-exe example.zig -O ReleaseSafe{#end_shell_samp#}
+      <ul>
+        <li>Medium runtime performance</li>
+        <li>Safety checks enabled</li>
+        <li>Slow compilation speed</li>
+        <li>Large binary size</li>
+        <li>Reproducible build</li>
+      </ul>
+      {#header_close#}
+      {#header_open|ReleaseSmall#}
+      {#shell_samp#}$ zig build-exe example.zig -O ReleaseSmall{#end_shell_samp#}
+      <ul>
+        <li>Medium runtime performance</li>
+        <li>Safety checks disabled</li>
+        <li>Slow compilation speed</li>
+        <li>Small binary size</li>
+        <li>Reproducible build</li>
+      </ul>
+      {#header_close#}
+      {#see_also|Compile Variables|Zig Build System|Illegal Behavior#}
+      {#header_close#}
+
+      {#header_open|Single Threaded Builds#}
+      <p>Zig has a compile option <kbd>-fsingle-threaded</kbd> which has the following effects:</p>
+      <ul>
+        <li>All {#link|Thread Local Variables#} are treated as regular {#link|Container Level Variables#}.</li>
+        <li>The overhead of {#link|Async Functions#} becomes equivalent to function call overhead.</li>
+        <li>The {#syntax#}@import("builtin").single_threaded{#endsyntax#} becomes {#syntax#}true{#endsyntax#}
+          and therefore various userland APIs which read this variable become more efficient.
+          For example {#syntax#}std.Mutex{#endsyntax#} becomes
+          an empty data structure and all of its functions become no-ops.</li>
+      </ul>
+      {#header_close#}
+
+      {#header_open|Illegal Behavior#}
+      <p>
+      Many operations in Zig trigger what is known as "Illegal Behavior" (IB). If Illegal Behavior is detected at
+      compile-time, Zig emits a compile error and refuses to continue. Otherwise, when Illegal Behavior is not caught
+      at compile-time, it falls into one of two categories.
+      </p>
+      <p>
+      Some Illegal Behavior is <em>safety-checked</em>: this means that the compiler will insert "safety checks"
+      anywhere that the Illegal Behavior may occur at runtime, to determine whether it is about to happen. If it
+      is, the safety check "fails", which triggers a panic.
+      </p>
+      <p>
+      All other Illegal Behavior is <em>unchecked</em>, meaning the compiler is unable to insert safety checks for
+      it. If Unchecked Illegal Behavior is invoked at runtime, anything can happen: usually that will be some kind of
+      crash, but the optimizer is free to make Unchecked Illegal Behavior do anything, such as calling arbitrary functions
+      or clobbering arbitrary data. This is similar to the concept of "undefined behavior" in some other languages. Note that
+      Unchecked Illegal Behavior still always results in a compile error if evaluated at {#link|comptime#}, because the Zig
+      compiler is able to perform more sophisticated checks at compile-time than at runtime.
+      </p>
+      <p>
+      Most Illegal Behavior is safety-checked. However, to facilitate optimizations, safety checks are disabled by default
+      in the {#link|ReleaseFast#} and {#link|ReleaseSmall#} optimization modes. Safety checks can also be enabled or disabled
+      on a per-block basis, overriding the default for the current optimization mode, using {#link|@setRuntimeSafety#}. When
+      safety checks are disabled, Safety-Checked Illegal Behavior behaves like Unchecked Illegal Behavior; that is, any behavior
+      may result from invoking it.
+      </p>
+      <p>
+      When a safety check fails, Zig's default panic handler crashes with a stack trace, like this:
+      </p>
+      {#code|test_illegal_behavior.zig#}
+
+      {#header_open|Reaching Unreachable Code#}
+      <p>At compile-time:</p>
+      {#code|test_comptime_reaching_unreachable.zig#}
+
+      <p>At runtime:</p>
+      {#code|runtime_reaching_unreachable.zig#}
+
+      {#header_close#}
+      {#header_open|Index out of Bounds#}
+      <p>At compile-time:</p>
+      {#code|test_comptime_index_out_of_bounds.zig#}
+
+      <p>At runtime:</p>
+      {#code|runtime_index_out_of_bounds.zig#}
+
+      {#header_close#}
+      {#header_open|Cast Negative Number to Unsigned Integer#}
+      <p>At compile-time:</p>
+      {#code|test_comptime_invalid_cast.zig#}
+
+      <p>At runtime:</p>
+      {#code|runtime_invalid_cast.zig#}
+
+      <p>
+      To obtain the maximum value of an unsigned integer, use {#syntax#}std.math.maxInt{#endsyntax#}.
+      </p>
+      {#header_close#}
+      {#header_open|Cast Truncates Data#}
+      <p>At compile-time:</p>
+      {#code|test_comptime_invalid_cast_truncate.zig#}
+
+      <p>At runtime:</p>
+      {#code|runtime_invalid_cast_truncate.zig#}
+
+      <p>
+      To truncate bits, use {#link|@truncate#}.
+      </p>
+      {#header_close#}
+      {#header_open|Integer Overflow#}
+      {#header_open|Default Operations#}
+      <p>The following operators can cause integer overflow:</p>
+      <ul>
+          <li>{#syntax#}+{#endsyntax#} (addition)</li>
+          <li>{#syntax#}-{#endsyntax#} (subtraction)</li>
+          <li>{#syntax#}-{#endsyntax#} (negation)</li>
+          <li>{#syntax#}*{#endsyntax#} (multiplication)</li>
+          <li>{#syntax#}/{#endsyntax#} (division)</li>
+        <li>{#link|@divTrunc#} (division)</li>
+        <li>{#link|@divFloor#} (division)</li>
+        <li>{#link|@divExact#} (division)</li>
+      </ul>
+      <p>Example with addition at compile-time:</p>
+      {#code|test_comptime_overflow.zig#}
+
+      <p>At runtime:</p>
+      {#code|runtime_overflow.zig#}
+
+      {#header_close#}
+      {#header_open|Standard Library Math Functions#}
+      <p>These functions provided by the standard library return possible errors.</p>
+      <ul>
+          <li>{#syntax#}@import("std").math.add{#endsyntax#}</li>
+          <li>{#syntax#}@import("std").math.sub{#endsyntax#}</li>
+          <li>{#syntax#}@import("std").math.mul{#endsyntax#}</li>
+          <li>{#syntax#}@import("std").math.divTrunc{#endsyntax#}</li>
+          <li>{#syntax#}@import("std").math.divFloor{#endsyntax#}</li>
+          <li>{#syntax#}@import("std").math.divExact{#endsyntax#}</li>
+          <li>{#syntax#}@import("std").math.shl{#endsyntax#}</li>
+      </ul>
+      <p>Example of catching an overflow for addition:</p>
+      {#code|math_add.zig#}
+
+      {#header_close#}
+      {#header_open|Builtin Overflow Functions#}
+      <p>
+      These builtins return a tuple containing whether there was an overflow
+      (as a {#syntax#}u1{#endsyntax#}) and the possibly overflowed bits of the operation:
+      </p>
+      <ul>
+          <li>{#link|@addWithOverflow#}</li>
+          <li>{#link|@subWithOverflow#}</li>
+          <li>{#link|@mulWithOverflow#}</li>
+          <li>{#link|@shlWithOverflow#}</li>
+      </ul>
+      <p>
+      Example of {#link|@addWithOverflow#}:
+      </p>
+      {#code|addWithOverflow_builtin.zig#}
+
+      {#header_close#}
+      {#header_open|Wrapping Operations#}
+      <p>
+      These operations have guaranteed wraparound semantics.
+      </p>
+      <ul>
+          <li>{#syntax#}+%{#endsyntax#} (wraparound addition)</li>
+          <li>{#syntax#}-%{#endsyntax#} (wraparound subtraction)</li>
+          <li>{#syntax#}-%{#endsyntax#} (wraparound negation)</li>
+          <li>{#syntax#}*%{#endsyntax#} (wraparound multiplication)</li>
+      </ul>
+      {#code|test_wraparound_semantics.zig#}
+
+      {#header_close#}
+      {#header_close#}
+      {#header_open|Exact Left Shift Overflow#}
+      <p>At compile-time:</p>
+      {#code|test_comptime_shlExact_overwlow.zig#}
+
+      <p>At runtime:</p>
+      {#code|runtime_shlExact_overflow.zig#}
+
+      {#header_close#}
+      {#header_open|Exact Right Shift Overflow#}
+      <p>At compile-time:</p>
+      {#code|test_comptime_shrExact_overflow.zig#}
+
+      <p>At runtime:</p>
+      {#code|runtime_shrExact_overflow.zig#}
+
+      {#header_close#}
+      {#header_open|Division by Zero#}
+      <p>At compile-time:</p>
+      {#code|test_comptime_division_by_zero.zig#}
+
+      <p>At runtime:</p>
+      {#code|runtime_division_by_zero.zig#}
+
+      {#header_close#}
+      {#header_open|Remainder Division by Zero#}
+      <p>At compile-time:</p>
+      {#code|test_comptime_remainder_division_by_zero.zig#}
+
+      <p>At runtime:</p>
+      {#code|runtime_remainder_division_by_zero.zig#}
+
+      {#header_close#}
+      {#header_open|Exact Division Remainder#}
+      <p>At compile-time:</p>
+      {#code|test_comptime_divExact_remainder.zig#}
+
+      <p>At runtime:</p>
+      {#code|runtime_divExact_remainder.zig#}
+
+      {#header_close#}
+      {#header_open|Attempt to Unwrap Null#}
+      <p>At compile-time:</p>
+      {#code|test_comptime_unwrap_null.zig#}
+
+      <p>At runtime:</p>
+      {#code|runtime_unwrap_null.zig#}
+
+      <p>One way to avoid this crash is to test for null instead of assuming non-null, with
+      the {#syntax#}if{#endsyntax#} expression:</p>
+      {#code|testing_null_with_if.zig#}
+
+      {#see_also|Optionals#}
+      {#header_close#}
+      {#header_open|Attempt to Unwrap Error#}
+      <p>At compile-time:</p>
+      {#code|test_comptime_unwrap_error.zig#}
+
+      <p>At runtime:</p>
+      {#code|runtime_unwrap_error.zig#}
+
+      <p>One way to avoid this crash is to test for an error instead of assuming a successful result, with
+      the {#syntax#}if{#endsyntax#} expression:</p>
+      {#code|testing_error_with_if.zig#}
+
+      {#see_also|Errors#}
+      {#header_close#}
+      {#header_open|Invalid Error Code#}
+      <p>At compile-time:</p>
+      {#code|test_comptime_invalid_error_code.zig#}
+
+      <p>At runtime:</p>
+      {#code|runtime_invalid_error_code.zig#}
+
+      {#header_close#}
+      {#header_open|Invalid Enum Cast#}
+      <p>At compile-time:</p>
+      {#code|test_comptime_invalid_enum_cast.zig#}
+
+      <p>At runtime:</p>
+      {#code|runtime_invalid_enum_cast.zig#}
+
+      {#header_close#}
+
+      {#header_open|Invalid Error Set Cast#}
+      <p>At compile-time:</p>
+      {#code|test_comptime_invalid_error_set_cast.zig#}
+
+      <p>At runtime:</p>
+      {#code|runtime_invalid_error_set_cast.zig#}
+
+      {#header_close#}
+
+      {#header_open|Incorrect Pointer Alignment#}
+      <p>At compile-time:</p>
+      {#code|test_comptime_incorrect_pointer_alignment.zig#}
+
+      <p>At runtime:</p>
+      {#code|runtime_incorrect_pointer_alignment.zig#}
+
+      {#header_close#}
+      {#header_open|Wrong Union Field Access#}
+      <p>At compile-time:</p>
+      {#code|test_comptime_wrong_union_field_access.zig#}
+
+      <p>At runtime:</p>
+      {#code|runtime_wrong_union_field_access.zig#}
+
+      <p>
+      This safety is not available for {#syntax#}extern{#endsyntax#} or {#syntax#}packed{#endsyntax#} unions.
+      </p>
+      <p>
+      To change the active field of a union, assign the entire union, like this:
+      </p>
+      {#code|change_active_union_field.zig#}
+
+      <p>
+      To change the active field of a union when a meaningful value for the field is not known,
+      use {#link|undefined#}, like this:
+      </p>
+      {#code|undefined_active_union_field.zig#}
+
+      {#see_also|union|extern union#}
+      {#header_close#}
+
+      {#header_open|Out of Bounds Float to Integer Cast#}
+      <p>
+      This happens when casting a float to an integer where the float has a value outside the
+      integer type's range.
+      </p>
+      <p>At compile-time:</p>
+      {#code|test_comptime_out_of_bounds_float_to_integer_cast.zig#}
+
+      <p>At runtime:</p>
+      {#code|runtime_out_of_bounds_float_to_integer_cast.zig#}
+
+      {#header_close#}
+
+      {#header_open|Pointer Cast Invalid Null#}
+      <p>
+      This happens when casting a pointer with the address 0 to a pointer which may not have the address 0.
+      For example, {#link|C Pointers#}, {#link|Optional Pointers#}, and {#link|allowzero#} pointers
+      allow address zero, but normal {#link|Pointers#} do not.
+      </p>
+      <p>At compile-time:</p>
+      {#code|test_comptime_invalid_null_pointer_cast.zig#}
+
+      <p>At runtime:</p>
+      {#code|runtime_invalid_null_pointer_cast.zig#}
+
+      {#header_close#}
+
+      {#header_close#}
+      {#header_open|Memory#}
+      <p>
+      The Zig language performs no memory management on behalf of the programmer. This is
+      why Zig has no runtime, and why Zig code works seamlessly in so many environments,
+      including real-time software, operating system kernels, embedded devices, and
+      low latency servers. As a consequence, Zig programmers must always be able to answer
+      the question:
+      </p>
+      <p>{#link|Where are the bytes?#}</p>
+      <p>
+      Like Zig, the C programming language has manual memory management. However, unlike Zig,
+      C has a default allocator - <code>malloc</code>, <code>realloc</code>, and <code>free</code>.
+      When linking against libc, Zig exposes this allocator with {#syntax#}std.heap.c_allocator{#endsyntax#}.
+      However, by convention, there is no default allocator in Zig. Instead, functions which need to
+      allocate accept an {#syntax#}Allocator{#endsyntax#} parameter. Likewise, data structures such as
+      {#syntax#}std.ArrayList{#endsyntax#} accept an {#syntax#}Allocator{#endsyntax#} parameter in
+      their initialization functions:
+      </p>
+      {#code|test_allocator.zig#}
+
+      <p>
+      In the above example, 100 bytes of stack memory are used to initialize a
+      {#syntax#}FixedBufferAllocator{#endsyntax#}, which is then passed to a function.
+      As a convenience there is a global {#syntax#}FixedBufferAllocator{#endsyntax#}
+      available for quick tests at {#syntax#}std.testing.allocator{#endsyntax#},
+      which will also perform basic leak detection.
+      </p>
+      <p>
+      Zig has a general purpose allocator available to be imported
+      with {#syntax#}std.heap.GeneralPurposeAllocator{#endsyntax#}. However, it is still recommended to
+      follow the {#link|Choosing an Allocator#} guide.
+      </p>
+
+      {#header_open|Choosing an Allocator#}
+      <p>What allocator to use depends on a number of factors. Here is a flow chart to help you decide:
+      </p>
+      <ol>
+          <li>
+              Are you making a library? In this case, best to accept an {#syntax#}Allocator{#endsyntax#}
+              as a parameter and allow your library's users to decide what allocator to use.
+          </li>
+          <li>Are you linking libc? In this case, {#syntax#}std.heap.c_allocator{#endsyntax#} is likely
+              the right choice, at least for your main allocator.</li>
+          <li>
+              Need to use the same allocator in multiple threads? Use one of your choice
+              wrapped around {#syntax#}std.heap.ThreadSafeAllocator{#endsyntax#}
+          </li>
+          <li>
+              Is the maximum number of bytes that you will need bounded by a number known at
+              {#link|comptime#}? In this case, use {#syntax#}std.heap.FixedBufferAllocator{#endsyntax#}.
+          </li>
+          <li>
+              Is your program a command line application which runs from start to end without any fundamental
+              cyclical pattern (such as a video game main loop, or a web server request handler),
+              such that it would make sense to free everything at once at the end?
+              In this case, it is recommended to follow this pattern:
+      {#code|cli_allocation.zig#}
+
+              When using this kind of allocator, there is no need to free anything manually. Everything
+              gets freed at once with the call to {#syntax#}arena.deinit(){#endsyntax#}.
+          </li>
+          <li>
+              Are the allocations part of a cyclical pattern such as a video game main loop, or a web
+              server request handler? If the allocations can all be freed at once, at the end of the cycle,
+              for example once the video game frame has been fully rendered, or the web server request has
+              been served, then {#syntax#}std.heap.ArenaAllocator{#endsyntax#} is a great candidate. As
+              demonstrated in the previous bullet point, this allows you to free entire arenas at once.
+              Note also that if an upper bound of memory can be established, then
+              {#syntax#}std.heap.FixedBufferAllocator{#endsyntax#} can be used as a further optimization.
+          </li>
+          <li>
+              Are you writing a test, and you want to make sure {#syntax#}error.OutOfMemory{#endsyntax#}
+              is handled correctly? In this case, use {#syntax#}std.testing.FailingAllocator{#endsyntax#}.
+          </li>
+          <li>
+              Are you writing a test? In this case, use {#syntax#}std.testing.allocator{#endsyntax#}.
+          </li>
+          <li>
+              Finally, if none of the above apply, you need a general purpose allocator.
+              Zig's general purpose allocator is available as a function that takes a {#link|comptime#}
+              {#link|struct#} of configuration options and returns a type.
+              Generally, you will set up one {#syntax#}std.heap.GeneralPurposeAllocator{#endsyntax#} in
+              your main function, and then pass it or sub-allocators around to various parts of your
+              application.
+          </li>
+          <li>
+              You can also consider {#link|Implementing an Allocator#}.
+          </li>
+      </ol>
+      {#header_close#}
+
+      {#header_open|Where are the bytes?#}
+      <p>String literals such as {#syntax#}"hello"{#endsyntax#} are in the global constant data section.
+      This is why it is an error to pass a string literal to a mutable slice, like this:
+      </p>
+      {#code|test_string_literal_to_slice.zig#}
+
+      <p>However if you make the slice constant, then it works:</p>
+      {#code|test_string_literal_to_const_slice.zig#}
+
+      <p>
+      Just like string literals, {#syntax#}const{#endsyntax#} declarations, when the value is known at {#link|comptime#},
+      are stored in the global constant data section. Also {#link|Compile Time Variables#} are stored
+      in the global constant data section.
+      </p>
+      <p>
+      {#syntax#}var{#endsyntax#} declarations inside functions are stored in the function's stack frame. Once a function returns,
+      any {#link|Pointers#} to variables in the function's stack frame become invalid references, and
+      dereferencing them becomes unchecked {#link|Illegal Behavior#}.
+      </p>
+      <p>
+      {#syntax#}var{#endsyntax#} declarations at the top level or in {#link|struct#} declarations are stored in the global
+      data section.
+      </p>
+      <p>
+      The location of memory allocated with {#syntax#}allocator.alloc{#endsyntax#} or
+      {#syntax#}allocator.create{#endsyntax#} is determined by the allocator's implementation.
+      </p>
+      <p>TODO: thread local variables</p>
+      {#header_close#}
+
+      {#header_open|Implementing an Allocator#}
+      <p>Zig programmers can implement their own allocators by fulfilling the Allocator interface.
+      In order to do this one must read carefully the documentation comments in std/mem.zig and
+      then supply a {#syntax#}allocFn{#endsyntax#} and a {#syntax#}resizeFn{#endsyntax#}.
+      </p>
+      <p>
+      There are many example allocators to look at for inspiration. Look at std/heap.zig and
+      {#syntax#}std.heap.GeneralPurposeAllocator{#endsyntax#}.
+      </p>
+      {#header_close#}
+
+      {#header_open|Heap Allocation Failure#}
+      <p>
+      Many programming languages choose to handle the possibility of heap allocation failure by
+      unconditionally crashing. By convention, Zig programmers do not consider this to be a
+      satisfactory solution. Instead, {#syntax#}error.OutOfMemory{#endsyntax#} represents
+      heap allocation failure, and Zig libraries return this error code whenever heap allocation
+      failure prevented an operation from completing successfully.
+      </p>
+      <p>
+      Some have argued that because some operating systems such as Linux have memory overcommit enabled by
+      default, it is pointless to handle heap allocation failure. There are many problems with this reasoning:
+      </p>
+      <ul>
+          <li>Only some operating systems have an overcommit feature.
+              <ul>
+                  <li>Linux has it enabled by default, but it is configurable.</li>
+                  <li>Windows does not overcommit.</li>
+                  <li>Embedded systems do not have overcommit.</li>
+                  <li>Hobby operating systems may or may not have overcommit.</li>
+              </ul>
+          </li>
+          <li>
+              For real-time systems, not only is there no overcommit, but typically the maximum amount
+              of memory per application is determined ahead of time.
+          </li>
+          <li>
+              When writing a library, one of the main goals is code reuse. By making code handle
+              allocation failure correctly, a library becomes eligible to be reused in
+              more contexts.
+          </li>
+          <li>
+              Although some software has grown to depend on overcommit being enabled, its existence
+              is the source of countless user experience disasters. When a system with overcommit enabled,
+              such as Linux on default settings, comes close to memory exhaustion, the system locks up
+              and becomes unusable. At this point, the OOM Killer selects an application to kill
+              based on heuristics. This non-deterministic decision often results in an important process
+              being killed, and often fails to return the system back to working order.
+          </li>
+      </ul>
+      {#header_close#}
+
+      {#header_open|Recursion#}
+      <p>
+      Recursion is a fundamental tool in modeling software. However it has an often-overlooked problem:
+      unbounded memory allocation.
+      </p>
+      <p>
+      Recursion is an area of active experimentation in Zig and so the documentation here is not final.
+      You can read a
+      <a href="https://ziglang.org/download/0.3.0/release-notes.html#recursion">summary of recursion status in the 0.3.0 release notes</a>.
+      </p>
+      <p>
+      The short summary is that currently recursion works normally as you would expect. Although Zig code
+      is not yet protected from stack overflow, it is planned that a future version of Zig will provide
+      such protection, with some degree of cooperation from Zig code required.
+      </p>
+      {#header_close#}
+
+      {#header_open|Lifetime and Ownership#}
+      <p>
+      It is the Zig programmer's responsibility to ensure that a {#link|pointer|Pointers#} is not
+      accessed when the memory pointed to is no longer available. Note that a {#link|slice|Slices#}
+      is a form of pointer, in that it references other memory.
+      </p>
+      <p>
+      In order to prevent bugs, there are some helpful conventions to follow when dealing with pointers.
+      In general, when a function returns a pointer, the documentation for the function should explain
+      who "owns" the pointer. This concept helps the programmer decide when it is appropriate, if ever,
+      to free the pointer.
+      </p>
+      <p>
+      For example, the function's documentation may say "caller owns the returned memory", in which case
+      the code that calls the function must have a plan for when to free that memory. Probably in this situation,
+      the function will accept an {#syntax#}Allocator{#endsyntax#} parameter.
+      </p>
+      <p>
+      Sometimes the lifetime of a pointer may be more complicated. For example, the
+      {#syntax#}std.ArrayList(T).items{#endsyntax#} slice has a lifetime that remains
+      valid until the next time the list is resized, such as by appending new elements.
+      </p>
+      <p>
+      The API documentation for functions and data structures should take great care to explain
+      the ownership and lifetime semantics of pointers. Ownership determines whose responsibility it
+      is to free the memory referenced by the pointer, and lifetime determines the point at which
+      the memory becomes inaccessible (lest {#link|Illegal Behavior#} occur).
+      </p>
+      {#header_close#}
+
+      {#header_close#}
+      {#header_open|Compile Variables#}
+      <p>
+      Compile variables are accessible by importing the {#syntax#}"builtin"{#endsyntax#} package,
+      which the compiler makes available to every Zig source file. It contains
+      compile-time constants such as the current target, endianness, and release mode.
+      </p>
+      {#code|compile_variables.zig#}
+
+      <p>
+      Example of what is imported with {#syntax#}@import("builtin"){#endsyntax#}:
+      </p>
+      {#builtin#}
+      {#see_also|Build Mode#}
+      {#header_close#}
+      {#header_open|Compilation Model#}
+      <p>
+      A Zig compilation is separated into <em>modules</em>. Each module is a collection of Zig source files,
+      one of which is the module's <em>root source file</em>. Each module can <em>depend</em> on any number of
+      other modules, forming a directed graph (dependency loops between modules are allowed). If module A
+      depends on module B, then any Zig source file in module A can import the <em>root source file</em> of
+      module B using {#syntax#}@import{#endsyntax#} with the module's name. In essence, a module acts as an
+      alias to import a Zig source file (which might exist in a completely separate part of the filesystem).
+      </p>
+      <p>
+      A simple Zig program compiled with <code>zig build-exe</code> has two key modules: the one containing your
+      code, known as the "main" or "root" module, and the standard library. Your module <em>depends on</em>
+      the standard library module under the name "std", which is what allows you to write
+      {#syntax#}@import("std"){#endsyntax#}! In fact, every single module in a Zig compilation &mdash; including
+      the standard library itself &mdash; implicitly depends on the standard library module under the name "std".
+      </p>
+      <p>
+      The "root module" (the one provided by you in the <code>zig build-exe</code> example) has a special
+      property. Like the standard library, it is implicitly made available to all modules (including itself),
+      this time under the name "root". So, {#syntax#}@import("root"){#endsyntax#} will always be equivalent to
+      {#syntax#}@import{#endsyntax#} of your "main" source file (often, but not necessarily, named
+      <code>main.zig</code>).
+      </p>
+      {#header_open|Source File Structs#}
+      <p>
+      Every Zig source file is implicitly a {#syntax#}struct{#endsyntax#} declaration; you can imagine that
+      the file's contents are literally surrounded by {#syntax#}struct { ... }{#endsyntax#}. This means that
+      as well as declarations, the top level of a file is permitted to contain fields:
+      </p>
+      {#code|TopLevelFields.zig#}
+      <p>
+      Such files can be instantiated just like any other {#syntax#}struct{#endsyntax#} type. A file's "root
+      struct type" can be referred to within that file using {#link|@This#}.
+      </p>
+      {#header_close#}
+      {#header_open|File and Declaration Discovery#}
+      <p>
+      Zig places importance on the concept of whether any piece of code is <em>semantically analyzed</em>; in
+      essence, whether the compiler "looks at" it. What code is analyzed is based on what files and
+      declarations are "discovered" from a certain point. This process of "discovery" is based on a simple set
+      of recursive rules:
+      </p>
+      <ul>
+        <li>If a call to {#syntax#}@import{#endsyntax#} is analyzed, the file being imported is analyzed.</li>
+        <li>If a type (including a file) is analyzed, all {#syntax#}comptime{#endsyntax#}, {#syntax#}usingnamespace{#endsyntax#}, and {#syntax#}export{#endsyntax#} declarations within it are analyzed.</li>
+        <li>If a type (including a file) is analyzed, and the compilation is for a {#link|test|Zig Test#}, and the module the type is within is the root module of the compilation, then all {#syntax#}test{#endsyntax#} declarations within it are also analyzed.</li>
+        <li>If a reference to a named declaration (i.e. a usage of it) is analyzed, the declaration being referenced is analyzed. Declarations are order-independent, so this reference may be above or below the declaration being referenced, or even in another file entirely.</li>
+      </ul>
+      <p>
+      That's it! Those rules define how Zig files and declarations are discovered. All that remains is to
+      understand where this process <em>starts</em>.
+      </p>
+      <p>
+      The answer to that is the root of the standard library: every Zig compilation begins by analyzing the
+      file <code>lib/std/std.zig</code>. This file contains a {#syntax#}comptime{#endsyntax#} declaration
+      which imports {#syntax#}lib/std/start.zig{#endsyntax#}, and that file in turn uses
+      {#syntax#}@import("root"){#endsyntax#} to reference the "root module"; so, the file you provide as your
+      main module's root source file is effectively also a root, because the standard library will always
+      reference it.
+      </p>
+      <p>
+      It is often desirable to make sure that certain declarations &mdash; particularly {#syntax#}test{#endsyntax#}
+      or {#syntax#}export{#endsyntax#} declarations &mdash; are discovered. Based on the above rules, a common
+      strategy for this is to use {#syntax#}@import{#endsyntax#} within a {#syntax#}comptime{#endsyntax#} or
+      {#syntax#}test{#endsyntax#} block:
+      </p>
+      {#syntax_block|zig|force_file_discovery.zig#}
+comptime {
+    // This will ensure that the file 'api.zig' is always discovered (as long as this file is discovered).
+    // It is useful if 'api.zig' contains important exported declarations.
+    _ = @import("api.zig");
+
+    // We could also have a file which contains declarations we only want to export depending on a comptime
+    // condition. In that case, we can use an `if` statement here:
+    if (builtin.os.tag == .windows) {
+        _ = @import("windows_api.zig");
+    }
+}
+
+test {
+    // This will ensure that the file 'tests.zig' is always discovered (as long as this file is discovered),
+    // if this compilation is a test. It is useful if 'tests.zig' contains tests we want to ensure are run.
+    _ = @import("tests.zig");
+
+    // We could also have a file which contains tests we only want to run depending on a comptime condition.
+    // In that case, we can use an `if` statement here:
+    if (builtin.os.tag == .windows) {
+        _ = @import("windows_tests.zig");
+    }
+}
+
+const builtin = @import("builtin");
+      {#end_syntax_block#}
+      {#header_close#}
+      {#header_open|Special Root Declarations#}
+      <p>
+      Because the root module's root source file is always accessible using
+      {#syntax#}@import("root"){#endsyntax#}, is is sometimes used by libraries &mdash; including the Zig Standard
+      Library &mdash; as a place for the program to expose some "global" information to that library. The Zig
+      Standard Library will look for several declarations in this file.
+      </p>
+      {#header_open|Entry Point#}
+      <p>
+      When building an executable, the most important thing to be looked up in this file is the program's
+      <em>entry point</em>. Most commonly, this is a function named {#syntax#}main{#endsyntax#}, which
+      {#syntax#}std.start{#endsyntax#} will call just after performing important initialization work.
+      </p>
+      <p>
+      Alternatively, the presence of a declaration named {#syntax#}_start{#endsyntax#} (for instance,
+      {#syntax#}pub const _start = {};{#endsyntax#}) will disable the default {#syntax#}std.start{#endsyntax#}
+      logic, allowing your root source file to export a low-level entry point as needed.
+      </p>
+      {#code|entry_point.zig#}
+      <p>
+      If the Zig compilation links libc, the {#syntax#}main{#endsyntax#} function can optionally be an
+      {#syntax#}export fn{#endsyntax#} which matches the signature of the C <code>main</code> function:
+      </p>
+      {#code|libc_export_entry_point.zig#}
+      <p>
+      {#syntax#}std.start{#endsyntax#} may also use other entry point declarations in certain situations, such
+      as {#syntax#}wWinMain{#endsyntax#} or {#syntax#}EfiMain{#endsyntax#}. Refer to the
+      {#syntax#}lib/std/start.zig{#endsyntax#} logic for details of these declarations.
+      </p>
+      {#header_close#}
+      {#header_open|Standard Library Options#}
+      <p>
+      The standard library also looks for a declaration in the root module's root source file named
+      {#syntax#}std_options{#endsyntax#}. If present, this declaration is expected to be a struct of type
+      {#syntax#}std.Options{#endsyntax#}, and allows the program to customize some standard library
+      functionality, such as the {#syntax#}std.log{#endsyntax#} implementation.
+      </p>
+      {#code|std_options.zig#}
+      {#header_close#}
+      {#header_open|Panic Handler#}
+      <p>
+      The Zig Standard Library looks for a declaration named {#syntax#}panic{#endsyntax#} in the root module's
+      root source file. If present, it is expected to be a namespace (container type) with declarations
+      providing different panic handlers.
+      </p>
+      <p>
+      See {#syntax#}std.debug.simple_panic{#endsyntax#} for a basic implementation of this namespace.
+      </p>
+      <p>
+      Overriding how the panic handler actually outputs messages, but keeping the formatted safety panics
+      which are enabled by default, can be easily achieved with {#syntax#}std.debug.FullPanic{#endsyntax#}:
+      </p>
+      {#code|panic_handler.zig#}
+      {#header_close#}
+      {#header_close#}
+      {#header_close#}
+      {#header_open|Zig Build System#}
+      <p>
+      The Zig Build System provides a cross-platform, dependency-free way to declare
+      the logic required to build a project. With this system, the logic to build
+      a project is written in a build.zig file, using the Zig Build System API to
+      declare and configure build artifacts and other tasks.
+      </p>
+      <p>
+      Some examples of tasks the build system can help with:
+      </p>
+      <ul>
+        <li>Performing tasks in parallel and caching the results.</li>
+        <li>Depending on other projects.</li>
+        <li>Providing a package for other projects to depend on.</li>
+        <li>Creating build artifacts by executing the Zig compiler. This includes
+          building Zig source code as well as C and C++ source code.</li>
+        <li>Capturing user-configured options and using those options to configure
+          the build.</li>
+        <li>Surfacing build configuration as {#link|comptime#} values by providing a
+          file that can be {#link|imported|@import#} by Zig code.</li>
+        <li>Caching build artifacts to avoid unnecessarily repeating steps.</li>
+        <li>Executing build artifacts or system-installed tools.</li>
+        <li>Running tests and verifying the output of executing a build artifact matches
+        the expected value.</li>
+        <li>Running <code>zig fmt</code> on a codebase or a subset of it.</li>
+        <li>Custom tasks.</li>
+      </ul>
+      <p>
+      To use the build system, run <kbd>zig build --help</kbd>
+      to see a command-line usage help menu. This will include project-specific
+      options that were declared in the build.zig script.
+      </p>
+      <p>
+      For the time being, the build system documentation is hosted externally:
+      <a href="https://ziglang.org/learn/build-system/">Build System Documentation</a>
+      </p>
+      {#header_close#}
+      {#header_open|C#}
+      <p>
+      Although Zig is independent of C, and, unlike most other languages, does not depend on libc,
+      Zig acknowledges the importance of interacting with existing C code.
+      </p>
+      <p>
+      There are a few ways that Zig facilitates C interop.
+      </p>
+      {#header_open|C Type Primitives#}
+      <p>
+      These have guaranteed C ABI compatibility and can be used like any other type.
+      </p>
+      <ul>
+          <li>{#syntax#}c_char{#endsyntax#}</li>
+          <li>{#syntax#}c_short{#endsyntax#}</li>
+          <li>{#syntax#}c_ushort{#endsyntax#}</li>
+          <li>{#syntax#}c_int{#endsyntax#}</li>
+          <li>{#syntax#}c_uint{#endsyntax#}</li>
+          <li>{#syntax#}c_long{#endsyntax#}</li>
+          <li>{#syntax#}c_ulong{#endsyntax#}</li>
+          <li>{#syntax#}c_longlong{#endsyntax#}</li>
+          <li>{#syntax#}c_ulonglong{#endsyntax#}</li>
+          <li>{#syntax#}c_longdouble{#endsyntax#}</li>
+      </ul>
+      <p>
+      To interop with the C {#syntax#}void{#endsyntax#} type, use {#syntax#}anyopaque{#endsyntax#}.
+      </p>
+      {#see_also|Primitive Types#}
+      {#header_close#}
+      {#header_open|Import from C Header File#}
+      <p>
+      The {#syntax#}@cImport{#endsyntax#} builtin function can be used
+      to directly import symbols from <code class="file">.h</code> files:
+      </p>
+      {#code|cImport_builtin.zig#}
+
+      <p>
+      The {#syntax#}@cImport{#endsyntax#} function takes an expression as a parameter.
+      This expression is evaluated at compile-time and is used to control
+      preprocessor directives and include multiple <code class="file">.h</code> files:
+      </p>
+      {#syntax_block|zig|@cImport Expression#}
+const builtin = @import("builtin");
+
+const c = @cImport({
+    @cDefine("NDEBUG", builtin.mode == .ReleaseFast);
+    if (something) {
+        @cDefine("_GNU_SOURCE", {});
+    }
+    @cInclude("stdlib.h");
+    if (something) {
+        @cUndef("_GNU_SOURCE");
+    }
+    @cInclude("soundio.h");
+});
+      {#end_syntax_block#}
+      {#see_also|@cImport|@cInclude|@cDefine|@cUndef|@import#}
+      {#header_close#}
+
+      {#header_open|C Translation CLI#}
+      <p>
+      Zig's C translation capability is available as a CLI tool via <kbd>zig translate-c</kbd>.
+      It requires a single filename as an argument. It may also take a set of optional flags that are
+      forwarded to clang. It writes the translated file to stdout.
+      </p>
+      {#header_open|Command line flags#}
+      <ul>
+        <li>
+          <kbd>-I</kbd>:
+          Specify a search directory for include files. May be used multiple times. Equivalent to
+          <a href="https://releases.llvm.org/12.0.0/tools/clang/docs/ClangCommandLineReference.html#cmdoption-clang-i-dir">
+          clang's <kbd>-I</kbd> flag</a>. The current directory is <em>not</em> included by default;
+          use <kbd>-I.</kbd> to include it.
+        </li>
+        <li>
+          <kbd>-D</kbd>: Define a preprocessor macro. Equivalent to
+          <a href="https://releases.llvm.org/12.0.0/tools/clang/docs/ClangCommandLineReference.html#cmdoption-clang-d-macro">
+          clang's <kbd>-D</kbd> flag</a>.
+        </li>
+        <li>
+          <kbd>-cflags [flags] --</kbd>: Pass arbitrary additional
+          <a href="https://releases.llvm.org/12.0.0/tools/clang/docs/ClangCommandLineReference.html">command line
+          flags</a> to clang. Note: the list of flags must end with <kbd>--</kbd>
+        </li>
+        <li>
+          <kbd>-target</kbd>: The {#link|target triple|Targets#} for the translated Zig code.
+          If no target is specified, the current host target will be used.
+        </li>
+      </ul>
+      {#header_close#}
+      {#header_open|Using -target and -cflags#}
+      <p>
+        <strong>Important!</strong> When translating C code with <kbd>zig translate-c</kbd>,
+        you <strong>must</strong> use the same <kbd>-target</kbd> triple that you will use when compiling
+        the translated code. In addition, you <strong>must</strong> ensure that the <kbd>-cflags</kbd> used,
+        if any, match the cflags used by code on the target system. Using the incorrect <kbd>-target</kbd>
+        or <kbd>-cflags</kbd> could result in clang or Zig parse failures, or subtle ABI incompatibilities
+        when linking with C code.
+      </p>
+      {#syntax_block|c|varytarget.h#}
+long FOO = __LONG_MAX__;
+      {#end_syntax_block#}
+      {#shell_samp#}$ zig translate-c -target thumb-freestanding-gnueabihf varytarget.h|grep FOO
+pub export var FOO: c_long = 2147483647;
+$ zig translate-c -target x86_64-macos-gnu varytarget.h|grep FOO
+pub export var FOO: c_long = 9223372036854775807;{#end_shell_samp#}
+      {#syntax_block|c|varycflags.h#}
+enum FOO { BAR };
+int do_something(enum FOO foo);
+      {#end_syntax_block#}
+      {#shell_samp#}$ zig translate-c varycflags.h|grep -B1 do_something
+pub const enum_FOO = c_uint;
+pub extern fn do_something(foo: enum_FOO) c_int;
+$ zig translate-c -cflags -fshort-enums -- varycflags.h|grep -B1 do_something
+pub const enum_FOO = u8;
+pub extern fn do_something(foo: enum_FOO) c_int;{#end_shell_samp#}
+      {#header_close#}
+      {#header_open|@cImport vs translate-c#}
+      <p>{#syntax#}@cImport{#endsyntax#} and <kbd>zig translate-c</kbd> use the same underlying
+      C translation functionality, so on a technical level they are equivalent. In practice,
+      {#syntax#}@cImport{#endsyntax#} is useful as a way to quickly and easily access numeric constants, typedefs,
+      and record types without needing any extra setup. If you need to pass {#link|cflags|Using -target and -cflags#}
+      to clang, or if you would like to edit the translated code, it is recommended to use
+      <kbd>zig translate-c</kbd> and save the results to a file. Common reasons for editing
+      the generated code include: changing {#syntax#}anytype{#endsyntax#} parameters in function-like macros to more
+      specific types; changing {#syntax#}[*c]T{#endsyntax#} pointers to {#syntax#}[*]T{#endsyntax#} or
+      {#syntax#}*T{#endsyntax#} pointers for improved type safety; and
+      {#link|enabling or disabling runtime safety|@setRuntimeSafety#} within specific functions.
+      </p>
+      {#header_close#}
+      {#see_also|Targets|C Type Primitives|Pointers|C Pointers|Import from C Header File|@cInclude|@cImport|@setRuntimeSafety#}
+      {#header_close#}
+      {#header_open|C Translation Caching#}
+      <p>
+        The C translation feature (whether used via <kbd>zig translate-c</kbd> or
+        {#syntax#}@cImport{#endsyntax#}) integrates with the Zig caching system. Subsequent runs with
+        the same source file, target, and cflags will use the cache instead of repeatedly translating
+        the same code.
+      </p>
+      <p>
+        To see where the cached files are stored when compiling code that uses {#syntax#}@cImport{#endsyntax#},
+        use the <kbd>--verbose-cimport</kbd> flag:
+      </p>
+      {#code|verbose_cimport_flag.zig#}
+
+      <p>
+        <code class="file">cimport.h</code> contains the file to translate (constructed from calls to
+        {#syntax#}@cInclude{#endsyntax#}, {#syntax#}@cDefine{#endsyntax#}, and {#syntax#}@cUndef{#endsyntax#}),
+        <code class="file">cimport.h.d</code> is the list of file dependencies, and
+        <code class="file">cimport.zig</code> contains the translated output.
+      </p>
+      {#see_also|Import from C Header File|C Translation CLI|@cInclude|@cImport#}
+      {#header_close#}
+      {#header_open|Translation failures#}
+      <p>
+        Some C constructs cannot be translated to Zig - for example, <em>goto</em>,
+        structs with bitfields, and token-pasting macros. Zig employs <em>demotion</em> to allow translation
+        to continue in the face of non-translatable entities.
+      </p>
+      <p>
+        Demotion comes in three varieties - {#link|opaque#}, <em>extern</em>, and
+        {#syntax#}@compileError{#endsyntax#}.
+
+        C structs and unions that cannot be translated correctly will be translated as {#syntax#}opaque{}{#endsyntax#}.
+        Functions that contain opaque types or code constructs that cannot be translated will be demoted
+        to {#syntax#}extern{#endsyntax#} declarations.
+
+        Thus, non-translatable types can still be used as pointers, and non-translatable functions
+        can be called so long as the linker is aware of the compiled function.
+      </p>
+      <p>
+        {#syntax#}@compileError{#endsyntax#} is used when top-level definitions (global variables,
+        function prototypes, macros) cannot be translated or demoted. Since Zig uses lazy analysis for
+        top-level declarations, untranslatable entities will not cause a compile error in your code unless
+        you actually use them.
+      </p>
+      {#see_also|opaque|extern|@compileError#}
+      {#header_close#}
+      {#header_open|C Macros#}
+      <p>
+        C Translation makes a best-effort attempt to translate function-like macros into equivalent
+        Zig functions. Since C macros operate at the level of lexical tokens, not all C macros
+        can be translated to Zig. Macros that cannot be translated will be demoted to
+        {#syntax#}@compileError{#endsyntax#}. Note that C code which <em>uses</em> macros will be
+        translated without any additional issues (since Zig operates on the pre-processed source
+        with macros expanded). It is merely the macros themselves which may not be translatable to
+        Zig.
+      </p>
+      <p>Consider the following example:</p>
+      {#syntax_block|c|macro.c#}
+#define MAKELOCAL(NAME, INIT) int NAME = INIT
+int foo(void) {
+   MAKELOCAL(a, 1);
+   MAKELOCAL(b, 2);
+   return a + b;
+}
+      {#end_syntax_block#}
+      {#shell_samp#}$ zig translate-c macro.c > macro.zig{#end_shell_samp#}
+      {#code|macro.zig#}
+
+      <p>Note that {#syntax#}foo{#endsyntax#} was translated correctly despite using a non-translatable
+        macro. {#syntax#}MAKELOCAL{#endsyntax#} was demoted to {#syntax#}@compileError{#endsyntax#} since
+        it cannot be expressed as a Zig function; this simply means that you cannot directly use
+        {#syntax#}MAKELOCAL{#endsyntax#} from Zig.
+      </p>
+      {#see_also|@compileError#}
+      {#header_close#}
+
+      {#header_open|C Pointers#}
+      <p>
+      This type is to be avoided whenever possible. The only valid reason for using a C pointer is in
+      auto-generated code from translating C code.
+      </p>
+      <p>
+      When importing C header files, it is ambiguous whether pointers should be translated as
+      single-item pointers ({#syntax#}*T{#endsyntax#}) or many-item pointers ({#syntax#}[*]T{#endsyntax#}).
+      C pointers are a compromise so that Zig code can utilize translated header files directly.
+      </p>
+      <p>{#syntax#}[*c]T{#endsyntax#} - C pointer.</p>
+      <ul>
+        <li>Supports all the syntax of the other two pointer types ({#syntax#}*T{#endsyntax#}) and ({#syntax#}[*]T{#endsyntax#}).</li>
+        <li>Coerces to other pointer types, as well as {#link|Optional Pointers#}.
+            When a C pointer is coerced to a non-optional pointer, safety-checked
+            {#link|Illegal Behavior#} occurs if the address is 0.
+        </li>
+        <li>Allows address 0. On non-freestanding targets, dereferencing address 0 is safety-checked
+            {#link|Illegal Behavior#}. Optional C pointers introduce another bit to keep track of
+            null, just like {#syntax#}?usize{#endsyntax#}. Note that creating an optional C pointer
+            is unnecessary as one can use normal {#link|Optional Pointers#}.
+        </li>
+        <li>Supports {#link|Type Coercion#} to and from integers.</li>
+        <li>Supports comparison with integers.</li>
+        <li>Does not support Zig-only pointer attributes such as alignment. Use normal {#link|Pointers#}
+        please!</li>
+      </ul>
+      <p>When a C pointer is pointing to a single struct (not an array), dereference the C pointer to
+        access the struct's fields or member data. That syntax looks like
+        this: </p>
+        <p>{#syntax#}ptr_to_struct.*.struct_member{#endsyntax#}</p>
+        <p>This is comparable to doing {#syntax#}->{#endsyntax#} in C.</p>
+        <p> When a C pointer is pointing to an array of structs, the syntax reverts to this:</p>
+        <p>{#syntax#}ptr_to_struct_array[index].struct_member{#endsyntax#}</p>
+      {#header_close#}
+
+      {#header_open|C Variadic Functions#}
+      <p>Zig supports extern variadic functions.</p>
+      {#code|test_variadic_function.zig#}
+
+      <p>
+        Variadic functions can be implemented using {#link|@cVaStart#}, {#link|@cVaEnd#}, {#link|@cVaArg#} and {#link|@cVaCopy#}.
+      </p>
+      {#code|test_defining_variadic_function.zig#}
+
+      {#header_close#}
+      {#header_open|Exporting a C Library#}
+      <p>
+      One of the primary use cases for Zig is exporting a library with the C ABI for other programming languages
+      to call into. The {#syntax#}export{#endsyntax#} keyword in front of functions, variables, and types causes them to
+      be part of the library API:
+      </p>
+      {#code|mathtest.zig#}
+
+      <p>To make a static library:</p>
+      {#shell_samp#}$ zig build-lib mathtest.zig{#end_shell_samp#}
+      <p>To make a shared library:</p>
+      {#shell_samp#}$ zig build-lib mathtest.zig -dynamic{#end_shell_samp#}
+      <p>Here is an example with the {#link|Zig Build System#}:</p>
+      {#syntax_block|c|test.c#}
+// This header is generated by zig from mathtest.zig
+#include "mathtest.h"
+#include <stdio.h>
+
+int main(int argc, char **argv) {
+    int32_t result = add(42, 1337);
+    printf("%d\n", result);
+    return 0;
+}
+      {#end_syntax_block#}
+      {#code|build_c.zig#}
+
+      {#shell_samp#}$ zig build test
+1379{#end_shell_samp#}
+      {#see_also|export#}
+      {#header_close#}
+      {#header_open|Mixing Object Files#}
+      <p>
+      You can mix Zig object files with any other object files that respect the C ABI. Example:
+      </p>
+      {#code|base64.zig#}
+
+      {#syntax_block|c|test.c#}
+// This header is generated by zig from base64.zig
+#include "base64.h"
+
+#include <string.h>
+#include <stdio.h>
+
+int main(int argc, char **argv) {
+    const char *encoded = "YWxsIHlvdXIgYmFzZSBhcmUgYmVsb25nIHRvIHVz";
+    char buf[200];
+
+    size_t len = decode_base_64(buf, 200, encoded, strlen(encoded));
+    buf[len] = 0;
+    puts(buf);
+
+    return 0;
+}
+      {#end_syntax_block#}
+      {#code|build_object.zig#}
+
+      {#shell_samp#}$ zig build
+$ ./zig-out/bin/test
+all your base are belong to us{#end_shell_samp#}
+      {#see_also|Targets|Zig Build System#}
+      {#header_close#}
+      {#header_close#}
+      {#header_open|WebAssembly#}
+      <p>Zig supports building for WebAssembly out of the box.</p>
+      {#header_open|Freestanding#}
+      <p>For host environments like the web browser and nodejs, build as an executable using the freestanding
+      OS target. Here's an example of running Zig code compiled to WebAssembly with nodejs.</p>
+      {#code|math.zig#}
+
+      {#syntax_block|javascript|test.js#}
+const fs = require('fs');
+const source = fs.readFileSync("./math.wasm");
+const typedArray = new Uint8Array(source);
+
+WebAssembly.instantiate(typedArray, {
+  env: {
+    print: (result) => { console.log(`The result is ${result}`); }
+  }}).then(result => {
+  const add = result.instance.exports.add;
+  add(1, 2);
+});
+      {#end_syntax_block#}
+      {#shell_samp#}$ node test.js
+The result is 3{#end_shell_samp#}
+      {#header_close#}
+      {#header_open|WASI#}
+      <p>Zig's support for WebAssembly System Interface (WASI) is under active development.
+      Example of using the standard library and reading command line arguments:</p>
+      {#code|wasi_args.zig#}
+
+      {#shell_samp#}$ wasmtime wasi_args.wasm 123 hello
+0: wasi_args.wasm
+1: 123
+2: hello{#end_shell_samp#}
+      <p>A more interesting example would be extracting the list of preopens from the runtime.
+      This is now supported in the standard library via {#syntax#}std.fs.wasi.Preopens{#endsyntax#}:</p>
+      {#code|wasi_preopens.zig#}
+
+      {#shell_samp#}$ wasmtime --dir=. wasi_preopens.wasm
+0: stdin
+1: stdout
+2: stderr
+3: .
+      {#end_shell_samp#}
+      {#header_close#}
+      {#header_close#}
+      {#header_open|Targets#}
+      <p>
+      <strong>Target</strong> refers to the computer that will be used to run an executable.
+      It is composed of the CPU architecture, the set of enabled CPU features, operating system,
+      minimum and maximum operating system version, ABI, and ABI version.
+      </p>
+      <p>
+      Zig is a general-purpose programming language which means that it is designed to
+      generate optimal code for a large set of targets. The command <code>zig targets</code>
+      provides information about all of the targets the compiler is aware of.</p>
+      <p>When no target option is provided to the compiler, the default choice
+      is to target the <strong>host computer</strong>, meaning that the
+      resulting executable will be <em>unsuitable for copying to a different
+      computer</em>. In order to copy an executable to another computer, the compiler
+      needs to know about the target requirements via the <code>-target</code> option.
+      </p>
+      <p>
+      The Zig Standard Library ({#syntax#}@import("std"){#endsyntax#}) has
+      cross-platform abstractions, making the same source code viable on many targets.
+      Some code is more portable than other code. In general, Zig code is extremely
+      portable compared to other programming languages.
+      </p>
+      <p>
+      Each platform requires its own implementations to make Zig's
+      cross-platform abstractions work. These implementations are at various
+      degrees of completion. Each tagged release of the compiler comes with
+      release notes that provide the full support table for each target.
+      </p>
+      {#header_close#}
+      {#header_open|Style Guide#}
+      <p>
+These coding conventions are not enforced by the compiler, but they are shipped in
+this documentation along with the compiler in order to provide a point of
+reference, should anyone wish to point to an authority on agreed upon Zig
+coding style.
+      </p>
+      {#header_open|Avoid Redundancy in Names#}
+      <p>Avoid these words in type names:</p>
+      <ul>
+        <li>Value</li>
+        <li>Data</li>
+        <li>Context</li>
+        <li>Manager</li>
+        <li>utils, misc, or somebody's initials</li>
+      </ul>
+      <p>Everything is a value, all types are data, everything is context, all logic manages state.
+      Nothing is communicated by using a word that applies to all types.</p>
+      <p>Temptation to use "utilities", "miscellaneous", or somebody's initials
+      is a failure to categorize, or more commonly, overcategorization. Such
+      declarations can live at the root of a module that needs them with no
+      namespace needed.</p>
+      {#header_close#}
+
+      {#header_open|Avoid Redundant Names in Fully-Qualified Namespaces#}
+      <p>Every declaration is assigned a <strong>fully qualified
+      namespace</strong> by the compiler, creating a tree structure. Choose names based
+      on the fully-qualified namespace, and avoid redundant name segments.</p>
+      {#code|redundant_fqn.zig#}
+
+      <p>In this example, "json" is repeated in the fully-qualified namespace. The solution
+      is to delete <code>Json</code> from <code>JsonValue</code>. In this example we have
+      an empty struct named <code>json</code> but remember that files also act
+      as part of the fully-qualified namespace.</p>
+      <p>This example is an exception to the rule specified in {#link|Avoid Redundancy in Names#}.
+      The meaning of the type has been reduced to its core: it is a json value. The name
+      cannot be any more specific without being incorrect.</p>
+      {#header_close#}
+
+      {#header_open|Whitespace#}
+      <ul>
+        <li>
+          4 space indentation
+        </li>
+        <li>
+          Open braces on same line, unless you need to wrap.
+        </li>
+        <li>If a list of things is longer than 2, put each item on its own line and
+          exercise the ability to put an extra comma at the end.
+        </li>
+        <li>
+          Line length: aim for 100; use common sense.
+        </li>
+      </ul>
+      {#header_close#}
+      {#header_open|Names#}
+      <p>
+      Roughly speaking: {#syntax#}camelCaseFunctionName{#endsyntax#}, {#syntax#}TitleCaseTypeName{#endsyntax#},
+              {#syntax#}snake_case_variable_name{#endsyntax#}. More precisely:
+      </p>
+      <ul>
+        <li>
+            If {#syntax#}x{#endsyntax#} is a {#syntax#}type{#endsyntax#}
+            then {#syntax#}x{#endsyntax#} should be {#syntax#}TitleCase{#endsyntax#}, unless it
+            is a {#syntax#}struct{#endsyntax#} with 0 fields and is never meant to be instantiated,
+            in which case it is considered to be a "namespace" and uses {#syntax#}snake_case{#endsyntax#}.
+        </li>
+        <li>
+            If {#syntax#}x{#endsyntax#} is callable, and {#syntax#}x{#endsyntax#}'s return type is
+            {#syntax#}type{#endsyntax#}, then {#syntax#}x{#endsyntax#} should be {#syntax#}TitleCase{#endsyntax#}.
+        </li>
+        <li>
+            If {#syntax#}x{#endsyntax#} is otherwise callable, then {#syntax#}x{#endsyntax#} should
+            be {#syntax#}camelCase{#endsyntax#}.
+        </li>
+        <li>
+            Otherwise, {#syntax#}x{#endsyntax#} should be {#syntax#}snake_case{#endsyntax#}.
+        </li>
+      </ul>
+      <p>
+      Acronyms, initialisms, proper nouns, or any other word that has capitalization
+      rules in written English are subject to naming conventions just like any other
+      word. Even acronyms that are only 2 letters long are subject to these
+      conventions.
+      </p>
+      <p>
+      File names fall into two categories: types and namespaces. If the file
+      (implicitly a struct) has top level fields, it should be named like any
+      other struct with fields using <code class="file">TitleCase</code>. Otherwise,
+      it should use <code class="file">snake_case</code>. Directory names should be
+      <code class="file">snake_case</code>.
+      </p>
+      <p>
+      These are general rules of thumb; if it makes sense to do something different,
+      do what makes sense. For example, if there is an established convention such as
+      {#syntax#}ENOENT{#endsyntax#}, follow the established convention.
+      </p>
+      {#header_close#}
+      {#header_open|Examples#}
+      {#syntax_block|zig|style_example.zig#}
+const namespace_name = @import("dir_name/file_name.zig");
+const TypeName = @import("dir_name/TypeName.zig");
+var global_var: i32 = undefined;
+const const_name = 42;
+const primitive_type_alias = f32;
+const string_alias = []u8;
+
+const StructName = struct {
+    field: i32,
+};
+const StructAlias = StructName;
+
+fn functionName(param_name: TypeName) void {
+    var functionPointer = functionName;
+    functionPointer();
+    functionPointer = otherFunction;
+    functionPointer();
+}
+const functionAlias = functionName;
+
+fn ListTemplateFunction(comptime ChildType: type, comptime fixed_size: usize) type {
+    return List(ChildType, fixed_size);
+}
+
+fn ShortList(comptime T: type, comptime n: usize) type {
+    return struct {
+        field_name: [n]T,
+        fn methodName() void {}
+    };
+}
+
+// The word XML loses its casing when used in Zig identifiers.
+const xml_document =
+    \\<?xml version="1.0" encoding="UTF-8"?>
+    \\<document>
+    \\</document>
+;
+const XmlParser = struct {
+    field: i32,
+};
+
+// The initials BE (Big Endian) are just another word in Zig identifier names.
+fn readU32Be() u32 {}
+      {#end_syntax_block#}
+      <p>
+      See the {#link|Zig Standard Library#} for more examples.
+      </p>
+      {#header_close#}
+      {#header_open|Doc Comment Guidance#}
+      <ul>
+        <li>Omit any information that is redundant based on the name of the thing being documented.</li>
+        <li>Duplicating information onto multiple similar functions is encouraged because it helps IDEs and other tools provide better help text.</li>
+        <li>Use the word <strong>assume</strong> to indicate invariants that cause <em>unchecked</em> {#link|Illegal Behavior#} when violated.</li>
+        <li>Use the word <strong>assert</strong> to indicate invariants that cause <em>safety-checked</em> {#link|Illegal Behavior#} when violated.</li>
+      </ul>
+      {#header_close#}
+      {#header_close#}
+      {#header_open|Source Encoding#}
+      <p>Zig source code is encoded in UTF-8. An invalid UTF-8 byte sequence results in a compile error.</p>
+      <p>Throughout all zig source code (including in comments), some code points are never allowed:</p>
+      <ul>
+        <li>Ascii control characters, except for U+000a (LF), U+000d (CR), and U+0009 (HT): U+0000 - U+0008, U+000b - U+000c, U+000e - U+0001f, U+007f.</li>
+        <li>Non-Ascii Unicode line endings: U+0085 (NEL), U+2028 (LS), U+2029 (PS).</li>
+      </ul>
+      <p>
+      LF (byte value 0x0a, code point U+000a, {#syntax#}'\n'{#endsyntax#}) is the line terminator in Zig source code.
+      This byte value terminates every line of zig source code except the last line of the file.
+      It is recommended that non-empty source files end with an empty line, which means the last byte would be 0x0a (LF).
+      </p>
+      <p>
+      Each LF may be immediately preceded by a single CR (byte value 0x0d, code point U+000d, {#syntax#}'\r'{#endsyntax#})
+      to form a Windows style line ending, but this is discouraged. Note that in multiline strings, CRLF sequences will
+      be encoded as LF when compiled into a zig program.
+      A CR in any other context is not allowed.
+      </p>
+      <p>
+      HT hard tabs (byte value 0x09, code point U+0009, {#syntax#}'\t'{#endsyntax#}) are interchangeable with
+      SP spaces (byte value 0x20, code point U+0020, {#syntax#}' '{#endsyntax#}) as a token separator,
+      but use of hard tabs is discouraged. See {#link|Grammar#}.
+      </p>
+      <p>
+      For compatibility with other tools, the compiler ignores a UTF-8-encoded byte order mark (U+FEFF)
+      if it is the first Unicode code point in the source text. A byte order mark is not allowed anywhere else in the source.
+      </p>
+      <p>
+      Note that running <kbd>zig fmt</kbd> on a source file will implement all recommendations mentioned here.
+      </p>
+      <p>
+      Note that a tool reading Zig source code can make assumptions if the source code is assumed to be correct Zig code.
+      For example, when identifying the ends of lines, a tool can use a naive search such as <code>/\n/</code>,
+      or an <a href="https://msdn.microsoft.com/en-us/library/dd409797.aspx">advanced</a>
+      search such as <code>/\r\n?|[\n\u0085\u2028\u2029]/</code>, and in either case line endings will be correctly identified.
+      For another example, when identifying the whitespace before the first token on a line,
+      a tool can either use a naive search such as <code>/[ \t]/</code>,
+      or an <a href="https://tc39.es/ecma262/#sec-characterclassescape">advanced</a> search such as <code>/\s/</code>,
+      and in either case whitespace will be correctly identified.
+      </p>
+      {#header_close#}
+
+      {#header_open|Keyword Reference#}
+      <div class="table-wrapper">
+      <table>
+        <thead>
+        <tr>
+          <th scope="col">Keyword</th>
+          <th scope="col">Description</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}addrspace{#endsyntax#}</pre>
+          </th>
+          <td>
+            The {#syntax#}addrspace{#endsyntax#} keyword.
+            <ul>
+              <li>TODO add documentation for addrspace</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}align{#endsyntax#}</pre>
+          </th>
+          <td>
+            {#syntax#}align{#endsyntax#} can be used to specify the alignment of a pointer.
+            It can also be used after a variable or function declaration to specify the alignment of pointers to that variable or function.
+            <ul>
+              <li>See also {#link|Alignment#}</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}allowzero{#endsyntax#}</pre>
+          </th>
+          <td>
+            The pointer attribute {#syntax#}allowzero{#endsyntax#} allows a pointer to have address zero.
+            <ul>
+              <li>See also {#link|allowzero#}</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}and{#endsyntax#}</pre>
+          </th>
+          <td>
+            The boolean operator {#syntax#}and{#endsyntax#}.
+            <ul>
+              <li>See also {#link|Operators#}</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}anyframe{#endsyntax#}</pre>
+          </th>
+          <td>
+            {#syntax#}anyframe{#endsyntax#} can be used as a type for variables which hold pointers to function frames.
+            <ul>
+              <li>See also {#link|Async Functions#}</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}anytype{#endsyntax#}</pre>
+          </th>
+          <td>
+            Function parameters can be declared with {#syntax#}anytype{#endsyntax#} in place of the type.
+            The type will be inferred where the function is called.
+            <ul>
+              <li>See also {#link|Function Parameter Type Inference#}</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}asm{#endsyntax#}</pre>
+          </th>
+          <td>
+            {#syntax#}asm{#endsyntax#} begins an inline assembly expression. This allows for directly controlling the machine code generated on compilation.
+            <ul>
+              <li>See also {#link|Assembly#}</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}async{#endsyntax#}</pre>
+          </th>
+          <td>
+            {#syntax#}async{#endsyntax#} can be used before a function call to get a pointer to the function's frame when it suspends.
+            <ul>
+              <li>See also {#link|Async Functions#}</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}await{#endsyntax#}</pre>
+          </th>
+          <td>
+            {#syntax#}await{#endsyntax#} can be used to suspend the current function until the frame provided after the {#syntax#}await{#endsyntax#} completes.
+            {#syntax#}await{#endsyntax#} copies the value returned from the target function's frame to the caller.
+            <ul>
+              <li>See also {#link|Async Functions#}</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}break{#endsyntax#}</pre>
+          </th>
+          <td>
+            {#syntax#}break{#endsyntax#} can be used with a block label to return a value from the block.
+            It can also be used to exit a loop before iteration completes naturally.
+            <ul>
+              <li>See also {#link|Blocks#}, {#link|while#}, {#link|for#}</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}callconv{#endsyntax#}</pre>
+          </th>
+          <td>
+            {#syntax#}callconv{#endsyntax#} can be used to specify the calling convention in a function type.
+            <ul>
+              <li>See also {#link|Functions#}</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}catch{#endsyntax#}</pre>
+          </th>
+          <td>
+            {#syntax#}catch{#endsyntax#} can be used to evaluate an expression if the expression before it evaluates to an error.
+            The expression after the {#syntax#}catch{#endsyntax#} can optionally capture the error value.
+            <ul>
+              <li>See also {#link|catch#}, {#link|Operators#}</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}comptime{#endsyntax#}</pre>
+          </th>
+          <td>
+            {#syntax#}comptime{#endsyntax#} before a declaration can be used to label variables or function parameters as known at compile time.
+            It can also be used to guarantee an expression is run at compile time.
+            <ul>
+              <li>See also {#link|comptime#}</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}const{#endsyntax#}</pre>
+          </th>
+          <td>
+            {#syntax#}const{#endsyntax#} declares a variable that can not be modified.
+            Used as a pointer attribute, it denotes the value referenced by the pointer cannot be modified.
+            <ul>
+              <li>See also {#link|Variables#}</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}continue{#endsyntax#}</pre>
+          </th>
+          <td>
+            {#syntax#}continue{#endsyntax#} can be used in a loop to jump back to the beginning of the loop.
+            <ul>
+              <li>See also {#link|while#}, {#link|for#}</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}defer{#endsyntax#}</pre>
+          </th>
+          <td>
+            {#syntax#}defer{#endsyntax#} will execute an expression when control flow leaves the current block.
+            <ul>
+              <li>See also {#link|defer#}</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}else{#endsyntax#}</pre>
+          </th>
+          <td>
+            {#syntax#}else{#endsyntax#} can be used to provide an alternate branch for {#syntax#}if{#endsyntax#}, {#syntax#}switch{#endsyntax#},
+            {#syntax#}while{#endsyntax#}, and {#syntax#}for{#endsyntax#} expressions.
+            <ul>
+              <li>If used after an if expression, the else branch will be executed if the test value returns false, null, or an error.</li>
+              <li>If used within a switch expression, the else branch will be executed if the test value matches no other cases.</li>
+              <li>If used after a loop expression, the else branch will be executed if the loop finishes without breaking.</li>
+              <li>See also {#link|if#}, {#link|switch#}, {#link|while#}, {#link|for#}</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}enum{#endsyntax#}</pre>
+          </th>
+          <td>
+            {#syntax#}enum{#endsyntax#} defines an enum type.
+            <ul>
+              <li>See also {#link|enum#}</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}errdefer{#endsyntax#}</pre>
+          </th>
+          <td>
+            {#syntax#}errdefer{#endsyntax#} will execute an expression when control flow leaves the current block if the function returns an error, the errdefer expression can capture the unwrapped value.
+            <ul>
+              <li>See also {#link|errdefer#}</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}error{#endsyntax#}</pre>
+          </th>
+          <td>
+            {#syntax#}error{#endsyntax#} defines an error type.
+            <ul>
+              <li>See also {#link|Errors#}</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}export{#endsyntax#}</pre>
+          </th>
+          <td>
+            {#syntax#}export{#endsyntax#} makes a function or variable externally visible in the generated object file.
+            Exported functions default to the C calling convention.
+            <ul>
+              <li>See also {#link|Functions#}</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}extern{#endsyntax#}</pre>
+          </th>
+          <td>
+            {#syntax#}extern{#endsyntax#} can be used to declare a function or variable that will be resolved at link time, when linking statically
+            or at runtime, when linking dynamically.
+            <ul>
+              <li>See also {#link|Functions#}</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}fn{#endsyntax#}</pre>
+          </th>
+          <td>
+            {#syntax#}fn{#endsyntax#} declares a function.
+            <ul>
+              <li>See also {#link|Functions#}</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}for{#endsyntax#}</pre>
+          </th>
+          <td>
+            A {#syntax#}for{#endsyntax#} expression can be used to iterate over the elements of a slice, array, or tuple.
+            <ul>
+              <li>See also {#link|for#}</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}if{#endsyntax#}</pre>
+          </th>
+          <td>
+            An {#syntax#}if{#endsyntax#} expression can test boolean expressions, optional values, or error unions.
+            For optional values or error unions, the if expression can capture the unwrapped value.
+            <ul>
+              <li>See also {#link|if#}</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}inline{#endsyntax#}</pre>
+          </th>
+          <td>
+            {#syntax#}inline{#endsyntax#} can be used to label a loop expression such that it will be unrolled at compile time.
+            It can also be used to force a function to be inlined at all call sites.
+            <ul>
+              <li>See also {#link|inline while#}, {#link|inline for#}, {#link|Functions#}</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}linksection{#endsyntax#}</pre>
+          </th>
+          <td>
+            The {#syntax#}linksection{#endsyntax#} keyword can be used to specify what section the function or global variable will be put into (e.g. <code>.text</code>).
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}noalias{#endsyntax#}</pre>
+          </th>
+          <td>
+            The {#syntax#}noalias{#endsyntax#} keyword.
+            <ul>
+              <li>TODO add documentation for noalias</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}noinline{#endsyntax#}</pre>
+          </th>
+          <td>
+            {#syntax#}noinline{#endsyntax#} disallows function to be inlined in all call sites.
+            <ul>
+              <li>See also {#link|Functions#}</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}nosuspend{#endsyntax#}</pre>
+          </th>
+          <td>
+            The {#syntax#}nosuspend{#endsyntax#} keyword can be used in front of a block, statement or expression, to mark a scope where no suspension points are reached.
+            In particular, inside a {#syntax#}nosuspend{#endsyntax#} scope:
+            <ul>
+              <li>Using the {#syntax#}suspend{#endsyntax#} keyword results in a compile error.</li>
+              <li>Using {#syntax#}await{#endsyntax#} on a function frame which hasn't completed yet results in safety-checked {#link|Illegal Behavior#}.</li>
+              <li>Calling an async function may result in safety-checked {#link|Illegal Behavior#}, because it's equivalent to <code>await async some_async_fn()</code>, which contains an {#syntax#}await{#endsyntax#}.</li>
+            </ul>
+            Code inside a {#syntax#}nosuspend{#endsyntax#} scope does not cause the enclosing function to become an {#link|async function|Async Functions#}.
+            <ul>
+              <li>See also {#link|Async Functions#}</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}opaque{#endsyntax#}</pre>
+          </th>
+          <td>
+            {#syntax#}opaque{#endsyntax#} defines an opaque type.
+            <ul>
+              <li>See also {#link|opaque#}</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}or{#endsyntax#}</pre>
+          </th>
+          <td>
+            The boolean operator {#syntax#}or{#endsyntax#}.
+            <ul>
+              <li>See also {#link|Operators#}</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}orelse{#endsyntax#}</pre>
+          </th>
+          <td>
+            {#syntax#}orelse{#endsyntax#} can be used to evaluate an expression if the expression before it evaluates to null.
+            <ul>
+              <li>See also {#link|Optionals#}, {#link|Operators#}</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}packed{#endsyntax#}</pre>
+          </th>
+          <td>
+            The {#syntax#}packed{#endsyntax#} keyword before a struct definition changes the struct's in-memory layout
+            to the guaranteed {#syntax#}packed{#endsyntax#} layout.
+            <ul>
+              <li>See also {#link|packed struct#}</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}pub{#endsyntax#}</pre>
+          </th>
+          <td>
+            The {#syntax#}pub{#endsyntax#} in front of a top level declaration makes the declaration available
+            to reference from a different file than the one it is declared in.
+            <ul>
+              <li>See also {#link|import#}</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}resume{#endsyntax#}</pre>
+          </th>
+          <td>
+            {#syntax#}resume{#endsyntax#} will continue execution of a function frame after the point the function was suspended.
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}return{#endsyntax#}</pre>
+          </th>
+          <td>
+            {#syntax#}return{#endsyntax#} exits a function with a value.
+            <ul>
+              <li>See also {#link|Functions#}</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}struct{#endsyntax#}</pre>
+          </th>
+          <td>
+            {#syntax#}struct{#endsyntax#} defines a struct.
+            <ul>
+              <li>See also {#link|struct#}</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}suspend{#endsyntax#}</pre>
+          </th>
+          <td>
+            {#syntax#}suspend{#endsyntax#} will cause control flow to return to the call site or resumer of the function.
+            {#syntax#}suspend{#endsyntax#} can also be used before a block within a function,
+            to allow the function access to its frame before control flow returns to the call site.
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}switch{#endsyntax#}</pre>
+          </th>
+          <td>
+            A {#syntax#}switch{#endsyntax#} expression can be used to test values of a common type.
+            {#syntax#}switch{#endsyntax#} cases can capture field values of a {#link|Tagged union#}.
+            <ul>
+              <li>See also {#link|switch#}</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}test{#endsyntax#}</pre>
+          </th>
+          <td>
+            The {#syntax#}test{#endsyntax#} keyword can be used to denote a top-level block of code
+            used to make sure behavior meets expectations.
+            <ul>
+              <li>See also {#link|Zig Test#}</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}threadlocal{#endsyntax#}</pre>
+          </th>
+          <td>
+            {#syntax#}threadlocal{#endsyntax#} can be used to specify a variable as thread-local.
+            <ul>
+              <li>See also {#link|Thread Local Variables#}</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}try{#endsyntax#}</pre>
+          </th>
+          <td>
+            {#syntax#}try{#endsyntax#} evaluates an error union expression.
+            If it is an error, it returns from the current function with the same error.
+            Otherwise, the expression results in the unwrapped value.
+            <ul>
+              <li>See also {#link|try#}</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}union{#endsyntax#}</pre>
+          </th>
+          <td>
+            {#syntax#}union{#endsyntax#} defines a union.
+            <ul>
+              <li>See also {#link|union#}</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}unreachable{#endsyntax#}</pre>
+          </th>
+          <td>
+            {#syntax#}unreachable{#endsyntax#} can be used to assert that control flow will never happen upon a particular location.
+            Depending on the build mode, {#syntax#}unreachable{#endsyntax#} may emit a panic.
+            <ul>
+              <li>Emits a panic in {#syntax#}Debug{#endsyntax#} and {#syntax#}ReleaseSafe{#endsyntax#} mode, or when using <kbd>zig test</kbd>.</li>
+              <li>Does not emit a panic in {#syntax#}ReleaseFast{#endsyntax#} and {#syntax#}ReleaseSmall{#endsyntax#} mode.</li>
+              <li>See also {#link|unreachable#}</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}usingnamespace{#endsyntax#}</pre>
+          </th>
+          <td>
+            {#syntax#}usingnamespace{#endsyntax#} is a top-level declaration that imports all the public declarations of the operand,
+            which must be a struct, union, or enum, into the current scope.
+            <ul>
+              <li>See also {#link|usingnamespace#}</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}var{#endsyntax#}</pre>
+          </th>
+          <td>
+            {#syntax#}var{#endsyntax#} declares a variable that may be modified.
+            <ul>
+              <li>See also {#link|Variables#}</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}volatile{#endsyntax#}</pre>
+          </th>
+          <td>
+            {#syntax#}volatile{#endsyntax#} can be used to denote loads or stores of a pointer have side effects.
+            It can also modify an inline assembly expression to denote it has side effects.
+            <ul>
+              <li>See also {#link|volatile#}, {#link|Assembly#}</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <pre>{#syntax#}while{#endsyntax#}</pre>
+          </th>
+          <td>
+            A {#syntax#}while{#endsyntax#} expression can be used to repeatedly test a boolean, optional, or error union expression,
+            and cease looping when that expression evaluates to false, null, or an error, respectively.
+            <ul>
+              <li>See also {#link|while#}</li>
+            </ul>
+          </td>
+        </tr>
+        </tbody>
+      </table>
+      </div>
+      {#header_close#}
+
+      {#header_open|Appendix#}
+      {#header_open|Containers#}
+      <p>
+      A <em>container</em> in Zig is any syntactical construct that acts as a namespace to hold {#link|variable|Container Level Variables#} and {#link|function|Functions#} declarations.
+      Containers are also type definitions which can be instantiated.
+      {#link|Structs|struct#}, {#link|enums|enum#}, {#link|unions|union#}, {#link|opaques|opaque#}, and even Zig source files themselves are containers.
+      </p>
+      <p>
+      Although containers (except Zig source files) use curly braces to surround their definition, they should not be confused with {#link|blocks|Blocks#} or functions.
+      Containers do not contain statements.
+      </p>
+      {#header_close#}
+
+      {#header_open|Grammar#}
+      {#syntax_block|peg|grammar.y#}
+Root <- skip container_doc_comment? ContainerMembers eof
+
+# *** Top level ***
+ContainerMembers <- ContainerDeclaration* (ContainerField COMMA)* (ContainerField / ContainerDeclaration*)
+
+ContainerDeclaration <- TestDecl / ComptimeDecl / doc_comment? KEYWORD_pub? Decl
+
+TestDecl <- KEYWORD_test (STRINGLITERALSINGLE / IDENTIFIER)? Block
+
+ComptimeDecl <- KEYWORD_comptime Block
+
+Decl
+    <- (KEYWORD_export / KEYWORD_extern STRINGLITERALSINGLE? / KEYWORD_inline / KEYWORD_noinline)? FnProto (SEMICOLON / Block)
+     / (KEYWORD_export / KEYWORD_extern STRINGLITERALSINGLE?)? KEYWORD_threadlocal? GlobalVarDecl
+     / KEYWORD_usingnamespace Expr SEMICOLON
+
+FnProto <- KEYWORD_fn IDENTIFIER? LPAREN ParamDeclList RPAREN ByteAlign? AddrSpace? LinkSection? CallConv? EXCLAMATIONMARK? TypeExpr
+
+VarDeclProto <- (KEYWORD_const / KEYWORD_var) IDENTIFIER (COLON TypeExpr)? ByteAlign? AddrSpace? LinkSection?
+
+GlobalVarDecl <- VarDeclProto (EQUAL Expr)? SEMICOLON
+
+ContainerField <- doc_comment? KEYWORD_comptime? !KEYWORD_fn (IDENTIFIER COLON)? TypeExpr ByteAlign? (EQUAL Expr)?
+
+# *** Block Level ***
+Statement
+    <- KEYWORD_comptime ComptimeStatement
+     / KEYWORD_nosuspend BlockExprStatement
+     / KEYWORD_suspend BlockExprStatement
+     / KEYWORD_defer BlockExprStatement
+     / KEYWORD_errdefer Payload? BlockExprStatement
+     / IfStatement
+     / LabeledStatement
+     / SwitchExpr
+     / VarDeclExprStatement
+
+ComptimeStatement
+    <- BlockExpr
+     / VarDeclExprStatement
+
+IfStatement
+    <- IfPrefix BlockExpr ( KEYWORD_else Payload? Statement )?
+     / IfPrefix AssignExpr ( SEMICOLON / KEYWORD_else Payload? Statement )
+
+LabeledStatement <- BlockLabel? (Block / LoopStatement)
+
+LoopStatement <- KEYWORD_inline? (ForStatement / WhileStatement)
+
+ForStatement
+    <- ForPrefix BlockExpr ( KEYWORD_else Statement )?
+     / ForPrefix AssignExpr ( SEMICOLON / KEYWORD_else Statement )
+
+WhileStatement
+    <- WhilePrefix BlockExpr ( KEYWORD_else Payload? Statement )?
+     / WhilePrefix AssignExpr ( SEMICOLON / KEYWORD_else Payload? Statement )
+
+BlockExprStatement
+    <- BlockExpr
+     / AssignExpr SEMICOLON
+
+BlockExpr <- BlockLabel? Block
+
+# An expression, assignment, or any destructure, as a statement.
+VarDeclExprStatement
+    <- VarDeclProto (COMMA (VarDeclProto / Expr))* EQUAL Expr SEMICOLON
+     / Expr (AssignOp Expr / (COMMA (VarDeclProto / Expr))+ EQUAL Expr)? SEMICOLON
+
+# *** Expression Level ***
+
+# An assignment or a destructure whose LHS are all lvalue expressions.
+AssignExpr <- Expr (AssignOp Expr / (COMMA Expr)+ EQUAL Expr)?
+
+SingleAssignExpr <- Expr (AssignOp Expr)?
+
+Expr <- BoolOrExpr
+
+BoolOrExpr <- BoolAndExpr (KEYWORD_or BoolAndExpr)*
+
+BoolAndExpr <- CompareExpr (KEYWORD_and CompareExpr)*
+
+CompareExpr <- BitwiseExpr (CompareOp BitwiseExpr)?
+
+BitwiseExpr <- BitShiftExpr (BitwiseOp BitShiftExpr)*
+
+BitShiftExpr <- AdditionExpr (BitShiftOp AdditionExpr)*
+
+AdditionExpr <- MultiplyExpr (AdditionOp MultiplyExpr)*
+
+MultiplyExpr <- PrefixExpr (MultiplyOp PrefixExpr)*
+
+PrefixExpr <- PrefixOp* PrimaryExpr
+
+PrimaryExpr
+    <- AsmExpr
+     / IfExpr
+     / KEYWORD_break BreakLabel? Expr?
+     / KEYWORD_comptime Expr
+     / KEYWORD_nosuspend Expr
+     / KEYWORD_continue BreakLabel?
+     / KEYWORD_resume Expr
+     / KEYWORD_return Expr?
+     / BlockLabel? LoopExpr
+     / Block
+     / CurlySuffixExpr
+
+IfExpr <- IfPrefix Expr (KEYWORD_else Payload? Expr)?
+
+Block <- LBRACE Statement* RBRACE
+
+LoopExpr <- KEYWORD_inline? (ForExpr / WhileExpr)
+
+ForExpr <- ForPrefix Expr (KEYWORD_else Expr)?
+
+WhileExpr <- WhilePrefix Expr (KEYWORD_else Payload? Expr)?
+
+CurlySuffixExpr <- TypeExpr InitList?
+
+InitList
+    <- LBRACE FieldInit (COMMA FieldInit)* COMMA? RBRACE
+     / LBRACE Expr (COMMA Expr)* COMMA? RBRACE
+     / LBRACE RBRACE
+
+TypeExpr <- PrefixTypeOp* ErrorUnionExpr
+
+ErrorUnionExpr <- SuffixExpr (EXCLAMATIONMARK TypeExpr)?
+
+SuffixExpr
+    <- KEYWORD_async PrimaryTypeExpr SuffixOp* FnCallArguments
+     / PrimaryTypeExpr (SuffixOp / FnCallArguments)*
+
+PrimaryTypeExpr
+    <- BUILTINIDENTIFIER FnCallArguments
+     / CHAR_LITERAL
+     / ContainerDecl
+     / DOT IDENTIFIER
+     / DOT InitList
+     / ErrorSetDecl
+     / FLOAT
+     / FnProto
+     / GroupedExpr
+     / LabeledTypeExpr
+     / IDENTIFIER
+     / IfTypeExpr
+     / INTEGER
+     / KEYWORD_comptime TypeExpr
+     / KEYWORD_error DOT IDENTIFIER
+     / KEYWORD_anyframe
+     / KEYWORD_unreachable
+     / STRINGLITERAL
+     / SwitchExpr
+
+ContainerDecl <- (KEYWORD_extern / KEYWORD_packed)? ContainerDeclAuto
+
+ErrorSetDecl <- KEYWORD_error LBRACE IdentifierList RBRACE
+
+GroupedExpr <- LPAREN Expr RPAREN
+
+IfTypeExpr <- IfPrefix TypeExpr (KEYWORD_else Payload? TypeExpr)?
+
+LabeledTypeExpr
+    <- BlockLabel Block
+     / BlockLabel? LoopTypeExpr
+
+LoopTypeExpr <- KEYWORD_inline? (ForTypeExpr / WhileTypeExpr)
+
+ForTypeExpr <- ForPrefix TypeExpr (KEYWORD_else TypeExpr)?
+
+WhileTypeExpr <- WhilePrefix TypeExpr (KEYWORD_else Payload? TypeExpr)?
+
+SwitchExpr <- KEYWORD_switch LPAREN Expr RPAREN LBRACE SwitchProngList RBRACE
+
+# *** Assembly ***
+AsmExpr <- KEYWORD_asm KEYWORD_volatile? LPAREN Expr AsmOutput? RPAREN
+
+AsmOutput <- COLON AsmOutputList AsmInput?
+
+AsmOutputItem <- LBRACKET IDENTIFIER RBRACKET STRINGLITERAL LPAREN (MINUSRARROW TypeExpr / IDENTIFIER) RPAREN
+
+AsmInput <- COLON AsmInputList AsmClobbers?
+
+AsmInputItem <- LBRACKET IDENTIFIER RBRACKET STRINGLITERAL LPAREN Expr RPAREN
+
+AsmClobbers <- COLON StringList
+
+# *** Helper grammar ***
+BreakLabel <- COLON IDENTIFIER
+
+BlockLabel <- IDENTIFIER COLON
+
+FieldInit <- DOT IDENTIFIER EQUAL Expr
+
+WhileContinueExpr <- COLON LPAREN AssignExpr RPAREN
+
+LinkSection <- KEYWORD_linksection LPAREN Expr RPAREN
+
+AddrSpace <- KEYWORD_addrspace LPAREN Expr RPAREN
+
+# Fn specific
+CallConv <- KEYWORD_callconv LPAREN Expr RPAREN
+
+ParamDecl
+    <- doc_comment? (KEYWORD_noalias / KEYWORD_comptime)? (IDENTIFIER COLON)? ParamType
+     / DOT3
+
+ParamType
+    <- KEYWORD_anytype
+     / TypeExpr
+
+# Control flow prefixes
+IfPrefix <- KEYWORD_if LPAREN Expr RPAREN PtrPayload?
+
+WhilePrefix <- KEYWORD_while LPAREN Expr RPAREN PtrPayload? WhileContinueExpr?
+
+ForPrefix <- KEYWORD_for LPAREN ForArgumentsList RPAREN PtrListPayload
+
+# Payloads
+Payload <- PIPE IDENTIFIER PIPE
+
+PtrPayload <- PIPE ASTERISK? IDENTIFIER PIPE
+
+PtrIndexPayload <- PIPE ASTERISK? IDENTIFIER (COMMA IDENTIFIER)? PIPE
+
+PtrListPayload <- PIPE ASTERISK? IDENTIFIER (COMMA ASTERISK? IDENTIFIER)* COMMA? PIPE
+
+# Switch specific
+SwitchProng <- KEYWORD_inline? SwitchCase EQUALRARROW PtrIndexPayload? SingleAssignExpr
+
+SwitchCase
+    <- SwitchItem (COMMA SwitchItem)* COMMA?
+     / KEYWORD_else
+
+SwitchItem <- Expr (DOT3 Expr)?
+
+# For specific
+ForArgumentsList <- ForItem (COMMA ForItem)* COMMA?
+
+ForItem <- Expr (DOT2 Expr?)?
+
+# Operators
+AssignOp
+    <- ASTERISKEQUAL
+     / ASTERISKPIPEEQUAL
+     / SLASHEQUAL
+     / PERCENTEQUAL
+     / PLUSEQUAL
+     / PLUSPIPEEQUAL
+     / MINUSEQUAL
+     / MINUSPIPEEQUAL
+     / LARROW2EQUAL
+     / LARROW2PIPEEQUAL
+     / RARROW2EQUAL
+     / AMPERSANDEQUAL
+     / CARETEQUAL
+     / PIPEEQUAL
+     / ASTERISKPERCENTEQUAL
+     / PLUSPERCENTEQUAL
+     / MINUSPERCENTEQUAL
+     / EQUAL
+
+CompareOp
+    <- EQUALEQUAL
+     / EXCLAMATIONMARKEQUAL
+     / LARROW
+     / RARROW
+     / LARROWEQUAL
+     / RARROWEQUAL
+
+BitwiseOp
+    <- AMPERSAND
+     / CARET
+     / PIPE
+     / KEYWORD_orelse
+     / KEYWORD_catch Payload?
+
+BitShiftOp
+    <- LARROW2
+     / RARROW2
+     / LARROW2PIPE
+
+AdditionOp
+    <- PLUS
+     / MINUS
+     / PLUS2
+     / PLUSPERCENT
+     / MINUSPERCENT
+     / PLUSPIPE
+     / MINUSPIPE
+
+MultiplyOp
+    <- PIPE2
+     / ASTERISK
+     / SLASH
+     / PERCENT
+     / ASTERISK2
+     / ASTERISKPERCENT
+     / ASTERISKPIPE
+
+PrefixOp
+    <- EXCLAMATIONMARK
+     / MINUS
+     / TILDE
+     / MINUSPERCENT
+     / AMPERSAND
+     / KEYWORD_try
+     / KEYWORD_await
+
+PrefixTypeOp
+    <- QUESTIONMARK
+     / KEYWORD_anyframe MINUSRARROW
+     / SliceTypeStart (ByteAlign / AddrSpace / KEYWORD_const / KEYWORD_volatile / KEYWORD_allowzero)*
+     / PtrTypeStart (AddrSpace / KEYWORD_align LPAREN Expr (COLON Expr COLON Expr)? RPAREN / KEYWORD_const / KEYWORD_volatile / KEYWORD_allowzero)*
+     / ArrayTypeStart
+
+SuffixOp
+    <- LBRACKET Expr (DOT2 (Expr? (COLON Expr)?)?)? RBRACKET
+     / DOT IDENTIFIER
+     / DOTASTERISK
+     / DOTQUESTIONMARK
+
+FnCallArguments <- LPAREN ExprList RPAREN
+
+# Ptr specific
+SliceTypeStart <- LBRACKET (COLON Expr)? RBRACKET
+
+PtrTypeStart
+    <- ASTERISK
+     / ASTERISK2
+     / LBRACKET ASTERISK (LETTERC / COLON Expr)? RBRACKET
+
+ArrayTypeStart <- LBRACKET Expr (COLON Expr)? RBRACKET
+
+# ContainerDecl specific
+ContainerDeclAuto <- ContainerDeclType LBRACE container_doc_comment? ContainerMembers RBRACE
+
+ContainerDeclType
+    <- KEYWORD_struct (LPAREN Expr RPAREN)?
+     / KEYWORD_opaque
+     / KEYWORD_enum (LPAREN Expr RPAREN)?
+     / KEYWORD_union (LPAREN (KEYWORD_enum (LPAREN Expr RPAREN)? / Expr) RPAREN)?
+
+# Alignment
+ByteAlign <- KEYWORD_align LPAREN Expr RPAREN
+
+# Lists
+IdentifierList <- (doc_comment? IDENTIFIER COMMA)* (doc_comment? IDENTIFIER)?
+
+SwitchProngList <- (SwitchProng COMMA)* SwitchProng?
+
+AsmOutputList <- (AsmOutputItem COMMA)* AsmOutputItem?
+
+AsmInputList <- (AsmInputItem COMMA)* AsmInputItem?
+
+StringList <- (STRINGLITERAL COMMA)* STRINGLITERAL?
+
+ParamDeclList <- (ParamDecl COMMA)* ParamDecl?
+
+ExprList <- (Expr COMMA)* Expr?
+
+# *** Tokens ***
+eof <- !.
+bin <- [01]
+bin_ <- '_'? bin
+oct <- [0-7]
+oct_ <- '_'? oct
+hex <- [0-9a-fA-F]
+hex_ <- '_'? hex
+dec <- [0-9]
+dec_ <- '_'? dec
+
+bin_int <- bin bin_*
+oct_int <- oct oct_*
+dec_int <- dec dec_*
+hex_int <- hex hex_*
+
+ox80_oxBF <- [\200-\277]
+oxF4 <- '\364'
+ox80_ox8F <- [\200-\217]
+oxF1_oxF3 <- [\361-\363]
+oxF0 <- '\360'
+ox90_0xBF <- [\220-\277]
+oxEE_oxEF <- [\356-\357]
+oxED <- '\355'
+ox80_ox9F <- [\200-\237]
+oxE1_oxEC <- [\341-\354]
+oxE0 <- '\340'
+oxA0_oxBF <- [\240-\277]
+oxC2_oxDF <- [\302-\337]
+
+# From https://lemire.me/blog/2018/05/09/how-quickly-can-you-check-that-a-string-is-valid-unicode-utf-8/
+# First Byte      Second Byte     Third Byte      Fourth Byte
+# [0x00,0x7F]
+# [0xC2,0xDF]     [0x80,0xBF]
+#    0xE0         [0xA0,0xBF]     [0x80,0xBF]
+# [0xE1,0xEC]     [0x80,0xBF]     [0x80,0xBF]
+#    0xED         [0x80,0x9F]     [0x80,0xBF]
+# [0xEE,0xEF]     [0x80,0xBF]     [0x80,0xBF]
+#    0xF0         [0x90,0xBF]     [0x80,0xBF]     [0x80,0xBF]
+# [0xF1,0xF3]     [0x80,0xBF]     [0x80,0xBF]     [0x80,0xBF]
+#    0xF4         [0x80,0x8F]     [0x80,0xBF]     [0x80,0xBF]
+
+mb_utf8_literal <-
+       oxF4      ox80_ox8F ox80_oxBF ox80_oxBF
+     / oxF1_oxF3 ox80_oxBF ox80_oxBF ox80_oxBF
+     / oxF0      ox90_0xBF ox80_oxBF ox80_oxBF
+     / oxEE_oxEF ox80_oxBF ox80_oxBF
+     / oxED      ox80_ox9F ox80_oxBF
+     / oxE1_oxEC ox80_oxBF ox80_oxBF
+     / oxE0      oxA0_oxBF ox80_oxBF
+     / oxC2_oxDF ox80_oxBF
+
+ascii_char_not_nl_slash_squote <- [\000-\011\013-\046\050-\133\135-\177]
+
+char_escape
+    <- "\\x" hex hex
+     / "\\u{" hex+ "}"
+     / "\\" [nr\\t'"]
+char_char
+    <- mb_utf8_literal
+     / char_escape
+     / ascii_char_not_nl_slash_squote
+
+string_char
+    <- char_escape
+     / [^\\"\n]
+
+container_doc_comment <- ('//!' [^\n]* [ \n]* skip)+
+doc_comment <- ('///' [^\n]* [ \n]* skip)+
+line_comment <- '//' ![!/][^\n]* / '////' [^\n]*
+line_string <- ("\\\\" [^\n]* [ \n]*)+
+skip <- ([ \n] / line_comment)*
+
+CHAR_LITERAL <- "'" char_char "'" skip
+FLOAT
+    <- "0x" hex_int "." hex_int ([pP] [-+]? dec_int)? skip
+     /      dec_int "." dec_int ([eE] [-+]? dec_int)? skip
+     / "0x" hex_int [pP] [-+]? dec_int skip
+     /      dec_int [eE] [-+]? dec_int skip
+INTEGER
+    <- "0b" bin_int skip
+     / "0o" oct_int skip
+     / "0x" hex_int skip
+     /      dec_int   skip
+STRINGLITERALSINGLE <- "\"" string_char* "\"" skip
+STRINGLITERAL
+    <- STRINGLITERALSINGLE
+     / (line_string                 skip)+
+IDENTIFIER
+    <- !keyword [A-Za-z_] [A-Za-z0-9_]* skip
+     / "@" STRINGLITERALSINGLE
+BUILTINIDENTIFIER <- "@"[A-Za-z_][A-Za-z0-9_]* skip
+
+
+AMPERSAND            <- '&'      ![=]      skip
+AMPERSANDEQUAL       <- '&='               skip
+ASTERISK             <- '*'      ![*%=|]   skip
+ASTERISK2            <- '**'               skip
+ASTERISKEQUAL        <- '*='               skip
+ASTERISKPERCENT      <- '*%'     ![=]      skip
+ASTERISKPERCENTEQUAL <- '*%='              skip
+ASTERISKPIPE         <- '*|'     ![=]      skip
+ASTERISKPIPEEQUAL    <- '*|='              skip
+CARET                <- '^'      ![=]      skip
+CARETEQUAL           <- '^='               skip
+COLON                <- ':'                skip
+COMMA                <- ','                skip
+DOT                  <- '.'      ![*.?]    skip
+DOT2                 <- '..'     ![.]      skip
+DOT3                 <- '...'              skip
+DOTASTERISK          <- '.*'               skip
+DOTQUESTIONMARK      <- '.?'               skip
+EQUAL                <- '='      ![>=]     skip
+EQUALEQUAL           <- '=='               skip
+EQUALRARROW          <- '=>'               skip
+EXCLAMATIONMARK      <- '!'      ![=]      skip
+EXCLAMATIONMARKEQUAL <- '!='               skip
+LARROW               <- '<'      ![<=]     skip
+LARROW2              <- '<<'     ![=|]     skip
+LARROW2EQUAL         <- '<<='              skip
+LARROW2PIPE          <- '<<|'    ![=]      skip
+LARROW2PIPEEQUAL     <- '<<|='             skip
+LARROWEQUAL          <- '<='               skip
+LBRACE               <- '{'                skip
+LBRACKET             <- '['                skip
+LPAREN               <- '('                skip
+MINUS                <- '-'      ![%=>|]   skip
+MINUSEQUAL           <- '-='               skip
+MINUSPERCENT         <- '-%'     ![=]      skip
+MINUSPERCENTEQUAL    <- '-%='              skip
+MINUSPIPE            <- '-|'     ![=]      skip
+MINUSPIPEEQUAL       <- '-|='              skip
+MINUSRARROW          <- '->'               skip
+PERCENT              <- '%'      ![=]      skip
+PERCENTEQUAL         <- '%='               skip
+PIPE                 <- '|'      ![|=]     skip
+PIPE2                <- '||'               skip
+PIPEEQUAL            <- '|='               skip
+PLUS                 <- '+'      ![%+=|]   skip
+PLUS2                <- '++'               skip
+PLUSEQUAL            <- '+='               skip
+PLUSPERCENT          <- '+%'     ![=]      skip
+PLUSPERCENTEQUAL     <- '+%='              skip
+PLUSPIPE             <- '+|'     ![=]      skip
+PLUSPIPEEQUAL        <- '+|='              skip
+LETTERC              <- 'c'                skip
+QUESTIONMARK         <- '?'                skip
+RARROW               <- '>'      ![>=]     skip
+RARROW2              <- '>>'     ![=]      skip
+RARROW2EQUAL         <- '>>='              skip
+RARROWEQUAL          <- '>='               skip
+RBRACE               <- '}'                skip
+RBRACKET             <- ']'                skip
+RPAREN               <- ')'                skip
+SEMICOLON            <- ';'                skip
+SLASH                <- '/'      ![=]      skip
+SLASHEQUAL           <- '/='               skip
+TILDE                <- '~'                skip
+
+end_of_word <- ![a-zA-Z0-9_] skip
+KEYWORD_addrspace   <- 'addrspace'   end_of_word
+KEYWORD_align       <- 'align'       end_of_word
+KEYWORD_allowzero   <- 'allowzero'   end_of_word
+KEYWORD_and         <- 'and'         end_of_word
+KEYWORD_anyframe    <- 'anyframe'    end_of_word
+KEYWORD_anytype     <- 'anytype'     end_of_word
+KEYWORD_asm         <- 'asm'         end_of_word
+KEYWORD_async       <- 'async'       end_of_word
+KEYWORD_await       <- 'await'       end_of_word
+KEYWORD_break       <- 'break'       end_of_word
+KEYWORD_callconv    <- 'callconv'    end_of_word
+KEYWORD_catch       <- 'catch'       end_of_word
+KEYWORD_comptime    <- 'comptime'    end_of_word
+KEYWORD_const       <- 'const'       end_of_word
+KEYWORD_continue    <- 'continue'    end_of_word
+KEYWORD_defer       <- 'defer'       end_of_word
+KEYWORD_else        <- 'else'        end_of_word
+KEYWORD_enum        <- 'enum'        end_of_word
+KEYWORD_errdefer    <- 'errdefer'    end_of_word
+KEYWORD_error       <- 'error'       end_of_word
+KEYWORD_export      <- 'export'      end_of_word
+KEYWORD_extern      <- 'extern'      end_of_word
+KEYWORD_fn          <- 'fn'          end_of_word
+KEYWORD_for         <- 'for'         end_of_word
+KEYWORD_if          <- 'if'          end_of_word
+KEYWORD_inline      <- 'inline'      end_of_word
+KEYWORD_noalias     <- 'noalias'     end_of_word
+KEYWORD_nosuspend   <- 'nosuspend'   end_of_word
+KEYWORD_noinline    <- 'noinline'    end_of_word
+KEYWORD_opaque      <- 'opaque'      end_of_word
+KEYWORD_or          <- 'or'          end_of_word
+KEYWORD_orelse      <- 'orelse'      end_of_word
+KEYWORD_packed      <- 'packed'      end_of_word
+KEYWORD_pub         <- 'pub'         end_of_word
+KEYWORD_resume      <- 'resume'      end_of_word
+KEYWORD_return      <- 'return'      end_of_word
+KEYWORD_linksection <- 'linksection' end_of_word
+KEYWORD_struct      <- 'struct'      end_of_word
+KEYWORD_suspend     <- 'suspend'     end_of_word
+KEYWORD_switch      <- 'switch'      end_of_word
+KEYWORD_test        <- 'test'        end_of_word
+KEYWORD_threadlocal <- 'threadlocal' end_of_word
+KEYWORD_try         <- 'try'         end_of_word
+KEYWORD_union       <- 'union'       end_of_word
+KEYWORD_unreachable <- 'unreachable' end_of_word
+KEYWORD_usingnamespace <- 'usingnamespace' end_of_word
+KEYWORD_var         <- 'var'         end_of_word
+KEYWORD_volatile    <- 'volatile'    end_of_word
+KEYWORD_while       <- 'while'       end_of_word
+
+keyword <- KEYWORD_addrspace / KEYWORD_align / KEYWORD_allowzero / KEYWORD_and
+         / KEYWORD_anyframe / KEYWORD_anytype / KEYWORD_asm / KEYWORD_async
+         / KEYWORD_await / KEYWORD_break / KEYWORD_callconv / KEYWORD_catch
+         / KEYWORD_comptime / KEYWORD_const / KEYWORD_continue / KEYWORD_defer
+         / KEYWORD_else / KEYWORD_enum / KEYWORD_errdefer / KEYWORD_error / KEYWORD_export
+         / KEYWORD_extern / KEYWORD_fn / KEYWORD_for / KEYWORD_if
+         / KEYWORD_inline / KEYWORD_noalias / KEYWORD_nosuspend / KEYWORD_noinline
+         / KEYWORD_opaque / KEYWORD_or / KEYWORD_orelse / KEYWORD_packed
+         / KEYWORD_pub / KEYWORD_resume / KEYWORD_return / KEYWORD_linksection
+         / KEYWORD_struct / KEYWORD_suspend / KEYWORD_switch / KEYWORD_test
+         / KEYWORD_threadlocal / KEYWORD_try / KEYWORD_union / KEYWORD_unreachable
+         / KEYWORD_usingnamespace / KEYWORD_var / KEYWORD_volatile / KEYWORD_while
+      {#end_syntax_block#}
+      {#header_close#}
+      {#header_open|Zen#}
+      <ul>
+        <li>Communicate intent precisely.</li>
+        <li>Edge cases matter.</li>
+        <li>Favor reading code over writing code.</li>
+        <li>Only one obvious way to do things.</li>
+        <li>Runtime crashes are better than bugs.</li>
+        <li>Compile errors are better than runtime crashes.</li>
+        <li>Incremental improvements.</li>
+        <li>Avoid local maximums.</li>
+        <li>Reduce the amount one must remember.</li>
+        <li>Focus on code rather than style.</li>
+        <li>Resource allocation may fail; resource deallocation must succeed.</li>
+        <li>Memory is a resource.</li>
+        <li>Together we serve the users.</li>
+      </ul>
+      {#header_close#}
+      {#header_close#}
+      </main></div>
+    </div>
+  </body>
+</html>

--- a/src/tools/langref_master.html.in
+++ b/src/tools/langref_master.html.in
@@ -316,6 +316,7 @@
           <a href="https://ziglang.org/documentation/0.11.0/">0.11.0</a> |
           <a href="https://ziglang.org/documentation/0.12.0/">0.12.0</a> |
           <a href="https://ziglang.org/documentation/0.13.0/">0.13.0</a> |
+          <a href="https://ziglang.org/documentation/0.14.0/">0.14.0</a> |
           master
         </nav>
         <nav aria-labelledby="table-of-contents">
@@ -360,6 +361,10 @@
         You will see many examples of Zig's Standard Library used in this documentation. To learn more about the Zig Standard Library,
         visit the link above.
       </p>
+      <p>
+        Alternatively, the Zig Standard Library documentation is provided with each Zig distribution. It can be rendered via a local webserver with:
+      </p>
+      {#shell_samp#}zig std{#end_shell_samp#}
       {#header_close#}
 
       {#header_open|Hello World#}
@@ -375,9 +380,9 @@
 
       <p>
       In this case, the {#syntax#}!{#endsyntax#} may be omitted from the return
-      type because no errors are returned from the function.
+      type of <code>main</code> because no errors are returned from the function.
       </p>
-      {#see_also|Values|@import|Errors|Root Source File|Source Encoding#}
+      {#see_also|Values|Tuples|@import|Errors|Entry Point|Source Encoding|try#}
       {#header_close#}
       {#header_open|Comments#}
       <p>
@@ -777,6 +782,30 @@
       implementation feature, not a language semantic, so it is not guaranteed to be observable to code.
       </p>
       {#header_close#}
+
+      {#header_open|Destructuring#}
+      <p>
+        A destructuring assignment can separate elements of indexable aggregate types
+        ({#link|Tuples#}, {#link|Arrays#}, {#link|Vectors#}):
+      </p>
+      {#code|destructuring_to_existing.zig#}
+
+      <p>
+        A destructuring expression may only appear within a block (i.e. not at container scope).
+        The left hand side of the assignment must consist of a comma separated list,
+        each element of which may be either an lvalue (for instance, an existing `var`) or a variable declaration:
+      </p>
+      {#code|destructuring_mixed.zig#}
+
+      <p>
+        A destructure may be prefixed with the {#syntax#}comptime{#endsyntax#} keyword, in which case the entire
+        destructure expression is evaluated at {#link|comptime#}. All {#syntax#}var{#endsyntax#}s declared would
+        be {#syntax#}comptime var{#endsyntax#}s and all expressions (both result locations and the assignee
+        expression) are evaluated at {#link|comptime#}.
+      </p>
+
+      {#see_also|Destructuring Tuples|Destructuring Arrays|Destructuring Vectors#}
+      {#header_close#}
       {#header_close#}
       {#header_close#}
       {#header_open|Zig Test#}
@@ -795,7 +824,7 @@
         <kbd>zig test</kbd> is a tool that creates and runs a test build. By default, it builds and runs an
         executable program using the <em>default test runner</em> provided by the {#link|Zig Standard Library#}
         as its main entry point. During the build, {#syntax#}test{#endsyntax#} declarations found while
-        {#link|resolving|Root Source File#} the given Zig source file are included for the default test runner
+        {#link|resolving|File and Declaration Discovery#} the given Zig source file are included for the default test runner
         to run and report on.
       </p>
       <aside>
@@ -1021,12 +1050,12 @@
       {#header_close#}
       {#header_open|Runtime Integer Values#}
       <p>
-      Integer literals have no size limitation, and if any undefined behavior occurs,
+      Integer literals have no size limitation, and if any Illegal Behavior occurs,
       the compiler catches it.
       </p>
       <p>
       However, once an integer value is no longer known at compile-time, it must have a
-      known size, and is vulnerable to undefined behavior.
+      known size, and is vulnerable to safety-checked {#link|Illegal Behavior#}.
       </p>
       {#code|runtime_vs_comptime.zig#}
 
@@ -1036,7 +1065,7 @@
       {#link|Division by Zero#}.
       </p>
       <p>
-      Operators such as {#syntax#}+{#endsyntax#} and {#syntax#}-{#endsyntax#} cause undefined behavior on
+      Operators such as {#syntax#}+{#endsyntax#} and {#syntax#}-{#endsyntax#} cause {#link|Illegal Behavior#} on
       integer overflow. Alternative operators are provided for wrapping and saturating arithmetic on all targets.
       {#syntax#}+%{#endsyntax#} and {#syntax#}-%{#endsyntax#} perform wrapping arithmetic
       while {#syntax#}+|{#endsyntax#} and {#syntax#}-|{#endsyntax#} perform saturating arithmetic.
@@ -1878,6 +1907,15 @@ or
 
       {#see_also|Sentinel-Terminated Pointers|Sentinel-Terminated Slices#}
       {#header_close#}
+
+      {#header_open|Destructuring Arrays#}
+      <p>
+        Arrays can be destructured:
+      </p>
+      {#code|destructuring_arrays.zig#}
+
+      {#see_also|Destructuring|Destructuring Tuples|Destructuring Vectors#}
+      {#header_close#}
       {#header_close#}
 
       {#header_open|Vectors#}
@@ -1924,6 +1962,14 @@ or
       TODO consider suggesting std.MultiArrayList
       </p>
       {#see_also|@splat|@shuffle|@select|@reduce#}
+
+      {#header_open|Destructuring Vectors#}
+      <p>
+        Vectors can be destructured:
+      </p>
+      {#code|destructuring_vectors.zig#}
+      {#see_also|Destructuring|Destructuring Tuples|Destructuring Arrays#}
+      {#header_close#}
 
       {#header_close#}
 
@@ -1984,7 +2030,7 @@ or
       </p>
       <p>
         Slices have bounds checking and are therefore protected
-        against this kind of undefined behavior. This is one reason
+        against this kind of Illegal Behavior. This is one reason
         we prefer slices to pointers.
       </p>
       {#code|test_slice_bounds.zig#}
@@ -2003,7 +2049,7 @@ or
 
       <p>
       {#link|@ptrCast#} converts a pointer's element type to another. This
-      creates a new pointer that can cause undetectable illegal behavior
+      creates a new pointer that can cause undetectable Illegal Behavior
       depending on the loads and stores that pass through it. Generally, other
       kinds of type conversions are preferable to
       {#syntax#}@ptrCast{#endsyntax#} if possible.
@@ -2119,7 +2165,7 @@ or
 
       <p>
       Sentinel-terminated slicing asserts that the element in the sentinel position of the backing data is
-      actually the sentinel value. If this is not the case, safety-protected {#link|Undefined Behavior#} results.
+      actually the sentinel value. If this is not the case, safety-checked {#link|Illegal Behavior#} results.
       </p>
       {#code|test_sentinel_mismatch.zig#}
 
@@ -2265,7 +2311,7 @@ or
           that variable.</li>
           <li>If the struct is in the {#syntax#}return{#endsyntax#} expression, it gets named after
           the function it is returning from, with the parameter values serialized.</li>
-          <li>Otherwise, the struct gets a name such as <code>(filename.funcname.__struct_ID)</code>.</li>
+          <li>Otherwise, the struct gets a name such as <code>(filename.funcname__struct_ID)</code>.</li>
           <li>If the struct is declared inside another struct, it gets named after both the parent
           struct and the name inferred by the previous rules, separated by a dot.</li>
       </ul>
@@ -2291,7 +2337,7 @@ or
 
       {#header_open|Tuples#}
       <p>
-      Anonymous structs can be created without specifying field names, and are referred to as "tuples".
+      Anonymous structs can be created without specifying field names, and are referred to as "tuples". An empty tuple looks like <code>.{}</code> and can be seen in one of the {#link|Hello World examples|Hello World#}.
       </p>
       <p>
       The fields are implicitly named using numbers starting from 0. Because their names are integers,
@@ -2305,6 +2351,23 @@ or
       </p>
       {#code|test_tuples.zig#}
 
+      {#header_open|Destructuring Tuples#}
+      <p>
+        Tuples can be {#link|destructured|Destructuring#}.
+      </p>
+      <p>
+        Tuple destructuring is helpful for returning multiple values from a block:
+      </p>
+      {#code|destructuring_block.zig#}
+
+      <p>
+        Tuple destructuring is helpful for dealing with functions and built-ins that return multiple values
+        as a tuple:
+      </p>
+      {#code|destructuring_return_value.zig#}
+
+      {#see_also|Destructuring|Destructuring Arrays|Destructuring Vectors#}
+      {#header_close#}
       {#header_close#}
       {#see_also|comptime|@fieldParentPtr#}
       {#header_close#}
@@ -2363,7 +2426,7 @@ or
       or use an {#link|extern union#} or a {#link|packed union#} which have
       guaranteed in-memory layout.
       {#link|Accessing the non-active field|Wrong Union Field Access#} is
-      safety-checked {#link|Undefined Behavior#}:
+      safety-checked {#link|Illegal Behavior#}:
       </p>
       {#code|test_wrong_union_access.zig#}
 
@@ -2875,8 +2938,7 @@ or
       </p>
       {#header_open|The Global Error Set#}
       <p>{#syntax#}anyerror{#endsyntax#} refers to the global error set.
-      This is the error set that contains all errors in the entire compilation unit.
-      It is a superset of all other error sets and a subset of none of them.
+      This is the error set that contains all errors in the entire compilation unit, i.e. it is the union of all other error sets.
       </p>
       <p>
       You can {#link|coerce|Type Coercion#} any error set to the global one, and you can explicitly
@@ -2962,11 +3024,11 @@ or
       {#syntax#}const number = parseU64("1234", 10) catch unreachable;{#endsyntax#}
       <p>
       Here we know for sure that "1234" will parse successfully. So we put the
-      {#syntax#}unreachable{#endsyntax#} value on the right hand side. {#syntax#}unreachable{#endsyntax#} generates
-      a panic in {#link|Debug#} and {#link|ReleaseSafe#} modes and undefined behavior in
-      {#link|ReleaseFast#} and {#link|ReleaseSmall#} modes. So, while we're debugging the
-      application, if there <em>was</em> a surprise error here, the application would crash
-      appropriately.
+      {#syntax#}unreachable{#endsyntax#} value on the right hand side.
+      {#syntax#}unreachable{#endsyntax#} invokes safety-checked {#link|Illegal Behavior#}, so
+      in {#link|Debug#} and {#link|ReleaseSafe#}, triggers a safety panic by default. So, while
+      we're debugging the application, if there <em>was</em> a surprise error here, the application
+      would crash appropriately.
       </p>
       <p>
       You may want to take a different action for every situation. For that, we combine
@@ -3973,7 +4035,7 @@ fn performFn(start_value: i32) i32 {
       </p>
       <p>
       Luckily, we used an unsigned integer, and so when we tried to subtract 1 from 0, it triggered
-      undefined behavior, which is always a compile error if the compiler knows it happened.
+      {#link|Illegal Behavior#}, which is always a compile error if the compiler knows it happened.
       But what would have happened if we used a signed integer?
       </p>
       {#code|fibonacci_comptime_infinite_recursion.zig#}
@@ -4178,7 +4240,7 @@ pub fn print(self: *Writer, arg0: []const u8, arg1: i32) !void {
       </p>
       <p>
       Failure to declare the full set of clobbers for a given inline assembly
-      expression is unchecked {#link|Undefined Behavior#}.
+      expression is unchecked {#link|Illegal Behavior#}.
       </p>
       {#header_close#}
 
@@ -4518,9 +4580,7 @@ comptime {
       Counts the number of most-significant (leading in a big-endian sense) zeroes in an integer - "count leading zeroes".
       </p>
       <p>
-      If {#syntax#}operand{#endsyntax#} is a {#link|comptime#}-known integer,
-      the return type is {#syntax#}comptime_int{#endsyntax#}.
-      Otherwise, the return type is an unsigned integer or vector of unsigned integers with the minimum number
+      The return type is an unsigned integer or vector of unsigned integers with the minimum number
       of bits that can represent the bit count of the integer type.
       </p>
       <p>
@@ -4534,7 +4594,7 @@ comptime {
       <pre>{#syntax#}@cmpxchgStrong(comptime T: type, ptr: *T, expected_value: T, new_value: T, success_order: AtomicOrder, fail_order: AtomicOrder) ?T{#endsyntax#}</pre>
       <p>
       This function performs a strong atomic compare-and-exchange operation, returning {#syntax#}null{#endsyntax#}
-      if the current value is not the given expected value. It's the equivalent of this code,
+      if the current value is the given expected value. It's the equivalent of this code,
       except atomic:
       </p>
       {#code|not_atomic_cmpxchgStrong.zig#}
@@ -4556,7 +4616,7 @@ comptime {
       <pre>{#syntax#}@cmpxchgWeak(comptime T: type, ptr: *T, expected_value: T, new_value: T, success_order: AtomicOrder, fail_order: AtomicOrder) ?T{#endsyntax#}</pre>
       <p>
       This function performs a weak atomic compare-and-exchange operation, returning {#syntax#}null{#endsyntax#}
-      if the current value is not the given expected value. It's the equivalent of this code,
+      if the current value is the given expected value. It's the equivalent of this code,
       except atomic:
       </p>
       {#syntax_block|zig|cmpxchgWeakButNotAtomic#}
@@ -4631,9 +4691,7 @@ fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_val
       Counts the number of least-significant (trailing in a big-endian sense) zeroes in an integer - "count trailing zeroes".
       </p>
       <p>
-      If {#syntax#}operand{#endsyntax#} is a {#link|comptime#}-known integer,
-      the return type is {#syntax#}comptime_int{#endsyntax#}.
-      Otherwise, the return type is an unsigned integer or vector of unsigned integers with the minimum number
+      The return type is an unsigned integer or vector of unsigned integers with the minimum number
       of bits that can represent the bit count of the integer type.
       </p>
       <p>
@@ -4748,7 +4806,7 @@ fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_val
       </p>
       <p>
       Attempting to convert an integer with no corresponding value in the enum invokes
-      safety-checked {#link|Undefined Behavior#}.
+      safety-checked {#link|Illegal Behavior#}.
       Note that a {#link|non-exhaustive enum|Non-exhaustive enum#} has corresponding values for all
       integers in the enum's integer tag type: the {#syntax#}_{#endsyntax#} value represents all
       the remaining unnamed integers in the enum's tag type.
@@ -4767,7 +4825,7 @@ fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_val
       </p>
       <p>
       Attempting to convert an integer that does not correspond to any error results in
-      safety-protected {#link|Undefined Behavior#}.
+      safety-checked {#link|Illegal Behavior#}.
       </p>
       {#see_also|@intFromError#}
       {#header_close#}
@@ -4799,7 +4857,7 @@ fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_val
       <p>
       Converts an error set or error union value from one error set to another error set. The return type is the
 			inferred result type. Attempting to convert an error which is not in the destination error
-			set results in safety-protected {#link|Undefined Behavior#}.
+			set results in safety-checked {#link|Illegal Behavior#}.
       </p>
       {#header_close#}
 
@@ -4850,7 +4908,12 @@ fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_val
       {#header_open|@fieldParentPtr#}
       <pre>{#syntax#}@fieldParentPtr(comptime field_name: []const u8, field_ptr: *T) anytype{#endsyntax#}</pre>
       <p>
-      Given a pointer to a field, returns the base pointer of a struct.
+      Given a pointer to a struct field, returns a pointer to the struct containing that field.
+      The return type (and struct in question) is the inferred result type.
+      </p>
+      <p>
+      If {#syntax#}field_ptr{#endsyntax#} does not point to the {#syntax#}field_name{#endsyntax#} field of an instance of
+      the result type, and the result type has ill-defined layout, invokes unchecked {#link|Illegal Behavior#}.
       </p>
       {#header_close#}
 
@@ -4967,7 +5030,7 @@ fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_val
       Converts an integer to another integer while keeping the same numerical value.
 			The return type is the inferred result type.
       Attempting to convert a number which is out of range of the destination type results in
-      safety-protected {#link|Undefined Behavior#}.
+      safety-checked {#link|Illegal Behavior#}.
       </p>
       {#code|test_intCast_builtin.zig#}
 
@@ -5028,7 +5091,7 @@ fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_val
       </p>
       <p>
       If the integer part of the floating point number cannot fit in the destination type,
-      it invokes safety-checked {#link|Undefined Behavior#}.
+      it invokes safety-checked {#link|Illegal Behavior#}.
       </p>
       {#see_also|@floatFromInt#}
       {#header_close#}
@@ -5062,9 +5125,8 @@ fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_val
       <p>{#syntax#}source{#endsyntax#} must be a slice, a pointer to
         an array, or a many-item {#link|pointer|Pointers#}. It may
         have any alignment, and it may have any element type.</p>
-      <p>The {#syntax#}source{#endsyntax#} element type must support {#link|Type Coercion#}
-        into the {#syntax#}dest{#endsyntax#} element type. The element types may have
-        different ABI size, however, that may incur a performance penalty.</p>
+      <p>The {#syntax#}source{#endsyntax#} element type must have the same in-memory
+        representation as the {#syntax#}dest{#endsyntax#} element type.</p>
       <p>Similar to {#link|for#} loops, at least one of {#syntax#}source{#endsyntax#} and
         {#syntax#}dest{#endsyntax#} must provide a length, and if two lengths are provided,
         they must be equal.</p>
@@ -5161,7 +5223,7 @@ fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_val
         <li>From library code, calling the programmer's panic function if they exposed one in the root source file.</li>
         <li>When mixing C and Zig code, calling the canonical panic implementation across multiple .o files.</li>
       </ul>
-      {#see_also|Root Source File#}
+      {#see_also|Panic Handler#}
       {#header_close#}
 
       {#header_open|@popCount#}
@@ -5172,9 +5234,7 @@ fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_val
       Counts the number of bits set in an integer - "population count".
       </p>
       <p>
-      If {#syntax#}operand{#endsyntax#} is a {#link|comptime#}-known integer,
-      the return type is {#syntax#}comptime_int{#endsyntax#}.
-      Otherwise, the return type is an unsigned integer or vector of unsigned integers with the minimum number
+      The return type is an unsigned integer or vector of unsigned integers with the minimum number
       of bits that can represent the bit count of the integer type.
       </p>
       {#see_also|@ctz|@clz#}
@@ -5191,7 +5251,7 @@ fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_val
       <p>
       The {#syntax#}ptr{#endsyntax#} argument may be any pointer type and determines the memory
       address to prefetch. This function does not dereference the pointer, it is perfectly legal
-      to pass a pointer to invalid memory to this function and no illegal behavior will result.
+      to pass a pointer to invalid memory to this function and no Illegal Behavior will result.
       </p>
       <p>{#syntax#}PrefetchOptions{#endsyntax#} can be found with {#syntax#}@import("std").builtin.PrefetchOptions{#endsyntax#}.</p>
       {#header_close#}
@@ -5203,7 +5263,7 @@ fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_val
       </p>
       <p>
       {#link|Optional Pointers#} are allowed. Casting an optional pointer which is {#link|null#}
-      to a non-optional pointer invokes safety-checked {#link|Undefined Behavior#}.
+      to a non-optional pointer invokes safety-checked {#link|Illegal Behavior#}.
       </p>
       <p>
       {#syntax#}@ptrCast{#endsyntax#} cannot be used for:
@@ -5227,7 +5287,7 @@ fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_val
       </p>
       <p>
       If the destination pointer type does not allow address zero and {#syntax#}address{#endsyntax#}
-      is zero, this invokes safety-checked {#link|Undefined Behavior#}.
+      is zero, this invokes safety-checked {#link|Illegal Behavior#}.
       </p>
       {#header_close#}
 
@@ -5302,8 +5362,8 @@ fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_val
         <li>
             {#syntax#}Optimized{#endsyntax#} - Floating point operations may do all of the following:
           <ul>
-            <li>Assume the arguments and result are not NaN. Optimizations are required to retain defined behavior over NaNs, but the value of the result is undefined.</li>
-            <li>Assume the arguments and result are not +/-Inf. Optimizations are required to retain defined behavior over +/-Inf, but the value of the result is undefined.</li>
+            <li>Assume the arguments and result are not NaN. Optimizations are required to retain legal behavior over NaNs, but the value of the result is undefined.</li>
+            <li>Assume the arguments and result are not +/-Inf. Optimizations are required to retain legal behavior over +/-Inf, but the value of the result is undefined.</li>
             <li>Treat the sign of a zero argument or result as insignificant.</li>
             <li>Use the reciprocal of an argument rather than perform division.</li>
             <li>Perform floating-point contraction (e.g. fusing a multiply followed by an addition into a fused multiply-add).</li>
@@ -5342,7 +5402,7 @@ fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_val
       </p>
       <p>
       The type of {#syntax#}shift_amt{#endsyntax#} is an unsigned integer with {#syntax#}log2(@typeInfo(T).int.bits){#endsyntax#} bits.
-              This is because {#syntax#}shift_amt >= @typeInfo(T).int.bits{#endsyntax#} is undefined behavior.
+      This is because {#syntax#}shift_amt >= @typeInfo(T).int.bits{#endsyntax#} triggers safety-checked {#link|Illegal Behavior#}.
       </p>
       <p>
       {#syntax#}comptime_int{#endsyntax#} is modeled as an integer with an infinite number of bits,
@@ -5359,7 +5419,7 @@ fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_val
       </p>
       <p>
       The type of {#syntax#}shift_amt{#endsyntax#} is an unsigned integer with {#syntax#}log2(@typeInfo(@TypeOf(a)).int.bits){#endsyntax#} bits.
-              This is because {#syntax#}shift_amt >= @typeInfo(@TypeOf(a)).int.bits{#endsyntax#} is undefined behavior.
+      This is because {#syntax#}shift_amt >= @typeInfo(@TypeOf(a)).int.bits{#endsyntax#} triggers safety-checked {#link|Illegal Behavior#}.
       </p>
       {#see_also|@shlExact|@shrExact#}
       {#header_close#}
@@ -5372,7 +5432,7 @@ fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_val
       </p>
       <p>
       The type of {#syntax#}shift_amt{#endsyntax#} is an unsigned integer with {#syntax#}log2(@typeInfo(T).int.bits){#endsyntax#} bits.
-              This is because {#syntax#}shift_amt >= @typeInfo(T).int.bits{#endsyntax#} is undefined behavior.
+      This is because {#syntax#}shift_amt >= @typeInfo(T).int.bits{#endsyntax#} triggers safety-checked {#link|Illegal Behavior#}.
       </p>
       {#see_also|@shlExact|@shlWithOverflow#}
       {#header_close#}
@@ -5647,7 +5707,7 @@ fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_val
       {#header_open|@tagName#}
       <pre>{#syntax#}@tagName(value: anytype) [:0]const u8{#endsyntax#}</pre>
       <p>
-      Converts an enum value or union value to a string literal representing the name.</p><p>If the enum is non-exhaustive and the tag value does not map to a name, it invokes safety-checked {#link|Undefined Behavior#}.
+      Converts an enum value or union value to a string literal representing the name.</p><p>If the enum is non-exhaustive and the tag value does not map to a name, it invokes safety-checked {#link|Illegal Behavior#}.
       </p>
       {#header_close#}
 
@@ -5884,7 +5944,7 @@ fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_val
         <li>Reproducible build</li>
       </ul>
       {#header_close#}
-      {#see_also|Compile Variables|Zig Build System|Undefined Behavior#}
+      {#see_also|Compile Variables|Zig Build System|Illegal Behavior#}
       {#header_close#}
 
       {#header_open|Single Threaded Builds#}
@@ -5899,20 +5959,36 @@ fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_val
       </ul>
       {#header_close#}
 
-      {#header_open|Undefined Behavior#}
+      {#header_open|Illegal Behavior#}
       <p>
-      Zig has many instances of undefined behavior. If undefined behavior is
-      detected at compile-time, Zig emits a compile error and refuses to continue.
-      Most undefined behavior that cannot be detected at compile-time can be detected
-      at runtime. In these cases, Zig has safety checks. Safety checks can be disabled
-      on a per-block basis with {#link|@setRuntimeSafety#}. The {#link|ReleaseFast#}
-      and {#link|ReleaseSmall#} build modes disable all safety checks (except where overridden
-      by {#link|@setRuntimeSafety#}) in order to facilitate optimizations.
+      Many operations in Zig trigger what is known as "Illegal Behavior" (IB). If Illegal Behavior is detected at
+      compile-time, Zig emits a compile error and refuses to continue. Otherwise, when Illegal Behavior is not caught
+      at compile-time, it falls into one of two categories.
       </p>
       <p>
-      When a safety check fails, Zig crashes with a stack trace, like this:
+      Some Illegal Behavior is <em>safety-checked</em>: this means that the compiler will insert "safety checks"
+      anywhere that the Illegal Behavior may occur at runtime, to determine whether it is about to happen. If it
+      is, the safety check "fails", which triggers a panic.
       </p>
-      {#code|test_undefined_behavior.zig#}
+      <p>
+      All other Illegal Behavior is <em>unchecked</em>, meaning the compiler is unable to insert safety checks for
+      it. If Unchecked Illegal Behavior is invoked at runtime, anything can happen: usually that will be some kind of
+      crash, but the optimizer is free to make Unchecked Illegal Behavior do anything, such as calling arbitrary functions
+      or clobbering arbitrary data. This is similar to the concept of "undefined behavior" in some other languages. Note that
+      Unchecked Illegal Behavior still always results in a compile error if evaluated at {#link|comptime#}, because the Zig
+      compiler is able to perform more sophisticated checks at compile-time than at runtime.
+      </p>
+      <p>
+      Most Illegal Behavior is safety-checked. However, to facilitate optimizations, safety checks are disabled by default
+      in the {#link|ReleaseFast#} and {#link|ReleaseSmall#} optimization modes. Safety checks can also be enabled or disabled
+      on a per-block basis, overriding the default for the current optimization mode, using {#link|@setRuntimeSafety#}. When
+      safety checks are disabled, Safety-Checked Illegal Behavior behaves like Unchecked Illegal Behavior; that is, any behavior
+      may result from invoking it.
+      </p>
+      <p>
+      When a safety check fails, Zig's default panic handler crashes with a stack trace, like this:
+      </p>
+      {#code|test_illegal_behavior.zig#}
 
       {#header_open|Reaching Unreachable Code#}
       <p>At compile-time:</p>
@@ -6278,7 +6354,7 @@ fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_val
       <p>
       {#syntax#}var{#endsyntax#} declarations inside functions are stored in the function's stack frame. Once a function returns,
       any {#link|Pointers#} to variables in the function's stack frame become invalid references, and
-      dereferencing them becomes unchecked {#link|Undefined Behavior#}.
+      dereferencing them becomes unchecked {#link|Illegal Behavior#}.
       </p>
       <p>
       {#syntax#}var{#endsyntax#} declarations at the top level or in {#link|struct#} declarations are stored in the global
@@ -6386,7 +6462,7 @@ fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_val
       The API documentation for functions and data structures should take great care to explain
       the ownership and lifetime semantics of pointers. Ownership determines whose responsibility it
       is to free the memory referenced by the pointer, and lifetime determines the point at which
-      the memory becomes inaccessible (lest {#link|Undefined Behavior#} occur).
+      the memory becomes inaccessible (lest {#link|Illegal Behavior#} occur).
       </p>
       {#header_close#}
 
@@ -6405,14 +6481,155 @@ fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_val
       {#builtin#}
       {#see_also|Build Mode#}
       {#header_close#}
-      {#header_open|Root Source File#}
-      <p>TODO: explain how root source file finds other files</p>
-      <p>TODO: pub fn main</p>
-      <p>TODO: pub fn panic</p>
-      <p>TODO: if linking with libc you can use export fn main</p>
-      <p>TODO: order independent top level declarations</p>
-      <p>TODO: lazy analysis</p>
-      <p>TODO: using comptime { _ = @import() }</p>
+      {#header_open|Compilation Model#}
+      <p>
+      A Zig compilation is separated into <em>modules</em>. Each module is a collection of Zig source files,
+      one of which is the module's <em>root source file</em>. Each module can <em>depend</em> on any number of
+      other modules, forming a directed graph (dependency loops between modules are allowed). If module A
+      depends on module B, then any Zig source file in module A can import the <em>root source file</em> of
+      module B using {#syntax#}@import{#endsyntax#} with the module's name. In essence, a module acts as an
+      alias to import a Zig source file (which might exist in a completely separate part of the filesystem).
+      </p>
+      <p>
+      A simple Zig program compiled with <code>zig build-exe</code> has two key modules: the one containing your
+      code, known as the "main" or "root" module, and the standard library. Your module <em>depends on</em>
+      the standard library module under the name "std", which is what allows you to write
+      {#syntax#}@import("std"){#endsyntax#}! In fact, every single module in a Zig compilation &mdash; including
+      the standard library itself &mdash; implicitly depends on the standard library module under the name "std".
+      </p>
+      <p>
+      The "root module" (the one provided by you in the <code>zig build-exe</code> example) has a special
+      property. Like the standard library, it is implicitly made available to all modules (including itself),
+      this time under the name "root". So, {#syntax#}@import("root"){#endsyntax#} will always be equivalent to
+      {#syntax#}@import{#endsyntax#} of your "main" source file (often, but not necessarily, named
+      <code>main.zig</code>).
+      </p>
+      {#header_open|Source File Structs#}
+      <p>
+      Every Zig source file is implicitly a {#syntax#}struct{#endsyntax#} declaration; you can imagine that
+      the file's contents are literally surrounded by {#syntax#}struct { ... }{#endsyntax#}. This means that
+      as well as declarations, the top level of a file is permitted to contain fields:
+      </p>
+      {#code|TopLevelFields.zig#}
+      <p>
+      Such files can be instantiated just like any other {#syntax#}struct{#endsyntax#} type. A file's "root
+      struct type" can be referred to within that file using {#link|@This#}.
+      </p>
+      {#header_close#}
+      {#header_open|File and Declaration Discovery#}
+      <p>
+      Zig places importance on the concept of whether any piece of code is <em>semantically analyzed</em>; in
+      essence, whether the compiler "looks at" it. What code is analyzed is based on what files and
+      declarations are "discovered" from a certain point. This process of "discovery" is based on a simple set
+      of recursive rules:
+      </p>
+      <ul>
+        <li>If a call to {#syntax#}@import{#endsyntax#} is analyzed, the file being imported is analyzed.</li>
+        <li>If a type (including a file) is analyzed, all {#syntax#}comptime{#endsyntax#}, {#syntax#}usingnamespace{#endsyntax#}, and {#syntax#}export{#endsyntax#} declarations within it are analyzed.</li>
+        <li>If a type (including a file) is analyzed, and the compilation is for a {#link|test|Zig Test#}, and the module the type is within is the root module of the compilation, then all {#syntax#}test{#endsyntax#} declarations within it are also analyzed.</li>
+        <li>If a reference to a named declaration (i.e. a usage of it) is analyzed, the declaration being referenced is analyzed. Declarations are order-independent, so this reference may be above or below the declaration being referenced, or even in another file entirely.</li>
+      </ul>
+      <p>
+      That's it! Those rules define how Zig files and declarations are discovered. All that remains is to
+      understand where this process <em>starts</em>.
+      </p>
+      <p>
+      The answer to that is the root of the standard library: every Zig compilation begins by analyzing the
+      file <code>lib/std/std.zig</code>. This file contains a {#syntax#}comptime{#endsyntax#} declaration
+      which imports {#syntax#}lib/std/start.zig{#endsyntax#}, and that file in turn uses
+      {#syntax#}@import("root"){#endsyntax#} to reference the "root module"; so, the file you provide as your
+      main module's root source file is effectively also a root, because the standard library will always
+      reference it.
+      </p>
+      <p>
+      It is often desirable to make sure that certain declarations &mdash; particularly {#syntax#}test{#endsyntax#}
+      or {#syntax#}export{#endsyntax#} declarations &mdash; are discovered. Based on the above rules, a common
+      strategy for this is to use {#syntax#}@import{#endsyntax#} within a {#syntax#}comptime{#endsyntax#} or
+      {#syntax#}test{#endsyntax#} block:
+      </p>
+      {#syntax_block|zig|force_file_discovery.zig#}
+comptime {
+    // This will ensure that the file 'api.zig' is always discovered (as long as this file is discovered).
+    // It is useful if 'api.zig' contains important exported declarations.
+    _ = @import("api.zig");
+
+    // We could also have a file which contains declarations we only want to export depending on a comptime
+    // condition. In that case, we can use an `if` statement here:
+    if (builtin.os.tag == .windows) {
+        _ = @import("windows_api.zig");
+    }
+}
+
+test {
+    // This will ensure that the file 'tests.zig' is always discovered (as long as this file is discovered),
+    // if this compilation is a test. It is useful if 'tests.zig' contains tests we want to ensure are run.
+    _ = @import("tests.zig");
+
+    // We could also have a file which contains tests we only want to run depending on a comptime condition.
+    // In that case, we can use an `if` statement here:
+    if (builtin.os.tag == .windows) {
+        _ = @import("windows_tests.zig");
+    }
+}
+
+const builtin = @import("builtin");
+      {#end_syntax_block#}
+      {#header_close#}
+      {#header_open|Special Root Declarations#}
+      <p>
+      Because the root module's root source file is always accessible using
+      {#syntax#}@import("root"){#endsyntax#}, is is sometimes used by libraries &mdash; including the Zig Standard
+      Library &mdash; as a place for the program to expose some "global" information to that library. The Zig
+      Standard Library will look for several declarations in this file.
+      </p>
+      {#header_open|Entry Point#}
+      <p>
+      When building an executable, the most important thing to be looked up in this file is the program's
+      <em>entry point</em>. Most commonly, this is a function named {#syntax#}main{#endsyntax#}, which
+      {#syntax#}std.start{#endsyntax#} will call just after performing important initialization work.
+      </p>
+      <p>
+      Alternatively, the presence of a declaration named {#syntax#}_start{#endsyntax#} (for instance,
+      {#syntax#}pub const _start = {};{#endsyntax#}) will disable the default {#syntax#}std.start{#endsyntax#}
+      logic, allowing your root source file to export a low-level entry point as needed.
+      </p>
+      {#code|entry_point.zig#}
+      <p>
+      If the Zig compilation links libc, the {#syntax#}main{#endsyntax#} function can optionally be an
+      {#syntax#}export fn{#endsyntax#} which matches the signature of the C <code>main</code> function:
+      </p>
+      {#code|libc_export_entry_point.zig#}
+      <p>
+      {#syntax#}std.start{#endsyntax#} may also use other entry point declarations in certain situations, such
+      as {#syntax#}wWinMain{#endsyntax#} or {#syntax#}EfiMain{#endsyntax#}. Refer to the
+      {#syntax#}lib/std/start.zig{#endsyntax#} logic for details of these declarations.
+      </p>
+      {#header_close#}
+      {#header_open|Standard Library Options#}
+      <p>
+      The standard library also looks for a declaration in the root module's root source file named
+      {#syntax#}std_options{#endsyntax#}. If present, this declaration is expected to be a struct of type
+      {#syntax#}std.Options{#endsyntax#}, and allows the program to customize some standard library
+      functionality, such as the {#syntax#}std.log{#endsyntax#} implementation.
+      </p>
+      {#code|std_options.zig#}
+      {#header_close#}
+      {#header_open|Panic Handler#}
+      <p>
+      The Zig Standard Library looks for a declaration named {#syntax#}panic{#endsyntax#} in the root module's
+      root source file. If present, it is expected to be a namespace (container type) with declarations
+      providing different panic handlers.
+      </p>
+      <p>
+      See {#syntax#}std.debug.simple_panic{#endsyntax#} for a basic implementation of this namespace.
+      </p>
+      <p>
+      Overriding how the panic handler actually outputs messages, but keeping the formatted safety panics
+      which are enabled by default, can be easily achieved with {#syntax#}std.debug.FullPanic{#endsyntax#}:
+      </p>
+      {#code|panic_handler.zig#}
+      {#header_close#}
+      {#header_close#}
       {#header_close#}
       {#header_open|Zig Build System#}
       <p>
@@ -6674,10 +6891,10 @@ int foo(void) {
         <li>Supports all the syntax of the other two pointer types ({#syntax#}*T{#endsyntax#}) and ({#syntax#}[*]T{#endsyntax#}).</li>
         <li>Coerces to other pointer types, as well as {#link|Optional Pointers#}.
             When a C pointer is coerced to a non-optional pointer, safety-checked
-            {#link|Undefined Behavior#} occurs if the address is 0.
+            {#link|Illegal Behavior#} occurs if the address is 0.
         </li>
         <li>Allows address 0. On non-freestanding targets, dereferencing address 0 is safety-checked
-            {#link|Undefined Behavior#}. Optional C pointers introduce another bit to keep track of
+            {#link|Illegal Behavior#}. Optional C pointers introduce another bit to keep track of
             null, just like {#syntax#}?usize{#endsyntax#}. Note that creating an optional C pointer
             is unnecessary as one can use normal {#link|Optional Pointers#}.
         </li>
@@ -6992,8 +7209,8 @@ fn readU32Be() u32 {}
       <ul>
         <li>Omit any information that is redundant based on the name of the thing being documented.</li>
         <li>Duplicating information onto multiple similar functions is encouraged because it helps IDEs and other tools provide better help text.</li>
-        <li>Use the word <strong>assume</strong> to indicate invariants that cause {#link|Undefined Behavior#} when violated.</li>
-        <li>Use the word <strong>assert</strong> to indicate invariants that cause <em>safety-checked</em> {#link|Undefined Behavior#} when violated.</li>
+        <li>Use the word <strong>assume</strong> to indicate invariants that cause <em>unchecked</em> {#link|Illegal Behavior#} when violated.</li>
+        <li>Use the word <strong>assert</strong> to indicate invariants that cause <em>safety-checked</em> {#link|Illegal Behavior#} when violated.</li>
       </ul>
       {#header_close#}
       {#header_close#}
@@ -7389,8 +7606,8 @@ fn readU32Be() u32 {}
             In particular, inside a {#syntax#}nosuspend{#endsyntax#} scope:
             <ul>
               <li>Using the {#syntax#}suspend{#endsyntax#} keyword results in a compile error.</li>
-              <li>Using {#syntax#}await{#endsyntax#} on a function frame which hasn't completed yet results in safety-checked {#link|Undefined Behavior#}.</li>
-              <li>Calling an async function may result in safety-checked {#link|Undefined Behavior#}, because it's equivalent to <code>await async some_async_fn()</code>, which contains an {#syntax#}await{#endsyntax#}.</li>
+              <li>Using {#syntax#}await{#endsyntax#} on a function frame which hasn't completed yet results in safety-checked {#link|Illegal Behavior#}.</li>
+              <li>Calling an async function may result in safety-checked {#link|Illegal Behavior#}, because it's equivalent to <code>await async some_async_fn()</code>, which contains an {#syntax#}await{#endsyntax#}.</li>
             </ul>
             Code inside a {#syntax#}nosuspend{#endsyntax#} scope does not cause the enclosing function to become an {#link|async function|Async Functions#}.
             <ul>


### PR DESCRIPTION
### Description

Provides compatibility with Zig 0.14.0

### Changes

- Updated CI, [flake.nix](flake.nix), [build.zig](build.zig), [build.zig.zon](build.zig.zon), and [BuildRunnerVersion.zig](src/build_runner/BuildRunnerVersion.zig) files to `0.14.0`
- Added [0.14.0.zig](src/build_runner/0.14.0.zig) build runner and [langref_0.14.0.html.in](src/tools/langref_0.14.0.html.in) language reference files
  - Removed the following deprecated cli options:
    - `--show-config-path`
    - `--enable-message-tracing`
    - `--enable-debug-log`

### Related issues and pull requests

[Issue #2212](https://github.com/zigtools/zls/issues/2212) - release ZLS 0.14