### PR TITLE
Use the default top-level step for build information

### DIFF
--- a/src/build_runner/0.14.0.zig
+++ b/src/build_runner/0.14.0.zig
@@ -1029,9 +1029,10 @@ fn extractBuildInformation(
         var stack: std.ArrayListUnmanaged(*Step) = .{};
         defer stack.deinit(gpa);
 
-        try stack.ensureUnusedCapacity(gpa, b.top_level_steps.count());
         for (b.top_level_steps.values()) |tls| {
-            stack.appendAssumeCapacity(&tls.step);
+            if (std.meta.eql(tls.step, b.default_step.*)) {
+                try stack.append(gpa, &tls.step);
+            }
         }
 
         while (stack.pop()) |step| {


### PR DESCRIPTION
Currently ZLS cannot correctly resolve `@import("root")` when there are multiple top-level steps defined in the build script (which is common when say the user needs a test step or something), since it refers to all the `root_module`s as "root". This leads to errors in the subsequent analysis and wrong derived type affecting inlay hints and auto-completion, because ZLS simply iterates through all packages and find the first one with its name equal to "root".

This PR makes ZLS only analyze the default step, which is often "install", to eliminate such ambiguity. It only does so when `build_on_save` is not set, so the user could still customize the build commands.

<details>
<summary>Example to reproduce</summary>

- src/main.zig
  ```zig
  pub const this_should_present = 0;
  pub fn main() void {}
  ```
- src/another_file.zig
  ```zig
  pub const this_should_not_present = 0;
  ```
- build.zig
  ```zig
  const std = @import("std");

  pub fn build(b: *std.Build) void {
      const target = b.standardTargetOptions(.{});
      const optimize = b.standardOptimizeOption(.{});

      const exe_mod = b.createModule(.{
          .root_source_file = b.path("src/main.zig"),
          .target = target,
          .optimize = optimize,
      });

      const exe = b.addExecutable(.{
          .name = "foo",
          .root_module = exe_mod,
      });

      b.installArtifact(exe);

      const run_cmd = b.addRunArtifact(exe);

      run_cmd.step.dependOn(b.getInstallStep());

      if (b.args) |args| {
          run_cmd.addArgs(args);
      }

      const run_step = b.step("run", "Run the app");
      run_step.dependOn(&run_cmd.step);

      const new_mod = b.createModule(.{
          .root_source_file = b.path("src/another_file.zig"),
          .target = target,
          .optimize = optimize,
      });

      const exe_unit_tests = b.addTest(.{
          .root_module = new_mod,
      });

      const run_exe_unit_tests = b.addRunArtifact(exe_unit_tests);

      const test_step = b.step("test", "Run unit tests");
      test_step.dependOn(&run_exe_unit_tests.step);
  }
  ```

Result (master branch, commit d697a73):

![image](https://github.com/user-attachments/assets/c6725696-cf93-49a0-a156-dbd0d3278b10)

</details>