### PR TITLE
`@TypeOf(.enum_literal)` -> `@Type(.enum_literal)`

### DIFF
--- a/src/analyser/InternPool.zig
+++ b/src/analyser/InternPool.zig
@@ -3843,7 +3843,7 @@ fn printInternal(ip: *InternPool, ty: Index, writer: anytype, options: FormatOpt
             .null_type => try writer.writeAll("@TypeOf(null)"),
             .undefined_type => try writer.writeAll("@TypeOf(undefined)"),
             .empty_struct_type => try writer.writeAll("@TypeOf(.{})"),
-            .enum_literal_type => try writer.writeAll("@TypeOf(.enum_literal)"),
+            .enum_literal_type => try writer.writeAll("@Type(.enum_literal)"),
 
             .atomic_order => try writer.writeAll("std.builtin.AtomicOrder"),
             .atomic_rmw_op => try writer.writeAll("std.builtin.AtomicRmwOp"),
@@ -4128,7 +4128,7 @@ test "simple types" {
 
     try expectFmt("@TypeOf(null)", "{}", .{null_type.fmt(&ip)});
     try expectFmt("@TypeOf(undefined)", "{}", .{undefined_type.fmt(&ip)});
-    try expectFmt("@TypeOf(.enum_literal)", "{}", .{enum_literal_type.fmt(&ip)});
+    try expectFmt("@Type(.enum_literal)", "{}", .{enum_literal_type.fmt(&ip)});
 
     try expectFmt("undefined", "{}", .{undefined_value.fmt(&ip)});
     try expectFmt("{}", "{}", .{void_value.fmt(&ip)});

--- a/src/main.zig
+++ b/src/main.zig
@@ -46,7 +46,7 @@ var log_file: ?std.fs.File = null;
 
 fn logFn(
     comptime level: std.log.Level,
-    comptime scope: @TypeOf(.enum_literal),
+    comptime scope: @Type(.enum_literal),
     comptime format: []const u8,
     args: anytype,
 ) void {

--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -1643,7 +1643,7 @@ test "enum literal" {
         \\const literal = .foo;
         \\const foo = <cursor>
     , &.{
-        .{ .label = "literal", .kind = .EnumMember, .detail = "@TypeOf(.enum_literal)" },
+        .{ .label = "literal", .kind = .EnumMember, .detail = "@Type(.enum_literal)" },
     });
 }
 


### PR DESCRIPTION
Related: [Zig 0.14.0 Release Notes § std.builtin.Type Fields Renamed](https://ziglang.org/download/0.14.0/release-notes.html#stdbuiltinType-Fields-Renamed)

```zig
const std = @import("std");
pub fn main() void {
    std.debug.print("{}\n", .{@TypeOf(.foo)}); // => @Type(.enum_literal)
}
```