### PR TITLE
feat(lsp): remove unused and duplicated imports in `organize @imports` code action

### DIFF
--- a/tests/lsp_features/code_actions.zig
+++ b/tests/lsp_features/code_actions.zig
@@ -841,6 +841,9 @@ fn testAutofix(before: []const u8, after: []const u8) !void {
 fn testOrganizeImports(before: []const u8, after: []const u8) !void {
     try testDiagnostic(before, after, .{ .filter_kind = .@"source.organizeImports", .filter_title = "organize @import" });
 }
+
+fn testCleanImports(before: []const u8, after: []const u8) !void {
+    try testDiagnostic(before, after, .{ .filter_kind = .@"source.organizeImports", .filter_title = "remove unused @import" });
 }
 
 fn testConvertString(before: []const u8, after: []const u8) !void {

--- a/tests/lsp_features/code_actions.zig
+++ b/tests/lsp_features/code_actions.zig
@@ -839,7 +839,8 @@ fn testAutofix(before: []const u8, after: []const u8) !void {
 }
 
 fn testOrganizeImports(before: []const u8, after: []const u8) !void {
-    try testDiagnostic(before, after, .{ .filter_kind = .@"source.organizeImports" });
+    try testDiagnostic(before, after, .{ .filter_kind = .@"source.organizeImports", .filter_title = "organize @import" });
+}
 }
 
 fn testConvertString(before: []const u8, after: []const u8) !void {

--- a/tests/lsp_features/code_actions.zig
+++ b/tests/lsp_features/code_actions.zig
@@ -645,6 +645,103 @@ test "organize imports - edge cases" {
     );
 }
 
+test "organize imports - duplicates" {
+    try testOrganizeImports(
+        \\const std = @import("std");
+        \\const std = @import("std");
+        \\
+        \\fn foo() void { _ = std; }
+    ,
+        \\const std = @import("std");
+        \\
+        \\fn foo() void { _ = std; }
+    );
+    try testOrganizeImports(
+        \\const abc = @import("abc.zig");
+        \\const xyz = @import("xyz.zig");
+        \\const xyz = @import("xyz.zig");
+        \\const abc = @import("abc.zig");
+        \\const xyz = @import("xyz.zig");
+        \\
+        \\fn foo() void {
+        \\    _ = xyz;
+        \\    _ = abc;
+        \\}
+    ,
+        \\const abc = @import("abc.zig");
+        \\const xyz = @import("xyz.zig");
+        \\
+        \\fn foo() void {
+        \\    _ = xyz;
+        \\    _ = abc;
+        \\}
+    );
+    try testOrganizeImports(
+        \\const abc = @import("abc.zig");
+        \\const std = @import("std");
+        \\const abc = @import("abc.zig");
+        \\
+        \\fn foo() void {
+        \\    _ = std;
+        \\    _ = abc;
+        \\}
+    ,
+        \\const std = @import("std");
+        \\
+        \\const abc = @import("abc.zig");
+        \\
+        \\fn foo() void {
+        \\    _ = std;
+        \\    _ = abc;
+        \\}
+    );
+}
+
+test "organize imports - unused" {
+    try testCleanImports(
+        \\const std = @import("std");
+        \\const mem = std.mem;
+        \\const abc = @import("abc.zig");
+    ,
+        \\const std = @import("std");
+        \\
+        \\
+    );
+    // pub decls are preserved
+    try testCleanImports(
+        \\const std = @import("std");
+        \\pub const mem = std.mem;
+        \\const abc = @import("abc.zig");
+    ,
+        \\const std = @import("std");
+        \\pub const mem = std.mem;
+        \\
+        \\
+    );
+    try testCleanImports(
+        \\const abc = @import("abc.zig");
+        \\pub const abc = @import("abc.zig");
+    ,
+        \\pub const abc = @import("abc.zig");
+        \\
+        \\
+    );
+    try testCleanImports(
+        \\const foo = @import("std").foo;
+        \\const bar = @import("bar").bar;
+        \\
+        \\fn main() void {
+        \\    foo();
+        \\}
+    ,
+        \\const foo = @import("std").foo;
+        \\
+        \\fn main() void {
+        \\    foo();
+        \\}
+    );
+}
+
 test "convert multiline string literal" {
     try testConvertString(
         \\const foo = \\Hell<cursor>o

--- a/tests/lsp_features/code_actions.zig
+++ b/tests/lsp_features/code_actions.zig
@@ -548,26 +548,29 @@ test "organize imports - comments" {
     );
 }
 
+// Field accesses are limited to imports of the always available "std" and "builtin".
+// If field accesses are made to nonexistent files, the test runner returns an error
+// regardless of the code action's success.
 test "organize imports - field access" {
     // field access on import
     try testOrganizeImports(
-        \\const xyz = @import("xyz.zig").a.long.chain;
-        \\const abc = @import("abc.zig");
+        \\const builtin = @import("builtin").a.long.chain;
+        \\const std = @import("std");
     ,
-        \\const abc = @import("abc.zig");
-        \\const xyz = @import("xyz.zig").a.long.chain;
+        \\const std = @import("std");
+        \\const builtin = @import("builtin").a.long.chain;
         \\
         \\
     );
     // declarations without @import move under the parent import
     try testOrganizeImports(
-        \\const xyz = @import("xyz.zig").a.long.chain;
-        \\const abc = @import("abc.zig");
-        \\const abc_related = abc.related;
+        \\const builtin = @import("builtin").a.long.chain;
+        \\const std = @import("std");
+        \\const std_related = std.related;
     ,
-        \\const abc = @import("abc.zig");
-        \\const abc_related = abc.related;
-        \\const xyz = @import("xyz.zig").a.long.chain;
+        \\const std = @import("std");
+        \\const std_related = std.related;
+        \\const builtin = @import("builtin").a.long.chain;
         \\
         \\
     );
@@ -585,7 +588,7 @@ test "organize imports - field access" {
     );
     // Inverse chain of parents
     try testOrganizeImports(
-        \\const abc = @import("abc.zig");
+        \\const builtin = @import("builtin");
         \\const isLower = ascii.isLower;
         \\const ascii = std.ascii;
         \\const std = @import("std");
@@ -593,24 +596,23 @@ test "organize imports - field access" {
         \\const std = @import("std");
         \\const ascii = std.ascii;
         \\const isLower = ascii.isLower;
-        \\
-        \\const abc = @import("abc.zig");
+        \\const builtin = @import("builtin");
         \\
         \\
     );
     // Parent chains are not mixed
     try testOrganizeImports(
-        \\const xyz = @import("xyz.zig");
-        \\const abc = @import("abc.zig");
-        \\const xyz_related = xyz.related;
+        \\const builtin = @import("builtin");
+        \\const std = @import("std");
+        \\const builtin_related = builtin.related;
         \\/// comment
-        \\const abc_related = abc.related;
+        \\const std_related = std.related;
     ,
-        \\const abc = @import("abc.zig");
+        \\const std = @import("std");
         \\/// comment
-        \\const abc_related = abc.related;
-        \\const xyz = @import("xyz.zig");
-        \\const xyz_related = xyz.related;
+        \\const std_related = std.related;
+        \\const builtin = @import("builtin");
+        \\const builtin_related = builtin.related;
         \\
         \\
     );
@@ -635,7 +637,6 @@ test "organize imports - edge cases" {
         \\const abc = @import("abc.zig");
         \\const std = @import("std");
     ,
-        \\const std = @import("std");
         \\const std = @import("std");
         \\
         \\const abc = @import("abc.zig");


### PR DESCRIPTION
This PR augments the existing `organize @imports` code action to do the following:

- Remove duplicate imports (e.g. if `const foo = @import("foo.zig");` is repeated)
- Remove unused imports
    - I did this by constructing a references request on the import decl. If no references are found, the import is marked to be removed. This rule is ignored if the import is marked with `pub`.

This required modifications to most of the existing tests for the code action, as nearly all imports were unused and thus removed. I avoided this by adding marking all imports in the existing tests with `pub`. Another option was to create a function in which the import is discard (e.g. `fn foo() void { _ = foo; }`). I used this for most of the new tests, but it seemed fairly invasive to apply to all of the existing tests.

Closes #2240