### PR TITLE
fix index OOB in completions

### DIFF
--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -1657,17 +1657,18 @@ fn collectFieldAccessContainerNodes(
             break :blk 0; // is `T`, no SelfParam
         };
         const fn_node = decl.decl.ast_node;
+        const fn_handle = decl.handle;
         const param_decl: Analyser.Declaration.Param = .{
             .param_index = @truncate(dot_context.fn_arg_index + additional_index),
             .func = fn_node,
         };
-        const param = param_decl.get(handle.tree) orelse continue;
+        const param = param_decl.get(fn_handle.tree) orelse continue;
 
         const type_expr = param.type_expr orelse continue;
         const param_rcts = try collectContainerNodes(
             builder,
-            handle,
-            offsets.nodeToLoc(handle.tree, type_expr).end,
+            fn_handle,
+            offsets.nodeToLoc(fn_handle.tree, type_expr).end,
             dot_context,
         );
         for (param_rcts) |prct| try types_with_handles.append(arena, prct);


### PR DESCRIPTION
was getting a crash like this from e.g. `std.debug.print("", .)`
```
thread 2062 panic: index out of bounds: index 483, len 15
/home/user/dev/zig/lib/std/zig/Ast.zig:87:34: 0x1276195 in nodeTag (zls)
    return tree.nodes.items(.tag)[@intFromEnum(node)];
                                 ^
/home/user/dev/zig/lib/std/zig/Ast.zig:2396:32: 0x127622f in fullFnProto (zls)
    return switch (tree.nodeTag(node)) {
                               ^
/home/user/dev/zls/src/DocumentScope.zig:190:42: 0x133a9dc in get (zls)
            const func = tree.fullFnProto(&buffer, self.func).?;
                                         ^
/home/user/dev/zls/src/features/completions.zig:1664:37: 0x14da9d9 in collectFieldAccessContainerNodes (zls)
        const param = param_decl.get(handle.tree) orelse continue;
                                    ^
```
there are multiple other uses of `handle` in this loop but the crash is fixed and all tests pass by just changing this one and i dont fully understand the logic. introduced in 4c759a25659d9d2db18505755b4581a93ecd100e cc @FnControlOption 