### PR TITLE
fix null value crash in analysis.zig

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -1643,7 +1643,7 @@ fn resolveTypeOfNodeUncached(analyser: *Analyser, node_handle: NodeWithHandle) e
                 const ptyp = try analyser.arena.allocator().create(Type);
                 ptyp.* = argument_type;
 
-                const symbol = offsets.identifierTokenToNameSlice(func_tree, param.name_token.?);
+                const symbol = if (param.name_token) |name_token| offsets.identifierTokenToNameSlice(func_tree, name_token) else "";
                 meta_params.appendAssumeCapacity(.{ .index = param_index, .symbol = symbol, .typ = ptyp });
             }
 

--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -422,6 +422,14 @@ test "recursive generic function" {
     , &.{});
 }
 
+test "generic function without body" {
+    try testCompletion(
+        \\const Foo: fn (type) type = undefined;
+        \\const Bar = Foo(u32);
+        \\const value = Bar.<cursor>;
+    , &.{});
+}
+
 test "std.ArrayList" {
     if (!std.process.can_spawn) return error.SkipZigTest;
     try testCompletion(


### PR DESCRIPTION
```zig
fn bar(_: type) void {}
// crash doesn't occur if the return type's paramater has a name. for example: fn foo() fn(_: type) void { ... }
fn foo() fn(type) void {
    return bar;
}
const foobar = foo();
// crash occurs only if the result is assigned to a declaration.
const crash = foobar(u69);
```

This file results in a null value being used crashing zls. I added a null check for `param.name_token` to prevent that.