### PR TITLE
Synchronize release targets with ziglang.org tarballs.

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -28,15 +28,18 @@ const minimum_build_zig_version = "0.14.0";
 const minimum_runtime_zig_version = "0.14.0";
 
 const release_targets = [_]std.Target.Query{
-    .{ .cpu_arch = .x86_64, .os_tag = .windows },
-    .{ .cpu_arch = .x86_64, .os_tag = .linux },
-    .{ .cpu_arch = .x86_64, .os_tag = .macos },
-    .{ .cpu_arch = .x86, .os_tag = .windows },
-    .{ .cpu_arch = .x86, .os_tag = .linux },
-    .{ .cpu_arch = .aarch64, .os_tag = .windows },
     .{ .cpu_arch = .aarch64, .os_tag = .linux },
     .{ .cpu_arch = .aarch64, .os_tag = .macos },
+    .{ .cpu_arch = .aarch64, .os_tag = .windows },
     .{ .cpu_arch = .arm, .os_tag = .linux },
+    .{ .cpu_arch = .loongarch64, .os_tag = .linux },
+    .{ .cpu_arch = .powerpc64le, .os_tag = .linux },
+    .{ .cpu_arch = .riscv64, .os_tag = .linux },
+    .{ .cpu_arch = .x86, .os_tag = .linux },
+    .{ .cpu_arch = .x86, .os_tag = .windows },
+    .{ .cpu_arch = .x86_64, .os_tag = .linux },
+    .{ .cpu_arch = .x86_64, .os_tag = .macos },
+    .{ .cpu_arch = .x86_64, .os_tag = .windows },
     .{ .cpu_arch = .wasm32, .os_tag = .wasi },
 };
 


### PR DESCRIPTION
Adds:

* `loongarch64-linux`
* `powerpc64le-linux`
* `riscv64-linux`