### PR TITLE
feat: support `workspace/didChangeWatchedFiles` for imported files

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -879,13 +879,15 @@ fn didChangeWatchedFilesHandler(server: *Server, arena: std.mem.Allocator, notif
         if (!(std.mem.endsWith(u8, change.uri, ".zig") or std.mem.endsWith(u8, change.uri, ".zon"))) continue;
         switch (change.type) {
             .Created, .Changed, .Deleted => {
-                try server.document_store.refreshDocumentFromFileSystem(change.uri);
-                updated_files += 1;
+                const did_update_file = try server.document_store.refreshDocumentFromFileSystem(change.uri);
+                updated_files += @intFromBool(did_update_file);
             },
             else => {},
         }
     }
-    log.info("updated {d} watched file(s)", .{updated_files});
+    if (updated_files != 0) {
+        log.info("updated {d} watched file(s)", .{updated_files});
+    }
 }
 
 fn didChangeWorkspaceFoldersHandler(server: *Server, arena: std.mem.Allocator, notification: types.DidChangeWorkspaceFoldersParams) Error!void {

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -878,7 +878,7 @@ fn didChangeWatchedFilesHandler(server: *Server, arena: std.mem.Allocator, notif
     for (notification.changes) |change| {
         if (!(std.mem.endsWith(u8, change.uri, ".zig") or std.mem.endsWith(u8, change.uri, ".zon"))) continue;
         switch (change.type) {
-            .Changed, .Deleted => {
+            .Created, .Changed, .Deleted => {
                 try server.document_store.refreshDocumentFromFileSystem(change.uri);
                 updated_files += 1;
             },


### PR DESCRIPTION
This adds support for `workspace/didChangeConfiguration`. I have a few questions/ points of interest:

- I ran into some minor issues with with the [`FileSystemWatcher`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#fileSystemWatcher)'s [`GlobPattern`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#pattern). 
   - Trying out just `"**/*.{zig,zon}"`  (as well as `"**/*.zig"`) caused the server to receive no notifications. I'm not sure if that was an issue with my implementation and/or Neovim's client implementation.
  - I opted to go with the basic [`Pattern`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#pattern) glob because the [`RelativePattern`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#relativePattern) glob is behind the capability's [registration params](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#didChangeWatchedFilesRegistrationOptions), so there may be some LSP clients that don't implement this feature.
  - Because registering for `"**"` includes *all* files in the project directory (including those in `.zig-cache`), I tried filtering out extraneous notifications by only applying updates to uris already in the document store. I *believe* this should cover all imported files, but I'm not 100% confident.

- Reading the entire file seems pretty expensive for every update, but it looks like the notification doesn't include any edit information. Maybe there's a smarter way around this?

- I wasn't sure if it was more better to use the document store's `refreshDocument` method in the `.Changed` case. The logic between `.Created` and `.Changed` would still be almost identical, except that `refreshDocument` takes a null terminated slice, and requires allocation via the document store. 

- `openDocument` is marked as not thread safe. If this is to be used in the `.Changed` case, should some additional checks/ locking be added at the call site?

- I wasn't sure how to add tests for this. 

Closes #2160