### PR TITLE
Fix alignment specs for Zig 0.15.0-dev.369

### DIFF
--- a/src/DocumentStore.zig
+++ b/src/DocumentStore.zig
@@ -677,7 +677,7 @@ pub fn getOrLoadHandle(self: *DocumentStore, uri: Uri) ?*Handle {
         file_path,
         max_document_size,
         null,
-        @alignOf(u8),
+        std.mem.Alignment.of(u8),
         0,
     ) catch |err| {
         log.err("failed to read document '{s}': {}", .{ file_path, err });

--- a/src/build_runner/shared.zig
+++ b/src/build_runner/shared.zig
@@ -91,7 +91,7 @@ pub const Transport = struct {
         comptime T: type,
         len: usize,
     ) (std.mem.Allocator.Error || std.fs.File.ReadError || error{EndOfStream})![]T {
-        const bytes = try allocator.alignedAlloc(u8, @alignOf(T), len * @sizeOf(T));
+        const bytes = try allocator.alignedAlloc(u8, std.mem.Alignment.of(T), len * @sizeOf(T));
         errdefer allocator.free(bytes);
         const amt = try transport.reader().readAll(bytes);
         if (amt != len * @sizeOf(T)) return error.EndOfStream;


### PR DESCRIPTION
Attempting to build `zls` with Zig `0.15.0-dev.369` (that being the latest release up on https://ziglang.org/download/ today) was failing because of a few changes where functions in `std` were expecting `std.mem.Alignment.of` instead of alignments specified as `comptime int`s.

I fixed it so the project builds with this nightly. Here is the two-line patch.

I was not able to determine, exactly, which upstream `zig` PR changed is API in `std` but this might be of relevance:

- https://github.com/ziglang/zig/issues/23548
