### PR TITLE
build: Don't check parent directories for git tag

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -322,7 +322,7 @@ fn getVersion(b: *Build) std.SemanticVersion {
     if (zls_version.pre == null and zls_version.build == null) return zls_version;
 
     const argv: []const []const u8 = &.{
-        "git", "-C", b.pathFromRoot("."), "describe", "--match", "*.*.*", "--tags",
+        "git", "-C", b.pathFromRoot("."), "--git-dir", ".git", "describe", "--match", "*.*.*", "--tags",
     };
     var code: u8 = undefined;
     const git_describe_untrimmed = b.runAllowFail(argv, &code, .Ignore) catch |err| {


### PR DESCRIPTION
Sometimes zls is built not from a git repository (e.g. from tarball), but inside another git repository (e.g. distro package repository). Make sure that the version check tries to parse a tag of zls, and not of a parent directory.