### PR TITLE
Only unwrap instances of error union type

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -909,6 +909,8 @@ pub fn resolveAddressOf(analyser: *Analyser, ty: Type) error{OutOfMemory}!?Type 
 pub const ErrorUnionSide = enum { error_set, payload };
 
 pub fn resolveUnwrapErrorUnionType(analyser: *Analyser, ty: Type, side: ErrorUnionSide) error{OutOfMemory}!?Type {
+    if (ty.is_type_val) return null;
+
     return switch (ty.data) {
         .error_union => |info| switch (side) {
             .error_set => (info.error_set orelse return null).instanceTypeVal(analyser),

--- a/tests/analysis/array.zig
+++ b/tests/analysis/array.zig
@@ -3,6 +3,11 @@ const ArrayType = [3]u8;
 const ArrayTypeWithSentinel = [3:0]u8;
 //    ^^^^^^^^^^^^^^^^^^^^^ (type)([3:0]u8)
 
+const InvalidArrayTypeAccess0 = ArrayType[0];
+//    ^^^^^^^^^^^^^^^^^^^^^^^ (unknown)()
+const InvalidArrayTypeAccess1 = ArrayType[1];
+//    ^^^^^^^^^^^^^^^^^^^^^^^ (unknown)()
+
 const empty_array: [0]u8 = undefined;
 //    ^^^^^^^^^^^ ([0]u8)()
 const empty_array_len = empty_array.len;

--- a/tests/analysis/error_union.zig
+++ b/tests/analysis/error_union.zig
@@ -1,0 +1,8 @@
+const Error = error{ Foo, Bar };
+
+const ErrorUnionType = Error!u32;
+//    ^^^^^^^^^^^^^^ (type)()
+
+const InvalidErrorUnionTypeUnwrap = ErrorUnionType catch |err| err;
+//    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ (unknown)()
+//                                                        ^^^ (unknown)()

--- a/tests/analysis/optional.zig
+++ b/tests/analysis/optional.zig
@@ -1,3 +1,9 @@
+const OptionalType = ?u32;
+//    ^^^^^^^^^^^^ (type)()
+
+const InvalidOptionalTypeUnwrap = OptionalType.?;
+//    ^^^^^^^^^^^^^^^^^^^^^^^^^ (unknown)()
+
 const alpha: ?u32 = undefined;
 //    ^^^^^ (?u32)()
 

--- a/tests/analysis/pointer.zig
+++ b/tests/analysis/pointer.zig
@@ -1,3 +1,9 @@
+const PointerType = *u32;
+//    ^^^^^^^^^^^ (type)()
+
+const InvalidPointerTypeDeref = PointerType.*;
+//    ^^^^^^^^^^^^^^^^^^^^^^^ (unknown)()
+
 //
 // single item pointer *T
 //

--- a/tests/analysis/tuple.zig
+++ b/tests/analysis/tuple.zig
@@ -1,6 +1,11 @@
 const TupleType = struct { i64, f32 };
 //    ^^^^^^^^^ (type)(struct { i64, f32 })
 
+const InvalidTupleTypeAccess0 = TupleType[0];
+//    ^^^^^^^^^^^^^^^^^^^^^^^ (unknown)()
+const InvalidTupleTypeAccess1 = TupleType[1];
+//    ^^^^^^^^^^^^^^^^^^^^^^^ (unknown)()
+
 const some_tuple: struct { i64, f32 } = undefined;
 //    ^^^^^^^^^^ (struct { i64, f32 })()
 


### PR DESCRIPTION
```zig
const Error = error{ Foo, Bar };
const ErrorUnionType = Error!u32;
const InvalidErrorUnionTypeUnwrap = ErrorUnionType catch |err| err;
//    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ (unknown)()
//                                                        ^^^ (unknown)()
```