### PR TITLE
fix edge case with quoted identifier range detection

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -612,7 +612,7 @@ pub fn identifierLocFromIndex(tree: Ast, source_index: usize) ?offsets.Loc {
         => {
             const token_loc = offsets.tokenToLoc(tree, token);
             if (!(token_loc.start <= source_index and source_index <= token_loc.end)) return null;
-            return offsets.identifierIndexToNameLoc(tree.source, tree.tokenStart(token));
+            return offsets.identifierIndexToLoc(tree.source, tree.tokenStart(token), .name);
         },
         else => {},
     }
@@ -3670,7 +3670,7 @@ pub fn getFieldAccessType(
         switch (tok.tag) {
             .eof => return current_type,
             .identifier => {
-                const symbol_name = offsets.identifierIndexToNameSlice(tokenizer.buffer, tok.loc.start);
+                const symbol_name = offsets.identifierIndexToSlice(tokenizer.buffer, tok.loc.start, .name);
                 if (try analyser.lookupSymbolGlobal(
                     handle,
                     symbol_name,
@@ -3696,7 +3696,7 @@ pub fn getFieldAccessType(
                             return current_type;
                         }
 
-                        const symbol = offsets.identifierIndexToNameSlice(tokenizer.buffer, after_period.loc.start);
+                        const symbol = offsets.identifierIndexToSlice(tokenizer.buffer, after_period.loc.start, .name);
 
                         current_type = try analyser.resolveFieldAccess(current_type orelse return null, symbol) orelse return null;
                     },

--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -730,7 +730,7 @@ fn completeFileSystemStringLiteral(builder: *Builder, pos_context: Analyser.Posi
     var string_content_loc = pos_context.stringLiteralContentLoc(source);
 
     // the position context is without lookahead so we have to do it ourself
-    string_content_loc.end = std.mem.indexOfAnyPos(u8, source, string_content_loc.end, &.{ 0, '\n', '\r', '\"' }) orelse source.len;
+    string_content_loc.end = std.mem.indexOfAnyPos(u8, source, string_content_loc.end, &.{ 0, '\n', '\r', '"' }) orelse source.len;
 
     if (builder.source_index < string_content_loc.start or string_content_loc.end < builder.source_index) return;
 

--- a/src/tools/config_gen.zig
+++ b/src/tools/config_gen.zig
@@ -763,7 +763,7 @@ fn writeMarkdownFromHtmlInternal(html: []const u8, single_line: bool, depth: u32
         } else if (std.mem.eql(u8, tag_name, "a")) {
             const href_part = std.mem.trimLeft(u8, html[tag_start_index + 2 .. content_start - 1], " ");
             std.debug.assert(std.mem.startsWith(u8, href_part, "href=\""));
-            std.debug.assert(href_part[href_part.len - 1] == '\"');
+            std.debug.assert(href_part[href_part.len - 1] == '"');
             const url = href_part["href=\"".len .. href_part.len - 1];
             try writer.print("[{s}]({s})", .{ content, std.mem.trimLeft(u8, url, "@") });
         } else if (std.mem.eql(u8, tag_name, "code")) {

--- a/tests/lsp_features/semantic_tokens.zig
+++ b/tests/lsp_features/semantic_tokens.zig
@@ -313,6 +313,14 @@ test "escaped identifier" {
         .{ "=", .operator, .{} },
         .{ "3", .number, .{} },
     });
+    try testSemanticTokens(
+        \\var @"\"" = 3;
+    , &.{
+        .{ "var", .keyword, .{} },
+        .{ "@\"\\\"\"", .variable, .{ .declaration = true, .mutable = true } },
+        .{ "=", .operator, .{} },
+        .{ "3", .number, .{} },
+    });
 }
 
 test "operators" {


### PR DESCRIPTION
before the loc for something like `@"\""` would end at the `\"`

this ended up bigger than needed but it felt silly having effectively the same logic in 2 places and `identifierIndexToLoc` wasnt tested so i just merged it with `identifierIndexToNameLoc`, lmk if the changes should be separated :sweat_smile: 