### PR TITLE
Fix position context of enum/decl literal after break label

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -4115,7 +4115,7 @@ pub fn getPositionContext(
                 else => {},
             },
             .period, .period_asterisk => switch (curr_ctx.ctx) {
-                .empty => curr_ctx.ctx = .{ .enum_literal = tok.loc },
+                .empty, .label_access => curr_ctx.ctx = .{ .enum_literal = tok.loc },
                 .enum_literal => curr_ctx.ctx = .empty,
                 .keyword => curr_ctx.ctx = .other, // no keyword can be `.`/`.*` accessed
                 .comment, .other, .field_access, .global_error_set => {},

--- a/tests/utility/position_context.zig
+++ b/tests/utility/position_context.zig
@@ -428,6 +428,15 @@ test "enum literal" {
     , .enum_literal, .{});
 }
 
+test "enum literal after break label" {
+    try testContext(
+        \\break :blk <loc>.<cursor>foo</loc>;
+    , .enum_literal, .{ .lookahead = true });
+    try testContext(
+        \\break :blk <loc>.foo<cursor></loc>;
+    , .enum_literal, .{});
+}
+
 test "label access" {
     try testContext(
         \\var foo = blk: { break :<loc><cursor>blk</loc> null };


### PR DESCRIPTION
Related: #2162