### PR TITLE
add config option insert_completion

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -9,6 +9,11 @@
             "type": "boolean",
             "default": true
         },
+        "insert_completions": {
+            "description": "Uses insertText completion items and lets the client handle filtering",
+            "type": "boolean",
+            "default": false
+        },
         "enable_argument_placeholders": {
             "description": "Whether to enable function argument placeholder completions",
             "type": "boolean",

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -7,6 +7,9 @@
 /// Enables snippet completions when the client also supports them
 enable_snippets: bool = true,
 
+/// Uses insertText completion items and lets the client handle filtering
+insert_completions: bool = false,
+
 /// Whether to enable function argument placeholder completions
 enable_argument_placeholders: bool = true,
 

--- a/src/tools/config.json
+++ b/src/tools/config.json
@@ -7,6 +7,12 @@
             "default": true
         },
         {
+            "name": "insert_completions",
+            "description": "Uses insertText completion items and lets the client handle filtering",
+            "type": "bool",
+            "default": false
+        },
+        {
             "name": "enable_argument_placeholders",
             "description": "Whether to enable function argument placeholder completions",
             "type": "bool",


### PR DESCRIPTION
Adds the option to use insertText completionitems instead of textEdit completionitems implying that filtering needs to be done on the client. This is probably a niche fix as most editors filter regardless, of which which completion kind is received. NeoVim declared this behavior as [intentional](https://github.com/neovim/neovim/issues/31911#issuecomment-2577906280) so this pr represents a workaround, until zls filters auto completions on its own