### PR TITLE
Map files to their corresponding compilation steps

### DIFF
--- a/src/DocumentStore.zig
+++ b/src/DocumentStore.zig
@@ -115,7 +115,7 @@ pub const BuildFile = struct {
 
         for (build_config.compilation_unit_info) |compilation_unit| {
             for (compilation_unit.packages) |package| {
-                try package_uris.append(allocator, try URI.fromPath(allocator,package.path));
+                try package_uris.append(allocator, try URI.fromPath(allocator, package.path));
             }
         }
 

--- a/src/build_runner/0.14.0.zig
+++ b/src/build_runner/0.14.0.zig
@@ -1166,7 +1166,7 @@ fn extractBuildInformation(
                 allocator.free(file_path);
             };
 
-            if (root_source_file == null or switch(root_source_file.?) {
+            if (root_source_file == null or switch (root_source_file.?) {
                 .src_path => false,
                 else => true,
             }) {
@@ -1343,7 +1343,6 @@ fn extractBuildInformation(
         run,
     );
 
-
     var compilation_unit_info = std.AutoArrayHashMap(*std.Build.Module, BuildConfig.CompilationUnit).init(gpa);
     defer {
         for (compilation_unit_info.values()) |value| {
@@ -1477,11 +1476,8 @@ fn extractBuildInformation(
         BuildConfig{
             .deps_build_roots = deps_build_roots.items,
             .compilation_unit_info = compilation_unit_info.values(),
-            // .packages = try packages.toPackageList(),
-            // .include_dirs = include_dirs.keys(),
             .top_level_steps = b.top_level_steps.keys(),
             .available_options = available_options,
-            // .c_macros = c_macros.keys(),
         },
         .{
             .whitespace = .indent_2,

--- a/src/build_runner/shared.zig
+++ b/src/build_runner/shared.zig
@@ -8,11 +8,8 @@ const need_bswap = native_endian != .little;
 pub const BuildConfig = struct {
     deps_build_roots: []DepsBuildRoots,
     compilation_unit_info: []CompilationUnit,
-    // packages: []Package,
-    // include_dirs: []const []const u8,
     top_level_steps: []const []const u8,
     available_options: std.json.ArrayHashMap(AvailableOption),
-    // c_macros: []const []const u8 = &.{},
 
     pub const DepsBuildRoots = Package;
     pub const Package = struct {

--- a/src/build_runner/shared.zig
+++ b/src/build_runner/shared.zig
@@ -7,16 +7,23 @@ const need_bswap = native_endian != .little;
 
 pub const BuildConfig = struct {
     deps_build_roots: []DepsBuildRoots,
-    packages: []Package,
-    include_dirs: []const []const u8,
+    compilation_unit_info: []CompilationUnit,
+    // packages: []Package,
+    // include_dirs: []const []const u8,
     top_level_steps: []const []const u8,
     available_options: std.json.ArrayHashMap(AvailableOption),
-    c_macros: []const []const u8 = &.{},
+    // c_macros: []const []const u8 = &.{},
 
     pub const DepsBuildRoots = Package;
     pub const Package = struct {
         name: []const u8,
         path: []const u8,
+    };
+    pub const CompilationUnit = struct {
+        include_dirs: []const []const u8,
+        c_macros: []const []const u8,
+        packages: []Package,
+        files: []const []const u8,
     };
     pub const AvailableOption = std.meta.FieldType(std.meta.FieldType(std.Build, .available_options_map).KV, .value);
 };

--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -809,13 +809,15 @@ fn completeFileSystemStringLiteral(builder: *Builder, pos_context: Analyser.Posi
             const build_config = build_file.tryLockConfig() orelse break :blk;
             defer build_file.unlockConfig();
 
-            try completions.ensureUnusedCapacity(builder.arena, build_config.packages.len);
-            for (build_config.packages) |pkg| {
-                completions.putAssumeCapacity(.{
-                    .label = pkg.name,
-                    .kind = .Module,
-                    .detail = pkg.path,
-                }, {});
+            // TODO: restrict to its own compilation unit.
+            for (build_config.compilation_unit_info) |compilation_unit| {
+                for (compilation_unit.packages) |pkg| {
+                    try completions.put(builder.arena, .{
+                        .label = pkg.name,
+                        .kind = .Module,
+                        .detail = pkg.path,
+                    }, {});
+                }
             }
         } else if (DocumentStore.isBuildFile(builder.orig_handle.uri)) blk: {
             const build_file = store.getBuildFile(builder.orig_handle.uri) orelse break :blk;

--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -809,7 +809,6 @@ fn completeFileSystemStringLiteral(builder: *Builder, pos_context: Analyser.Posi
             const build_config = build_file.tryLockConfig() orelse break :blk;
             defer build_file.unlockConfig();
 
-            // TODO: restrict to its own compilation unit.
             for (build_config.compilation_unit_info) |compilation_unit| {
                 for (compilation_unit.packages) |pkg| {
                     try completions.put(builder.arena, .{

--- a/tests/build_runner_cases/add_module.json
+++ b/tests/build_runner_cases/add_module.json
@@ -1,16 +1,23 @@
 {
   "deps_build_roots": [],
-  "packages": [
+  "compilation_unit_info": [
     {
-      "name": "root",
-      "path": "root.zig"
+      "include_dirs": [],
+      "c_macros": [],
+      "packages": [
+        {
+          "name": "root",
+          "path": "root.zig"
+        }
+      ],
+      "files": [
+        "root.zig"
+      ]
     }
   ],
-  "include_dirs": [],
   "top_level_steps": [
     "install",
     "uninstall"
   ],
-  "available_options": {},
-  "c_macros": []
+  "available_options": {}
 }

--- a/tests/build_runner_cases/define_c_macro.json
+++ b/tests/build_runner_cases/define_c_macro.json
@@ -1,18 +1,25 @@
 {
   "deps_build_roots": [],
-  "packages": [
+  "compilation_unit_info": [
     {
-      "name": "root",
-      "path": "root.zig"
+      "include_dirs": [],
+      "c_macros": [
+        "-Dkey=value"
+      ],
+      "packages": [
+        {
+          "name": "root",
+          "path": "root.zig"
+        }
+      ],
+      "files": [
+        "root.zig"
+      ]
     }
   ],
-  "include_dirs": [],
   "top_level_steps": [
     "install",
     "uninstall"
   ],
-  "available_options": {},
-  "c_macros": [
-    "-Dkey=value"
-  ]
+  "available_options": {}
 }

--- a/tests/build_runner_cases/empty.json
+++ b/tests/build_runner_cases/empty.json
@@ -1,11 +1,9 @@
 {
   "deps_build_roots": [],
-  "packages": [],
-  "include_dirs": [],
+  "compilation_unit_info": [],
   "top_level_steps": [
     "install",
     "uninstall"
   ],
-  "available_options": {},
-  "c_macros": []
+  "available_options": {}
 }

--- a/tests/build_runner_cases/module_self_import.json
+++ b/tests/build_runner_cases/module_self_import.json
@@ -1,20 +1,27 @@
 {
   "deps_build_roots": [],
-  "packages": [
+  "compilation_unit_info": [
     {
-      "name": "bar",
-      "path": "root.zig"
-    },
-    {
-      "name": "root",
-      "path": "root.zig"
+      "include_dirs": [],
+      "c_macros": [],
+      "packages": [
+        {
+          "name": "bar",
+          "path": "root.zig"
+        },
+        {
+          "name": "root",
+          "path": "root.zig"
+        }
+      ],
+      "files": [
+        "root.zig"
+      ]
     }
   ],
-  "include_dirs": [],
   "top_level_steps": [
     "install",
     "uninstall"
   ],
-  "available_options": {},
-  "c_macros": []
+  "available_options": {}
 }

--- a/tests/build_runner_cases/multiple_module_import_names.json
+++ b/tests/build_runner_cases/multiple_module_import_names.json
@@ -1,40 +1,81 @@
 {
   "deps_build_roots": [],
-  "packages": [
+  "compilation_unit_info": [
     {
-      "name": "bar_in_foo",
-      "path": "bar.zig"
+      "include_dirs": [],
+      "c_macros": [],
+      "packages": [
+        {
+          "name": "bar_in_foo",
+          "path": "bar.zig"
+        },
+        {
+          "name": "foo_in_bar",
+          "path": "foo.zig"
+        },
+        {
+          "name": "root",
+          "path": "foo.zig"
+        }
+      ],
+      "files": [
+        "foo.zig"
+      ]
     },
     {
-      "name": "bar_in_main",
-      "path": "bar.zig"
+      "include_dirs": [],
+      "c_macros": [],
+      "packages": [
+        {
+          "name": "bar_in_foo",
+          "path": "bar.zig"
+        },
+        {
+          "name": "foo_in_bar",
+          "path": "foo.zig"
+        },
+        {
+          "name": "root",
+          "path": "bar.zig"
+        }
+      ],
+      "files": [
+        "bar.zig"
+      ]
     },
     {
-      "name": "foo_in_bar",
-      "path": "foo.zig"
-    },
-    {
-      "name": "foo_in_main",
-      "path": "foo.zig"
-    },
-    {
-      "name": "root",
-      "path": "foo.zig"
-    },
-    {
-      "name": "root",
-      "path": "bar.zig"
-    },
-    {
-      "name": "root",
-      "path": "main.zig"
+      "include_dirs": [],
+      "c_macros": [],
+      "packages": [
+        {
+          "name": "bar_in_foo",
+          "path": "bar.zig"
+        },
+        {
+          "name": "bar_in_main",
+          "path": "bar.zig"
+        },
+        {
+          "name": "foo_in_bar",
+          "path": "foo.zig"
+        },
+        {
+          "name": "foo_in_main",
+          "path": "foo.zig"
+        },
+        {
+          "name": "root",
+          "path": "main.zig"
+        }
+      ],
+      "files": [
+        "main.zig"
+      ]
     }
   ],
-  "include_dirs": [],
   "top_level_steps": [
     "install",
     "uninstall"
   ],
-  "available_options": {},
-  "c_macros": []
+  "available_options": {}
 }


### PR DESCRIPTION
This PR solves the problem discussed in #2305 by categorizing build context (packages, c_macros and include_dirs) into different “compilation units,” which hold modules and files required by a single compilation step.

When ZLS analyzes a symbol, it will find the context of the compilation unit that the current file belongs to. When there are multiple of them, it picks a random one. However, this could be improved by calculating the longest common prefix between the current file and the root file of the compilation unit.

After the changes, only modules required by at least one compilation step (which could be an arbitrary one instead of just of the descendants of the default step) will be analyzed by ZLS. This behavior is also seen in other language servers like [rust-analyzer](https://github.com/rust-lang/rust-analyzer).