### PR TITLE
Ignore directories when finding Zig executable

### DIFF
--- a/src/configuration.zig
+++ b/src/configuration.zig
@@ -244,6 +244,7 @@ pub fn findZig(allocator: std.mem.Allocator) error{OutOfMemory}!?[]const u8 {
             const stat = file.stat() catch break :stat_failed;
             if (stat.kind == .directory) {
                 logger.warn("ignoring entry in PATH '{s}' because it is a directory", .{full_path});
+                continue;
             }
         }
 


### PR DESCRIPTION
This PR fixes an issue where directories named "zig" (or "zig.exe" on Windows) in the PATH environment variable is not ignored.