### PR TITLE
More result location types

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -5346,6 +5346,26 @@ pub fn resolveExpressionTypeFromAncestors(
             );
         },
 
+        .builtin_call,
+        .builtin_call_comma,
+        .builtin_call_two,
+        .builtin_call_two_comma,
+        => {
+            var buffer: [2]Ast.Node.Index = undefined;
+            const params = tree.builtinCallParams(&buffer, ancestors[0]).?;
+            const call_name = tree.tokenSlice(tree.nodeMainToken(ancestors[0]));
+
+            if (std.mem.eql(u8, call_name, "@as")) {
+                if (params.len != 2) return null;
+                if (params[1] != node) return null;
+                const ty = try analyser.resolveTypeOfNode(.{
+                    .node = params[0],
+                    .handle = handle,
+                }) orelse return null;
+                return ty.instanceTypeVal(analyser);
+            }
+        },
+
         else => {}, // TODO: Implement more expressions; better safe than sorry
     }
 

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -5377,6 +5377,17 @@ pub fn resolveExpressionTypeFromAncestors(
             }
         },
 
+        .@"catch" => {
+            const lhs, const rhs = tree.nodeData(ancestors[0]).node_and_node;
+            if (node == rhs) {
+                const lhs_ty = try analyser.resolveTypeOfNode(.{
+                    .node = lhs,
+                    .handle = handle,
+                }) orelse return null;
+                return try analyser.resolveUnwrapErrorUnionType(lhs_ty, .payload);
+            }
+        },
+
         else => {}, // TODO: Implement more expressions; better safe than sorry
     }
 

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -5366,6 +5366,17 @@ pub fn resolveExpressionTypeFromAncestors(
             }
         },
 
+        .@"orelse" => {
+            const lhs, const rhs = tree.nodeData(ancestors[0]).node_and_node;
+            if (node == rhs) {
+                const lhs_ty = try analyser.resolveTypeOfNode(.{
+                    .node = lhs,
+                    .handle = handle,
+                }) orelse return null;
+                return try analyser.resolveOptionalUnwrap(lhs_ty);
+            }
+        },
+
         else => {}, // TODO: Implement more expressions; better safe than sorry
     }
 

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -5335,7 +5335,10 @@ pub fn resolveExpressionTypeFromAncestors(
                 ancestors[index + 1 ..],
             );
         },
-        .@"try" => {
+
+        .grouped_expression,
+        .@"try",
+        => {
             return try analyser.resolveExpressionType(
                 handle,
                 ancestors[0],

--- a/tests/analysis/result_location_type.zig
+++ b/tests/analysis/result_location_type.zig
@@ -253,3 +253,10 @@ test "try" {
 
 const builtin_as = @as(StructType, .{ .foo = 1 });
 //                                    ^^^^ (u32)()
+
+//
+// orelse
+//
+
+const @"orelse" = some_optional orelse .{ .foo = 1 };
+//                                        ^^^^ (u32)()

--- a/tests/analysis/result_location_type.zig
+++ b/tests/analysis/result_location_type.zig
@@ -260,3 +260,10 @@ const builtin_as = @as(StructType, .{ .foo = 1 });
 
 const @"orelse" = some_optional orelse .{ .foo = 1 };
 //                                        ^^^^ (u32)()
+
+//
+// catch
+//
+
+const @"catch" = some_error_union catch .{ .foo = 1 };
+//                                         ^^^^ (u32)()

--- a/tests/analysis/result_location_type.zig
+++ b/tests/analysis/result_location_type.zig
@@ -246,3 +246,10 @@ test "try" {
     //                        ^^^^^^^^^^^^ (fn () !StructType)()
     _ = s;
 }
+
+//
+// builtin_call
+//
+
+const builtin_as = @as(StructType, .{ .foo = 1 });
+//                                    ^^^^ (u32)()

--- a/tests/analysis/result_location_type.zig
+++ b/tests/analysis/result_location_type.zig
@@ -231,6 +231,13 @@ const break_block: StructType =
     };
 
 //
+// grouped_expression
+//
+
+const grouped_expression: StructType = (.{ .foo = 1 });
+//                                         ^^^^ (u32)()
+
+//
 // try
 //
 


### PR DESCRIPTION
```zig
const grouped_expression: StructType = (.{ .foo = 1 });
//                                         ^^^^ (u32)()

const @"orelse" = some_optional orelse .{ .foo = 1 };
//                                        ^^^^ (u32)()

const @"catch" = some_error_union catch .{ .foo = 1 };
//                                         ^^^^ (u32)()
```