### PR TITLE
Some improvements to hover text

### DIFF
--- a/src/features/hover.zig
+++ b/src/features/hover.zig
@@ -122,7 +122,7 @@ fn hoverSymbolResolved(
     markup_kind: types.MarkupKind,
     doc_strings: []const []const u8,
     def_str: []const u8,
-    resolved_type_str: ?[]const u8,
+    resolved_type_str: []const u8,
     referenced_types: []const Analyser.ReferencedType,
 ) error{OutOfMemory}![]const u8 {
     var hover_text: std.ArrayListUnmanaged(u8) = .empty;
@@ -130,9 +130,7 @@ fn hoverSymbolResolved(
     if (markup_kind == .markdown) {
         for (doc_strings) |doc|
             try writer.print("{s}\n\n", .{doc});
-        try writer.print("```zig\n{s}\n```", .{def_str});
-        if (resolved_type_str) |s|
-            try writer.print("\n```zig\n({s})\n```", .{s});
+        try writer.print("```zig\n{s}\n```\n```zig\n({s})\n```", .{ def_str, resolved_type_str });
         if (referenced_types.len > 0)
             try writer.print("\n\n" ++ "Go to ", .{});
         for (referenced_types, 0..) |ref, index| {
@@ -145,9 +143,7 @@ fn hoverSymbolResolved(
     } else {
         for (doc_strings) |doc|
             try writer.print("{s}\n\n", .{doc});
-        try writer.print("{s}", .{def_str});
-        if (resolved_type_str) |s|
-            try writer.print("\n({s})", .{s});
+        try writer.print("{s}\n({s})", .{ def_str, resolved_type_str });
     }
 
     return hover_text.items;

--- a/src/features/hover.zig
+++ b/src/features/hover.zig
@@ -36,12 +36,8 @@ fn hoverSymbolRecursive(
     const handle = decl_handle.handle;
     const tree = handle.tree;
 
-    var type_references: Analyser.ReferencedType.Set = .empty;
-    var reference_collector: Analyser.ReferencedType.Collector = .{ .referenced_types = &type_references };
     if (try decl_handle.docComments(arena)) |doc|
         try doc_strings.append(arena, doc);
-
-    var is_fn = false;
 
     const def_str = switch (decl_handle.decl) {
         .ast_node => |node| def: {
@@ -56,18 +52,6 @@ fn hoverSymbolRecursive(
                 .simple_var_decl,
                 => {
                     const var_decl = tree.fullVarDecl(node).?;
-                    const opt_type_node: ?Ast.Node.Index = blk: {
-                        if (var_decl.ast.type_node.unwrap()) |type_node| break :blk type_node;
-                        const init_node = var_decl.ast.init_node.unwrap() orelse break :blk null;
-                        var struct_init_buf: [2]Ast.Node.Index = undefined;
-                        const struct_init = tree.fullStructInit(&struct_init_buf, init_node) orelse break :blk null;
-                        break :blk struct_init.ast.type_expr.unwrap();
-                    };
-
-                    if (opt_type_node) |type_node| {
-                        try analyser.referencedTypesFromNode(.of(type_node, handle), &reference_collector);
-                    }
-
                     break :def try Analyser.getVariableSignature(arena, tree, var_decl, true);
                 },
                 .container_field,
@@ -75,12 +59,6 @@ fn hoverSymbolRecursive(
                 .container_field_align,
                 => {
                     const field = tree.fullContainerField(node).?;
-                    var converted = field;
-                    converted.convertToNonTupleLike(&tree);
-                    if (converted.ast.type_expr.unwrap()) |type_expr| {
-                        try analyser.referencedTypesFromNode(.of(type_expr, handle), &reference_collector);
-                    }
-
                     break :def Analyser.getContainerFieldSignature(tree, field) orelse return null;
                 },
                 .fn_proto,
@@ -89,7 +67,6 @@ fn hoverSymbolRecursive(
                 .fn_proto_simple,
                 .fn_decl,
                 => {
-                    is_fn = true;
                     var buf: [1]Ast.Node.Index = undefined;
                     const fn_proto = tree.fullFnProto(&buf, node).?;
                     break :def Analyser.getFunctionSignature(tree, fn_proto);
@@ -106,11 +83,6 @@ fn hoverSymbolRecursive(
         },
         .function_parameter => |pay| def: {
             const param = pay.get(tree).?;
-
-            if (param.type_expr) |type_expr| { // null for `anytype` and extern C varargs `...`
-                try analyser.referencedTypesFromNode(.of(type_expr, handle), &reference_collector);
-            }
-
             break :def ast.paramSlice(tree, param, false);
         },
         .optional_payload,
@@ -124,23 +96,23 @@ fn hoverSymbolRecursive(
         => tree.tokenSlice(decl_handle.nameToken()),
     };
 
+    var referenced: Analyser.ReferencedType.Set = .empty;
     var resolved_type_str: []const u8 = "unknown";
     if (try decl_handle.resolveType(analyser)) |resolved_type| {
         if (try resolved_type.docComments(arena)) |doc|
             try doc_strings.append(arena, doc);
-        try analyser.referencedTypes(
-            resolved_type,
-            &reference_collector,
-        );
-        resolved_type_str = try std.fmt.allocPrint(arena, "{}", .{resolved_type.fmt(analyser, .{ .truncate_container_decls = false })});
+        resolved_type_str = try std.fmt.allocPrint(arena, "{}", .{resolved_type.fmt(analyser, .{
+            .referenced = &referenced,
+            .truncate_container_decls = false,
+        })});
     }
-    const referenced_types: []const Analyser.ReferencedType = type_references.keys();
+    const referenced_types: []const Analyser.ReferencedType = referenced.keys();
     return try hoverSymbolResolved(
         arena,
         markup_kind,
         doc_strings.items,
         def_str,
-        if (is_fn) null else resolved_type_str,
+        resolved_type_str,
         referenced_types,
     );
 }

--- a/tests/lsp_features/hover.zig
+++ b/tests/lsp_features/hover.zig
@@ -326,6 +326,21 @@ test "struct" {
     );
 }
 
+test "root struct" {
+    try testHover(
+        \\const f<cursor>oo: @This() = .{};
+    ,
+        \\```zig
+        \\const foo: @This() = .{}
+        \\```
+        \\```zig
+        \\(test)
+        \\```
+        \\
+        \\Go to [test](file:///test.zig#L1)
+    );
+}
+
 test "decl literal" {
     try testHover(
         \\const S = struct {
@@ -361,6 +376,9 @@ test "decl literal function" {
         \\```zig
         \\fn foo() S
         \\```
+        \\```zig
+        \\(fn () S)
+        \\```
         \\
         \\Go to [S](file:///test.zig#L1)
     );
@@ -375,6 +393,9 @@ test "decl literal function" {
     ,
         \\```zig
         \\fn foo() !S
+        \\```
+        \\```zig
+        \\(fn () !S)
         \\```
         \\
         \\Go to [S](file:///test.zig#L1)
@@ -392,6 +413,9 @@ test "decl literal function" {
     ,
         \\```zig
         \\fn init() Inner
+        \\```
+        \\```zig
+        \\(fn () Inner)
         \\```
         \\
         \\Go to [Inner](file:///test.zig#L1)
@@ -417,7 +441,7 @@ test "decl literal on generic type" {
         \\(Box)
         \\```
         \\
-        \\Go to [@This()](file:///test.zig#L1)
+        \\Go to [Box](file:///test.zig#L1)
     );
 }
 
@@ -511,6 +535,28 @@ test "enum member" {
     );
 }
 
+test "generic type" {
+    try testHover(
+        \\const StructType = struct {};
+        \\const EnumType = enum {};
+        \\fn GenericType(A: type, B: type) type {
+        \\    _ = .{ A, B };
+        \\    return struct {};
+        \\}
+        \\const T = GenericType(StructType, EnumType);
+        \\const t<cursor>: T = .{};
+    ,
+        \\```zig
+        \\const t: T = .{}
+        \\```
+        \\```zig
+        \\(GenericType(StructType,EnumType))
+        \\```
+        \\
+        \\Go to [GenericType](file:///test.zig#L3) | [StructType](file:///test.zig#L1) | [EnumType](file:///test.zig#L2)
+    );
+}
+
 test "block label" {
     try testHover(
         \\const foo: i32 = undefined;
@@ -567,6 +613,9 @@ test "function" {
         \\```zig
         \\fn foo(a: A, b: B) E!C
         \\```
+        \\```zig
+        \\(fn (A, B) error{A,B}!C)
+        \\```
         \\
         \\Go to [A](file:///test.zig#L1) | [B](file:///test.zig#L2) | [C](file:///test.zig#L3)
     );
@@ -578,8 +627,22 @@ test "function" {
         \\```zig
         \\fn foo(a: S, b: S) E!S
         \\```
+        \\```zig
+        \\(fn (S, S) error{A,B}!S)
+        \\```
         \\
         \\Go to [S](file:///test.zig#L1)
+    );
+    try testHover(
+        \\const E = error { A, B, C };
+        \\fn f<cursor>oo() E!void {}
+    ,
+        \\```zig
+        \\fn foo() E!void
+        \\```
+        \\```zig
+        \\(fn () error{...}!void)
+        \\```
     );
     try testHover(
         \\fn foo(b<cursor>ar: enum { fizz, buzz }) void {}
@@ -597,6 +660,9 @@ test "function" {
         \\```zig
         \\fn foo() !i32
         \\```
+        \\```zig
+        \\(fn () !i32)
+        \\```
     );
     try testHover(
         \\extern fn f<cursor>oo(u32) void;
@@ -604,11 +670,15 @@ test "function" {
         \\```zig
         \\fn foo(u32) void
         \\```
+        \\```zig
+        \\(fn (u32) void)
+        \\```
     );
     try testHoverWithOptions(
         \\fn f<cursor>oo() i32 {}
     ,
         \\fn foo() i32
+        \\(fn () i32)
     , .{ .markup_kind = .plaintext });
 }
 
@@ -744,6 +814,9 @@ test "var decl alias" {
         \\```zig
         \\fn foo() void
         \\```
+        \\```zig
+        \\(fn () void)
+        \\```
     );
     try testHover(
         \\const foo = 5;
@@ -829,6 +902,9 @@ test "type reference cycle" {
         \\    alpha: anytype,
         \\    beta: @TypeOf(alpha),
         \\) void
+        \\```
+        \\```zig
+        \\(unknown)
         \\```
     );
 }

--- a/tests/lsp_features/hover.zig
+++ b/tests/lsp_features/hover.zig
@@ -904,7 +904,7 @@ test "type reference cycle" {
         \\) void
         \\```
         \\```zig
-        \\(unknown)
+        \\(fn (anytype, (unknown value)) void)
         \\```
     );
 }

--- a/tests/lsp_features/inlay_hints.zig
+++ b/tests/lsp_features/inlay_hints.zig
@@ -346,7 +346,7 @@ test "function alias" {
         \\fn foo(alpha: u32) void {
         \\    return alpha;
         \\}
-        \\const bar<fn (alpha: u32) void> = foo;
+        \\const bar<fn (u32) void> = foo;
     , .{ .kind = .Type });
     try testInlayHints(
         \\pub fn foo(
@@ -355,7 +355,7 @@ test "function alias" {
         \\) u32 {
         \\    return alpha;
         \\}
-        \\const bar<*fn (comptime alpha: u32) u32> = &foo;
+        \\const bar<*fn (comptime u32) u32> = &foo;
     , .{ .kind = .Type });
 }
 


### PR DESCRIPTION
- Turned off parameter names when printing function types, which is consistent with how they're normally printed via `std.fmt`
- Added the resolved type (in the parentheses) of a function when hovering over it, which makes the "Go to ..." part less confusing
  <img width="538" alt="Screenshot 2025-04-23 at 10 08 01 AM" src="https://github.com/user-attachments/assets/fb318d30-df58-431a-8f26-1b4dfd92d3f5" />
- Merged `Analyser.addReferencedTypes` with `Type.format`, which has pretty much the same logic but also handles generic types
  <img width="955" alt="Screenshot 2025-04-23 at 10 08 36 AM" src="https://github.com/user-attachments/assets/4ba346c2-4d90-4cf7-9723-173a4c210dc6" />
