### PR TITLE
dont give label details for typeless valueless enum and union fields

### DIFF
--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -1361,10 +1361,14 @@ fn collectContainerFields(
                     break :insert_text try std.fmt.allocPrint(builder.arena, "{s} = ", .{name});
                 };
 
+                const detail = if (Analyser.getContainerFieldSignature(tree, field)) |signature| detail: {
+                    if (std.mem.eql(u8, name, signature) and field.ast.tuple_like) break :detail null;
+                    break :detail signature;
+                } else null;
                 break :blk .{
                     .label = name,
                     .kind = if (field.ast.tuple_like) .EnumMember else .Field,
-                    .detail = Analyser.getContainerFieldSignature(tree, field),
+                    .detail = detail,
                     .insertTextFormat = if (use_snippets) .Snippet else .PlainText,
                     .insertText = insert_text,
                 };

--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -1477,13 +1477,6 @@ fn resolveBuiltinFnArg(
             }
         }
 
-        if (std.mem.eql(u8, name, "@fence")) {
-            switch (arg_index) {
-                0 => break :name "AtomicOrder",
-                else => return null,
-            }
-        }
-
         if (std.mem.eql(u8, name, "@cmpxchgWeak") or std.mem.eql(u8, name, "@cmpxchgStrong")) {
             switch (arg_index) {
                 4, 5 => break :name "AtomicOrder",

--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -2763,8 +2763,8 @@ test "builtin fns taking an enum arg" {
         \\    @setFloatMode(.<cursor>)
         \\}
     , &.{
-        .{ .label = "strict", .kind = .EnumMember, .detail = "strict" },
-        .{ .label = "optimized", .kind = .EnumMember, .detail = "optimized" },
+        .{ .label = "strict", .kind = .EnumMember },
+        .{ .label = "optimized", .kind = .EnumMember },
     });
     try testCompletion(
         \\test {
@@ -2780,13 +2780,13 @@ test "builtin fns taking an enum arg" {
         \\    @reduce(.<cursor>
         \\}
     , &.{
-        .{ .label = "And", .kind = .EnumMember, .detail = "And" },
-        .{ .label = "Or", .kind = .EnumMember, .detail = "Or" },
-        .{ .label = "Xor", .kind = .EnumMember, .detail = "Xor" },
-        .{ .label = "Min", .kind = .EnumMember, .detail = "Min" },
-        .{ .label = "Max", .kind = .EnumMember, .detail = "Max" },
-        .{ .label = "Add", .kind = .EnumMember, .detail = "Add" },
-        .{ .label = "Mul", .kind = .EnumMember, .detail = "Mul" },
+        .{ .label = "And", .kind = .EnumMember },
+        .{ .label = "Or", .kind = .EnumMember },
+        .{ .label = "Xor", .kind = .EnumMember },
+        .{ .label = "Min", .kind = .EnumMember },
+        .{ .label = "Max", .kind = .EnumMember },
+        .{ .label = "Add", .kind = .EnumMember },
+        .{ .label = "Mul", .kind = .EnumMember },
     });
     try testCompletionTextEdit(.{
         .source = "comptime { @export(foo ,.<cursor>",
@@ -2849,14 +2849,14 @@ test "builtin fns taking an enum arg" {
         \\    @call(.<cursor>
         \\}
     , &.{
-        .{ .label = "auto", .kind = .EnumMember, .detail = "auto" },
-        .{ .label = "async_kw", .kind = .EnumMember, .detail = "async_kw" },
-        .{ .label = "never_tail", .kind = .EnumMember, .detail = "never_tail" },
-        .{ .label = "never_inline", .kind = .EnumMember, .detail = "never_inline" },
-        .{ .label = "no_async", .kind = .EnumMember, .detail = "no_async" },
-        .{ .label = "always_tail", .kind = .EnumMember, .detail = "always_tail" },
-        .{ .label = "always_inline", .kind = .EnumMember, .detail = "always_inline" },
-        .{ .label = "compile_time", .kind = .EnumMember, .detail = "compile_time" },
+        .{ .label = "auto", .kind = .EnumMember },
+        .{ .label = "async_kw", .kind = .EnumMember },
+        .{ .label = "never_tail", .kind = .EnumMember },
+        .{ .label = "never_inline", .kind = .EnumMember },
+        .{ .label = "no_async", .kind = .EnumMember },
+        .{ .label = "always_tail", .kind = .EnumMember },
+        .{ .label = "always_inline", .kind = .EnumMember },
+        .{ .label = "compile_time", .kind = .EnumMember },
     });
     try testCompletionTextEdit(.{
         .source = "var a: u16 addrspace(.<cursor>",

--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -2803,13 +2803,6 @@ test "builtin fns taking an enum arg" {
         .enable_snippets = false,
     });
     try testCompletionTextEdit(.{
-        .source = "test { @fence(.<cursor>",
-        .label = "acq_rel",
-        .expected_insert_line = "test { @fence(.acq_rel",
-        .expected_replace_line = "test { @fence(.acq_rel",
-        .enable_snippets = false,
-    });
-    try testCompletionTextEdit(.{
         .source = "test { @cmpxchgWeak(1,2,3,4, .<cursor>",
         .label = "acq_rel",
         .expected_insert_line = "test { @cmpxchgWeak(1,2,3,4, .acq_rel",


### PR DESCRIPTION
maybe this is a bit opinionated but i find it quite noisy depending on how the editor presents details e.g. zed which has no separation 
before:
![image](https://github.com/user-attachments/assets/b282ff8b-bdb9-44ad-a5ec-9ba0ce72cf90)
after:
![image](https://github.com/user-attachments/assets/9b170b4c-bab8-4ebf-b79e-7e0c4cb92bd1)
the name is still duplicated on `a` unfortunately, i considered just leaving ` = 69` but its a bit awkward imo, i think its alright here. open to other formatting suggestions though
