### PR TITLE
Fix label in switch statement

### DIFF
--- a/src/features/semantic_tokens.zig
+++ b/src/features/semantic_tokens.zig
@@ -459,7 +459,10 @@ fn writeNodeTokens(builder: *Builder, node: Ast.Node.Index) error{OutOfMemory}!v
         .switch_comma,
         => {
             const switch_node = tree.fullSwitch(node).?;
-            try writeToken(builder, main_token, .keyword);
+            if (switch_node.label_token) |label_token| {
+                try writeTokenMod(builder, label_token, .label, .{ .declaration = true });
+            }
+            try writeToken(builder, switch_node.ast.switch_token, .keyword);
             try writeNodeTokens(builder, switch_node.ast.condition);
             for (switch_node.ast.cases) |case_node| {
                 try writeNodeTokens(builder, case_node);

--- a/tests/lsp_features/semantic_tokens.zig
+++ b/tests/lsp_features/semantic_tokens.zig
@@ -1707,6 +1707,29 @@ test "switch" {
         .{ "false", .keywordLiteral, .{} },
     });
     try testSemanticTokens(
+        \\const foo = sw: switch (3) {
+        \\    0 => continue :sw 1,
+        \\    1 => true,
+        \\    else => false,
+        \\};
+    , &.{
+        .{ "const", .keyword, .{} },
+        .{ "foo", .variable, .{ .declaration = true } },
+        .{ "=", .operator, .{} },
+        .{ "sw", .label, .{ .declaration = true } },
+        .{ "switch", .keyword, .{} },
+        .{ "3", .number, .{} },
+        .{ "0", .number, .{} },
+        .{ "continue", .keyword, .{} },
+        .{ "sw", .label, .{} },
+        .{ "1", .number, .{} },
+        .{ "1", .number, .{} },
+        .{ "true", .keywordLiteral, .{} },
+        .{ "else", .keyword, .{} },
+        .{ "false", .keywordLiteral, .{} },
+    });
+
+    try testSemanticTokens(
         \\const foo = switch (3) {
         \\    inline else => |*val| val,
         \\};


### PR DESCRIPTION
When a switch was preceded by a label, the `keyword` semantic token was being assigned to the label instead of the switch token, and the label was not receiving its appropriate semantic token.