### PR TITLE
Improvements to how hover documentation is shown

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -131,12 +131,25 @@ pub fn collectDocComments(allocator: std.mem.Allocator, tree: Ast, doc_comments:
     var lines: std.ArrayListUnmanaged([]const u8) = .empty;
     defer lines.deinit(allocator);
 
+    var lines_start_with_space = true;
+
     var curr_line_tok = doc_comments;
     while (true) : (curr_line_tok += 1) {
         const comm = tree.tokenTag(curr_line_tok);
         if ((container_doc and comm == .container_doc_comment) or (!container_doc and comm == .doc_comment)) {
-            try lines.append(allocator, tree.tokenSlice(curr_line_tok)[3..]);
+            const line = tree.tokenSlice(curr_line_tok)[3..];
+            if (line.len > 1 and line[0] != ' ') lines_start_with_space = false;
+            try lines.append(allocator, line);
         } else break;
+    }
+
+    // If all of the lines that aren't empty start with a space, remove the first space
+    if (lines_start_with_space) {
+        for (lines.items, 0..) |line, i| {
+            if (line.len > 1 and line[0] == ' ') {
+                lines.items[i] = line[1..];
+            }
+        }
     }
 
     return try std.mem.join(allocator, "\n", lines.items);

--- a/src/features/hover.zig
+++ b/src/features/hover.zig
@@ -147,12 +147,19 @@ fn hoverSymbolResolved(
 
                 try writer.print("{s}\n", .{trimmed_line});
             }
-            try writer.print("\n", .{});
         }
     } else {
-        for (doc_strings) |doc|
-            try writer.print("{s}\n\n", .{doc});
         try writer.print("{s}\n({s})", .{ def_str, resolved_type_str });
+        if (doc_strings.len > 0) try writer.print("\n", .{});
+        for (doc_strings) |doc| {
+            // Better format the document string
+            var lines = std.mem.splitAny(u8, doc, "\n");
+            while (lines.next()) |line| {
+                const trimmed_line = std.mem.trimLeft(u8, line, " ");
+
+                try writer.print("{s}\n", .{trimmed_line});
+            }
+        }
     }
 
     return hover_text.items;

--- a/src/features/hover.zig
+++ b/src/features/hover.zig
@@ -156,8 +156,17 @@ fn hoverSymbolResolved(
     var hover_text: std.ArrayListUnmanaged(u8) = .empty;
     const writer = hover_text.writer(arena);
     if (markup_kind == .markdown) {
-        for (doc_strings) |doc|
-            try writer.print("{s}\n\n", .{doc});
+        for (doc_strings) |doc| {
+            // Better format the document string
+            var lines = std.mem.splitAny(u8, doc, "\n");
+            while (lines.next()) |line| {
+                const trimmed_line = std.mem.trimLeft(u8, line, " ");
+
+                try writer.print("{s}\n", .{trimmed_line});
+            }
+            try writer.print("\n", .{});
+        }
+        if (doc_strings.len > 0) try writer.print("---\n", .{});
         try writer.print("```zig\n{s}\n```", .{def_str});
         if (resolved_type_str) |s|
             try writer.print("\n```zig\n({s})\n```", .{s});

--- a/src/features/hover.zig
+++ b/src/features/hover.zig
@@ -128,22 +128,6 @@ fn hoverSymbolResolved(
     var hover_text: std.ArrayListUnmanaged(u8) = .empty;
     const writer = hover_text.writer(arena);
     if (markup_kind == .markdown) {
-        for (doc_strings) |doc| {
-            // Better format the document string
-            var lines = std.mem.splitAny(u8, doc, "\n");
-            while (lines.next()) |line| {
-                const trimmed_line = std.mem.trimLeft(u8, line, " ");
-
-                try writer.print("{s}\n", .{trimmed_line});
-            }
-            try writer.print("\n", .{});
-        }
-        if (doc_strings.len > 0) try writer.print("---\n", .{});
-        try writer.print("```zig\n{s}\n```", .{def_str});
-        if (resolved_type_str) |s|
-            try writer.print("\n```zig\n({s})\n```", .{s});
-        for (doc_strings) |doc|
-            try writer.print("{s}\n\n", .{doc});
         try writer.print("```zig\n{s}\n```\n```zig\n({s})\n```", .{ def_str, resolved_type_str });
         if (referenced_types.len > 0)
             try writer.print("\n\n" ++ "Go to ", .{});
@@ -153,6 +137,17 @@ fn hoverSymbolResolved(
             const source_index = ref.handle.tree.tokenStart(ref.token);
             const line = 1 + std.mem.count(u8, ref.handle.tree.source[0..source_index], "\n");
             try writer.print("[{s}]({s}#L{d})", .{ ref.str, ref.handle.uri, line });
+        }
+        if (doc_strings.len > 0) try writer.print("\n---\n", .{});
+        for (doc_strings) |doc| {
+            // Better format the document string
+            var lines = std.mem.splitAny(u8, doc, "\n");
+            while (lines.next()) |line| {
+                const trimmed_line = std.mem.trimLeft(u8, line, " ");
+
+                try writer.print("{s}\n", .{trimmed_line});
+            }
+            try writer.print("\n", .{});
         }
     } else {
         for (doc_strings) |doc|

--- a/src/features/hover.zig
+++ b/src/features/hover.zig
@@ -138,23 +138,15 @@ fn hoverSymbolResolved(
             const line = 1 + std.mem.count(u8, ref.handle.tree.source[0..source_index], "\n");
             try writer.print("[{s}]({s}#L{d})", .{ ref.str, ref.handle.uri, line });
         }
-
-        if (doc_strings.len > 0) {
-            try writer.writeAll("\n\n");
-            for (doc_strings, 0..) |doc, i| {
-                try writer.writeAll(doc);
-                if (i != doc_strings.len - 1) try writer.writeAll("\n\n");
-            }
-        }
     } else {
         try writer.print("{s}\n({s})", .{ def_str, resolved_type_str });
+    }
 
-        if (doc_strings.len > 0) {
-            try writer.writeAll("\n\n");
-            for (doc_strings, 0..) |doc, i| {
-                try writer.writeAll(doc);
-                if (i != doc_strings.len - 1) try writer.writeAll("\n\n");
-            }
+    if (doc_strings.len > 0) {
+        try writer.writeAll("\n\n");
+        for (doc_strings, 0..) |doc, i| {
+            try writer.writeAll(doc);
+            if (i != doc_strings.len - 1) try writer.writeAll("\n\n");
         }
     }
 

--- a/src/features/hover.zig
+++ b/src/features/hover.zig
@@ -139,14 +139,23 @@ fn hoverSymbolResolved(
             try writer.print("[{s}]({s}#L{d})", .{ ref.str, ref.handle.uri, line });
         }
 
-        try writer.print("\n", .{});
-        for (doc_strings) |doc|
-            try writer.print("{s}", .{doc});
+        if (doc_strings.len > 0) {
+            try writer.writeAll("\n\n");
+            for (doc_strings, 0..) |doc, i| {
+                try writer.writeAll(doc);
+                if (i != doc_strings.len - 1) try writer.writeAll("\n\n");
+            }
+        }
     } else {
         try writer.print("{s}\n({s})", .{ def_str, resolved_type_str });
-        try writer.print("\n", .{});
-        for (doc_strings) |doc|
-            try writer.print("{s}", .{doc});
+
+        if (doc_strings.len > 0) {
+            try writer.writeAll("\n\n");
+            for (doc_strings, 0..) |doc, i| {
+                try writer.writeAll(doc);
+                if (i != doc_strings.len - 1) try writer.writeAll("\n\n");
+            }
+        }
     }
 
     return hover_text.items;

--- a/src/features/hover.zig
+++ b/src/features/hover.zig
@@ -138,28 +138,15 @@ fn hoverSymbolResolved(
             const line = 1 + std.mem.count(u8, ref.handle.tree.source[0..source_index], "\n");
             try writer.print("[{s}]({s}#L{d})", .{ ref.str, ref.handle.uri, line });
         }
-        if (doc_strings.len > 0) try writer.print("\n---\n", .{});
-        for (doc_strings) |doc| {
-            // Better format the document string
-            var lines = std.mem.splitAny(u8, doc, "\n");
-            while (lines.next()) |line| {
-                const trimmed_line = std.mem.trimLeft(u8, line, " ");
 
-                try writer.print("{s}\n", .{trimmed_line});
-            }
-        }
+        try writer.print("\n", .{});
+        for (doc_strings) |doc|
+            try writer.print("{s}", .{doc});
     } else {
         try writer.print("{s}\n({s})", .{ def_str, resolved_type_str });
-        if (doc_strings.len > 0) try writer.print("\n", .{});
-        for (doc_strings) |doc| {
-            // Better format the document string
-            var lines = std.mem.splitAny(u8, doc, "\n");
-            while (lines.next()) |line| {
-                const trimmed_line = std.mem.trimLeft(u8, line, " ");
-
-                try writer.print("{s}\n", .{trimmed_line});
-            }
-        }
+        try writer.print("\n", .{});
+        for (doc_strings) |doc|
+            try writer.print("{s}", .{doc});
     }
 
     return hover_text.items;

--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -3167,9 +3167,9 @@ test "top-level doc comment" {
             .kind = .Struct,
             .detail = "type",
             .documentation =
-            \\ A
+            \\A
             \\
-            \\ B
+            \\B
             ,
         },
     });

--- a/tests/lsp_features/hover.zig
+++ b/tests/lsp_features/hover.zig
@@ -274,8 +274,6 @@ test "struct" {
         \\    };
         \\};
     ,
-        \\ Foo doc comment
-        \\
         \\```zig
         \\const FooStruct = struct {
         \\    bar: u32,
@@ -286,6 +284,9 @@ test "struct" {
         \\```zig
         \\(type)
         \\```
+        \\---
+        \\Foo doc comment
+        \\
     );
     try testHover(
         \\const Edge<cursor>Cases = struct {
@@ -691,14 +692,15 @@ test "function parameter" {
         \\    return a;
         \\}
     ,
-        \\ hello world
-        \\
         \\```zig
         \\a: u32
         \\```
         \\```zig
         \\(u32)
         \\```
+        \\---
+        \\hello world
+        \\
     );
 }
 
@@ -748,16 +750,15 @@ test "either types" {
         \\const either = if (undefined) A else B;
         \\const bar = either.<cursor>T;
     ,
-        \\small type
-        \\
         \\```zig
         \\const T = u32
         \\```
         \\```zig
         \\(type)
         \\```
+        \\---
+        \\small type
         \\
-        \\large type
         \\
         \\```zig
         \\const T = u64
@@ -765,6 +766,9 @@ test "either types" {
         \\```zig
         \\(type)
         \\```
+        \\---
+        \\large type
+        \\
     );
     try testHoverWithOptions(
         \\const A = struct {
@@ -778,15 +782,15 @@ test "either types" {
         \\const either = if (undefined) A else B;
         \\const bar = either.<cursor>T;
     ,
-        \\small type
-        \\
         \\const T = u32
         \\(type)
+        \\small type
         \\
-        \\large type
         \\
         \\const T = u64
         \\(type)
+        \\large type
+        \\
     , .{ .markup_kind = .plaintext });
 }
 
@@ -795,14 +799,15 @@ test "var decl comments" {
         \\///this is a comment
         \\const f<cursor>oo = 0 + 0;
     ,
-        \\this is a comment
-        \\
         \\```zig
         \\const foo = 0 + 0
         \\```
         \\```zig
         \\(unknown)
         \\```
+        \\---
+        \\this is a comment
+        \\
     );
 }
 
@@ -931,16 +936,16 @@ test "combine doc comments of declaration and definition" {
         \\    const baz = struct {};
         \\};
     ,
-        \\ Foo
-        \\
-        \\ Bar
-        \\
         \\```zig
         \\const baz = struct
         \\```
         \\```zig
         \\(type)
         \\```
+        \\---
+        \\Foo
+        \\Bar
+        \\
     );
     try testHoverWithOptions(
         \\/// Foo
@@ -950,12 +955,11 @@ test "combine doc comments of declaration and definition" {
         \\    const baz = struct {};
         \\};
     ,
-        \\ Foo
-        \\
-        \\ Bar
-        \\
         \\const baz = struct
         \\(type)
+        \\Foo
+        \\Bar
+        \\
     , .{ .markup_kind = .plaintext });
 }
 
@@ -966,16 +970,16 @@ test "top-level doc comment" {
         \\/// A
         \\const S<cursor>elf = @This();
     ,
-        \\ A
-        \\
-        \\ B
-        \\
         \\```zig
         \\const Self = @This()
         \\```
         \\```zig
         \\(type)
         \\```
+        \\---
+        \\A
+        \\B
+        \\
     );
 }
 

--- a/tests/lsp_features/hover.zig
+++ b/tests/lsp_features/hover.zig
@@ -284,9 +284,8 @@ test "struct" {
         \\```zig
         \\(type)
         \\```
-        \\---
-        \\Foo doc comment
         \\
+        \\Foo doc comment
     );
     try testHover(
         \\const Edge<cursor>Cases = struct {
@@ -698,9 +697,8 @@ test "function parameter" {
         \\```zig
         \\(u32)
         \\```
-        \\---
-        \\hello world
         \\
+        \\hello world
     );
 }
 
@@ -756,9 +754,8 @@ test "either types" {
         \\```zig
         \\(type)
         \\```
-        \\---
-        \\small type
         \\
+        \\small type
         \\
         \\```zig
         \\const T = u64
@@ -766,9 +763,8 @@ test "either types" {
         \\```zig
         \\(type)
         \\```
-        \\---
-        \\large type
         \\
+        \\large type
     );
     try testHoverWithOptions(
         \\const A = struct {
@@ -784,13 +780,13 @@ test "either types" {
     ,
         \\const T = u32
         \\(type)
-        \\small type
         \\
+        \\small type
         \\
         \\const T = u64
         \\(type)
-        \\large type
         \\
+        \\large type
     , .{ .markup_kind = .plaintext });
 }
 
@@ -805,9 +801,8 @@ test "var decl comments" {
         \\```zig
         \\(comptime_int)
         \\```
-        \\---
-        \\this is a comment
         \\
+        \\this is a comment
     );
 }
 
@@ -942,10 +937,10 @@ test "combine doc comments of declaration and definition" {
         \\```zig
         \\(type)
         \\```
-        \\---
-        \\Foo
-        \\Bar
         \\
+        \\Foo
+        \\
+        \\Bar
     );
     try testHoverWithOptions(
         \\/// Foo
@@ -957,9 +952,10 @@ test "combine doc comments of declaration and definition" {
     ,
         \\const baz = struct
         \\(type)
-        \\Foo
-        \\Bar
         \\
+        \\Foo
+        \\
+        \\Bar
     , .{ .markup_kind = .plaintext });
 }
 
@@ -976,10 +972,10 @@ test "top-level doc comment" {
         \\```zig
         \\(type)
         \\```
-        \\---
-        \\A
-        \\B
         \\
+        \\A
+        \\
+        \\B
     );
 }
 


### PR DESCRIPTION
* Remove leading spaces from doc comments.
 
Hover documentation could look off in editors like Neovim with leading spaces in front of comments with a space after the `///`. For example:
<img width="469" alt="image" src="https://github.com/user-attachments/assets/5a0e7889-cc8b-4089-8e7d-502d074a397d" />
<img width="468" alt="image" src="https://github.com/user-attachments/assets/23bb6ec6-3617-4889-a683-f8ff24bae55b" />

* Separator between symbol docs and signature. 

I also added a separator between the symbol documentation and the signature. This is just a stylistic choice to better separate the two. I also moved the documentation _below_ the signature. This is because if you have a long doc comment, you want the first thing you see to be the signature, not the documentation.
<img width="456" alt="image" src="https://github.com/user-attachments/assets/530e1d61-f685-4ff7-8aa3-62d3af313c79" />
