### PR TITLE
Improve type resolution of unlabeled blocks

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -2193,8 +2193,15 @@ fn resolveTypeOfNodeUncached(analyser: *Analyser, node_handle: NodeWithHandle) e
             if (std.mem.eql(u8, call_name, "@src")) {
                 return analyser.instanceStdBuiltinType("SourceLocation");
             }
+
             if (std.mem.eql(u8, call_name, "@compileError")) {
                 return .{ .data = .{ .compile_error = node_handle }, .is_type_val = false };
+            }
+
+            if (std.mem.eql(u8, call_name, "@panic") or
+                std.mem.eql(u8, call_name, "@trap"))
+            {
+                return Type.fromIP(analyser, .noreturn_type, null);
             }
 
             if (std.mem.eql(u8, call_name, "@Vector")) {

--- a/tests/analysis/block.zig
+++ b/tests/analysis/block.zig
@@ -1,0 +1,45 @@
+const empty_block = {};
+//    ^^^^^^^^^^^ (void)()
+
+// zig fmt: off
+const void_block = { _ = 1; };
+//    ^^^^^^^^^^ (void)()
+
+const compile_error_block = { @compileError("foo"); };
+//    ^^^^^^^^^^^^^^^^^^^ (noreturn)()
+
+const panic_block = { @panic("foo"); };
+//    ^^^^^^^^^^^ (noreturn)()
+
+const labeled_block_0 = blk: { break :blk @as(i32, 1); };
+//    ^^^^^^^^^^^^^^^ (i32)()
+
+// TODO this should be `i64`
+const labeled_block_1 = blk: {
+//    ^^^^^^^^^^^^^^^ (i32)()
+    if (false) break :blk @as(i32, 1);
+    break :blk @as(i64, 2);
+};
+// zig fmt: on
+
+pub fn main() void {
+    const return_block = {
+        return;
+    };
+    _ = return_block;
+    //  ^^^^^^^^^^^^ (noreturn)()
+
+    for (0..1) |_| {
+        const break_block = {
+            break;
+        };
+        _ = break_block;
+        //  ^^^^^^^^^^^ (noreturn)()
+
+        const continue_block = {
+            continue;
+        };
+        _ = continue_block;
+        //  ^^^^^^^^^^^^^^ (noreturn)()
+    }
+}

--- a/tests/analysis/builtins.zig
+++ b/tests/analysis/builtins.zig
@@ -111,6 +111,11 @@ const abs_vector_i8 = @abs(@as(@Vector(4, i8), undefined));
 const abs_vector_u8 = @abs(@as(@Vector(4, u8), undefined));
 //    ^^^^^^^^^^^^^ (@Vector(4,u8))()
 
+const panic = @panic("foo");
+//    ^^^^^ (noreturn)()
+const trap = @trap();
+//    ^^^^ (noreturn)()
+
 comptime {
     // Use @compileLog to verify the expected type with the compiler
     // @compileLog(vector_builtin_13);


### PR DESCRIPTION
If the last statement of an unlabeled block is a `noreturn`, the block becomes `noreturn` also. Otherwise, the block is `void`.

This will be helpful for peer type resolution:

```zig
const foo = bar() catch |err| {
    // do stuff
    return;
};
```