### PR TITLE
Fix various resolved types of const pointers

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -2664,6 +2664,31 @@ fn resolveMutability(analyser: *Analyser, node_handle: NodeWithHandle) error{Out
                 return .@"var";
         },
 
+        .field_access => {
+            const lhs_node, const field_name = tree.nodeData(node_handle.node).node_and_token;
+
+            const lhs_handle: NodeWithHandle = .{
+                .node = lhs_node,
+                .handle = handle,
+            };
+
+            const lhs = try analyser.resolveTypeOfNodeInternal(lhs_handle) orelse
+                return null;
+
+            const symbol = offsets.identifierTokenToNameSlice(tree, field_name);
+
+            if (!lhs.is_type_val)
+                return try analyser.resolveMutability(lhs_handle);
+
+            const decl = try lhs.lookupSymbol(analyser, symbol) orelse
+                return null;
+
+            if (decl.isConst())
+                return .@"const"
+            else
+                return .@"var";
+        },
+
         else => {}, // TODO: Implement more expressions; better safe than sorry
     }
 

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -2718,6 +2718,17 @@ fn resolveMutability(analyser: *Analyser, node_handle: NodeWithHandle) error{Out
         .error_value,
         => return .@"const",
 
+        .builtin_call,
+        .builtin_call_comma,
+        .builtin_call_two,
+        .builtin_call_two_comma,
+        => {
+            const call_name = tree.tokenSlice(tree.nodeMainToken(node));
+
+            if (std.mem.eql(u8, call_name, "@as"))
+                return .@"const";
+        },
+
         else => {}, // TODO: Implement more expressions; better safe than sorry
     }
 

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -2698,6 +2698,26 @@ fn resolveMutability(analyser: *Analyser, node_handle: NodeWithHandle) error{Out
                 return .@"var";
         },
 
+        .array_init_one,
+        .array_init_one_comma,
+        .array_init_dot_two,
+        .array_init_dot_two_comma,
+        .array_init_dot,
+        .array_init_dot_comma,
+        .array_init,
+        .array_init_comma,
+
+        .array_mult,
+        .array_cat,
+
+        .char_literal,
+        .number_literal,
+        .enum_literal,
+        .string_literal,
+        .multiline_string_literal,
+        .error_value,
+        => return .@"const",
+
         else => {}, // TODO: Implement more expressions; better safe than sorry
     }
 

--- a/src/features/semantic_tokens.zig
+++ b/src/features/semantic_tokens.zig
@@ -866,12 +866,12 @@ fn writeNodeTokens(builder: *Builder, node: Ast.Node.Index) error{OutOfMemory}!v
                     .simple_var_decl,
                     => {
                         const var_decl = tree.fullVarDecl(lhs_node).?;
-                        const field_type = if (resolved_type) |ty| try builder.analyser.resolveBracketAccessType(ty, .{ .single = index }) else null;
+                        const field_type = if (resolved_type) |ty| try builder.analyser.resolveBracketAccessType(.@"var", ty, .{ .single = index }) else null;
                         try writeVarDecl(builder, var_decl, field_type);
                     },
                     .identifier => {
                         const name_token = tree.nodeMainToken(lhs_node);
-                        const maybe_type = if (resolved_type) |ty| try builder.analyser.resolveBracketAccessType(ty, .{ .single = index }) else null;
+                        const maybe_type = if (resolved_type) |ty| try builder.analyser.resolveBracketAccessType(.@"var", ty, .{ .single = index }) else null;
                         const ty = maybe_type orelse {
                             try writeIdentifier(builder, name_token);
                             continue;

--- a/tests/analysis/address_of.zig
+++ b/tests/analysis/address_of.zig
@@ -1,0 +1,13 @@
+const StructType = struct {
+    foo: i32,
+};
+
+const some_struct: StructType = .{ .foo = 1 };
+
+var mutable_struct: StructType = .{ .foo = 1 };
+
+const some_struct_pointer = &some_struct;
+//    ^^^^^^^^^^^^^^^^^^^ (*const StructType)()
+
+const mutable_struct_pointer = &mutable_struct;
+//    ^^^^^^^^^^^^^^^^^^^^^^ (*StructType)()

--- a/tests/analysis/address_of.zig
+++ b/tests/analysis/address_of.zig
@@ -20,6 +20,12 @@ const multiline_string_literal_pointer = &
 const error_value_pointer = &error.Foo;
 //    ^^^^^^^^^^^^^^^^^^^ (*const error{Foo})()
 
+const builtin_as_0 = &@as(i32, 0);
+//    ^^^^^^^^^^^^ (*const i32)()
+
+const builtin_as_1 = &@as(StructType, mutable_struct);
+//    ^^^^^^^^^^^^ (*const StructType)()
+
 const StructType = struct {
     foo: i32,
     const const_decl: bool = true;

--- a/tests/analysis/address_of.zig
+++ b/tests/analysis/address_of.zig
@@ -1,5 +1,25 @@
 const StructType = struct {
     foo: i32,
+    const const_decl: bool = true;
+    var var_decl: bool = false;
+};
+
+const UnionType = union {
+    foo: i32,
+    const const_decl: bool = true;
+    var var_decl: bool = false;
+};
+
+const EnumType = enum {
+    foo,
+    const const_decl: bool = true;
+    var var_decl: bool = false;
+};
+
+const TaggedUnionType = union(EnumType) {
+    foo: i32,
+    const const_decl: bool = true;
+    var var_decl: bool = false;
 };
 
 const some_struct: StructType = .{ .foo = 1 };
@@ -11,3 +31,45 @@ const some_struct_pointer = &some_struct;
 
 const mutable_struct_pointer = &mutable_struct;
 //    ^^^^^^^^^^^^^^^^^^^^^^ (*StructType)()
+
+const some_field_pointer = &some_struct.foo;
+//    ^^^^^^^^^^^^^^^^^^ (*const i32)()
+
+const mutable_field_pointer = &mutable_struct.foo;
+//    ^^^^^^^^^^^^^^^^^^^^^ (*i32)()
+
+const struct_field_pointer = &StructType.foo;
+//    ^^^^^^^^^^^^^^^^^^^^ (unknown)()
+
+const struct_const_decl_pointer = &StructType.const_decl;
+//    ^^^^^^^^^^^^^^^^^^^^^^^^^ (*const bool)()
+
+const struct_var_decl_pointer = &StructType.var_decl;
+//    ^^^^^^^^^^^^^^^^^^^^^^^ (*bool)()
+
+const union_field_pointer = &UnionType.foo;
+//    ^^^^^^^^^^^^^^^^^^^ (unknown)()
+
+const union_const_decl_pointer = &UnionType.const_decl;
+//    ^^^^^^^^^^^^^^^^^^^^^^^^ (*const bool)()
+
+const union_var_decl_pointer = &UnionType.var_decl;
+//    ^^^^^^^^^^^^^^^^^^^^^^ (*bool)()
+
+const enum_value_pointer = &EnumType.foo;
+//    ^^^^^^^^^^^^^^^^^^ (*const EnumType)()
+
+const enum_const_decl_pointer = &EnumType.const_decl;
+//    ^^^^^^^^^^^^^^^^^^^^^^^ (*const bool)()
+
+const enum_var_decl_pointer = &EnumType.var_decl;
+//    ^^^^^^^^^^^^^^^^^^^^^ (*bool)()
+
+const tagged_union_tag_pointer = &TaggedUnionType.foo;
+//    ^^^^^^^^^^^^^^^^^^^^^^^^ (*const EnumType)()
+
+const tagged_union_const_decl_pointer = &TaggedUnionType.const_decl;
+//    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (*const bool)()
+
+const tagged_union_var_decl_pointer = &TaggedUnionType.var_decl;
+//    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (*bool)()

--- a/tests/analysis/address_of.zig
+++ b/tests/analysis/address_of.zig
@@ -1,3 +1,25 @@
+const char_literal_pointer = &'a';
+//    ^^^^^^^^^^^^^^^^^^^^ (*const comptime_int)()
+
+const int_literal_pointer = &0;
+//    ^^^^^^^^^^^^^^^^^^^ (*const comptime_int)()
+
+const enum_literal_pointer = &.foo;
+//    ^^^^^^^^^^^^^^^^^^^^ (*const @TypeOf(.enum_literal))()
+
+const string_literal_pointer = &"foo";
+//    ^^^^^^^^^^^^^^^^^^^^^^ (*const *const [3:0]u8)()
+
+// zig fmt: off
+const multiline_string_literal_pointer = &
+//    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (*const *const [3:0]u8)()
+    \\foo
+;
+// zig fmt: on
+
+const error_value_pointer = &error.Foo;
+//    ^^^^^^^^^^^^^^^^^^^ (*const error{Foo})()
+
 const StructType = struct {
     foo: i32,
     const const_decl: bool = true;

--- a/tests/analysis/array.zig
+++ b/tests/analysis/array.zig
@@ -27,42 +27,37 @@ const some_unsized_array_len = some_unsized_array.len;
 const array_indexing = some_array[0];
 //    ^^^^^^^^^^^^^^ (u8)()
 
-// TODO this should be `*const [2]u8`
 const array_slice_open_1 = some_array[1..];
-//    ^^^^^^^^^^^^^^^^^^ (*[2]u8)()
+//    ^^^^^^^^^^^^^^^^^^ (*const [2]u8)()
 
-// TODO this should be `*const [0]u8`
 const array_slice_open_3 = some_array[3..];
-//    ^^^^^^^^^^^^^^^^^^ (*[0]u8)()
+//    ^^^^^^^^^^^^^^^^^^ (*const [0]u8)()
 
-// TODO this should be `*const [?]u8`
 const array_slice_open_4 = some_array[4..];
-//    ^^^^^^^^^^^^^^^^^^ (*[?]u8)()
+//    ^^^^^^^^^^^^^^^^^^ (*const [?]u8)()
 
 const array_slice_open_runtime = some_array[runtime_index..];
-//    ^^^^^^^^^^^^^^^^^^^^^^^^ ([]u8)()
+//    ^^^^^^^^^^^^^^^^^^^^^^^^ ([]const u8)()
 
-// TODO this should be `*const [2]u8`
 const array_slice_0_2 = some_array[0..2];
-//    ^^^^^^^^^^^^^^^ (*[2]u8)()
+//    ^^^^^^^^^^^^^^^ (*const [2]u8)()
 
 // TODO this should be `*const [2 :0]u8`
 const array_slice_0_2_sentinel = some_array[0..2 :0];
-// TODO   ^^^^^^^^^^^^^^^ ([:0]u8)()
+//    ^^^^^^^^^^^^^^^^^^^^^^^^ (*const [2]u8)()
 
-// TODO this should be `*const [?]u8`
 const array_slice_0_5 = some_array[0..5];
-//    ^^^^^^^^^^^^^^^ (*[?]u8)()
+//    ^^^^^^^^^^^^^^^ (*const [?]u8)()
 
-// TODO this should be `*const [?]u8`
 const array_slice_3_2 = some_array[3..2];
-//    ^^^^^^^^^^^^^^^ (*[?]u8)()
+//    ^^^^^^^^^^^^^^^ (*const [?]u8)()
 
 const array_slice_0_runtime = some_array[0..runtime_index];
-//    ^^^^^^^^^^^^^^^^^^^^^ ([]u8)()
+//    ^^^^^^^^^^^^^^^^^^^^^ ([]const u8)()
 
+// TODO this should be `[:0]const u8`
 const array_slice_with_sentinel = some_array[0..runtime_index :0];
-// TODO   ^^^^^^^^^^^^^^^^^^^^^^^^^ ([:0]u8)()
+//    ^^^^^^^^^^^^^^^^^^^^^^^^^ ([]const u8)()
 
 //
 // Array init

--- a/tests/analysis/array.zig
+++ b/tests/analysis/array.zig
@@ -15,6 +15,9 @@ var runtime_index: usize = 5;
 const some_array: [length]u8 = undefined;
 //    ^^^^^^^^^^ ([3]u8)()
 
+const some_array_pointer = &[3]u8{ 1, 2, 3 };
+//    ^^^^^^^^^^^^^^^^^^ (*const [3]u8)()
+
 const some_unsized_array: [unknown_length]u8 = undefined;
 //    ^^^^^^^^^^^^^^^^^^ ([?]u8)()
 
@@ -86,9 +89,8 @@ const array_cat_2 = [_]u8{0} ++ [1]u8{1};
 const array_cat_3 = [1]u8{0} ++ [1]u8{1};
 //    ^^^^^^^^^^^ ([2]u8)()
 
-// TODO this should be `*const [5]u8`
 const array_cat_4 = &[2]u8{ 0, 1 } ++ &[3]u8{ 2, 3, 4 };
-//    ^^^^^^^^^^^ (*[5]u8)()
+//    ^^^^^^^^^^^ (*const [5]u8)()
 
 //
 // Array multiplication
@@ -100,9 +102,8 @@ const array_mult_0 = [_]u8{0} ** 2;
 const array_mult_1 = [1]u8{0} ** 2;
 //    ^^^^^^^^^^^^ ([2]u8)()
 
-// TODO this should be `*const [6]u8`
 const array_mult_2 = &[3]u8{ 0, 1, 2 } ** 2;
-//    ^^^^^^^^^^^^ (*[6]u8)()
+//    ^^^^^^^^^^^^ (*const [6]u8)()
 
 comptime {
     // Use @compileLog to verify the expected type with the compiler:

--- a/tests/analysis/sentinel_value.zig
+++ b/tests/analysis/sentinel_value.zig
@@ -7,13 +7,11 @@ const slice0: [:0]i1 = undefined;
 const slice1: [:42]u8 = undefined;
 //    ^^^^^^ ([:42]u8)()
 
-// TODO this should be `*const [2]u8`
 const slice2 = array[0..2];
-//    ^^^^^^ (*[2]u8)()
+//    ^^^^^^ (*const [2]u8)()
 
-// TODO this should be `*const [3:0]u8`
 const slice3 = array[1..];
-//    ^^^^^^ (*[3:0]u8)()
+//    ^^^^^^ (*const [3:0]u8)()
 
 const hw = "Hello, World!";
 //    ^^ (*const [13:0]u8)()

--- a/tests/lsp_features/inlay_hints.zig
+++ b/tests/lsp_features/inlay_hints.zig
@@ -243,7 +243,7 @@ test "var decl" {
         \\const foo<@TypeOf(undefined)> = undefined;
     , .{ .kind = .Type });
     try testInlayHints(
-        \\const foo<**const [3:0]u8> = &"Bar";
+        \\const foo<*const *const [3:0]u8> = &"Bar";
     , .{ .kind = .Type });
     try testInlayHints(
         \\const foo: *[]const u8 = &"Bar";

--- a/tests/lsp_features/inlay_hints.zig
+++ b/tests/lsp_features/inlay_hints.zig
@@ -247,7 +247,7 @@ test "var decl" {
     , .{ .kind = .Type });
     try testInlayHints(
         \\const foo: *[]const u8 = &"Bar";
-        \\const baz<**[]const u8> = &foo;
+        \\const baz<*const *[]const u8> = &foo;
     , .{ .kind = .Type });
     try testInlayHints(
         \\const Foo<type> = struct { bar: u32 };
@@ -256,7 +256,7 @@ test "var decl" {
         \\    const baz: ?Foo = Foo{ .bar<u32> = 42 };
         \\    if (baz) |b<Foo>| {
         \\        const d: Error!?Foo = b;
-        \\        const e<*error{e}!?Foo> = &d;
+        \\        const e<*const error{e}!?Foo> = &d;
         \\        const f<Foo> = (try e.*).?;
         \\        _ = f;
         \\    }
@@ -355,7 +355,7 @@ test "function alias" {
         \\) u32 {
         \\    return alpha;
         \\}
-        \\const bar<*fn (comptime alpha: u32) u32> = &foo;
+        \\const bar<*const fn (comptime alpha: u32) u32> = &foo;
     , .{ .kind = .Type });
 }
 


### PR DESCRIPTION
Notable addition: `resolveMutability` is similar to `resolveTypeOfNodeUncached` but returns `.@"var"`, `.@"const"`, or `null`, depending on whether the given AST node refers to a known variable/constant. (I went with an enum instead of a boolean for readability's sake, but I have no strong preference for one or the other.)