### PR TITLE
use resolved function type for arg completions

### DIFF
--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -1656,22 +1656,11 @@ fn collectFieldAccessContainerNodes(
             }
             break :blk 0; // is `T`, no SelfParam
         };
-        const fn_node = decl.decl.ast_node;
-        const fn_handle = decl.handle;
-        const param_decl: Analyser.Declaration.Param = .{
-            .param_index = @truncate(dot_context.fn_arg_index + additional_index),
-            .func = fn_node,
-        };
-        const param = param_decl.get(fn_handle.tree) orelse continue;
-
-        const type_expr = param.type_expr orelse continue;
-        const param_rcts = try collectContainerNodes(
-            builder,
-            fn_handle,
-            offsets.nodeToLoc(fn_handle.tree, type_expr).end,
-            dot_context,
-        );
-        for (param_rcts) |prct| try types_with_handles.append(arena, prct);
+        const params = node_type.data.function.parameters;
+        const param_index = dot_context.fn_arg_index + additional_index;
+        if (param_index >= params.len) continue;
+        const param_type = params[param_index].type orelse continue;
+        try param_type.getAllTypesWithHandlesArrayList(arena, types_with_handles);
     }
 }
 

--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -311,6 +311,20 @@ test "function alias" {
             .detail = "fn () void",
         },
     });
+    try testCompletion(
+        \\const S = struct {
+        \\    alpha: u32,
+        \\    fn foo(_: S) void {}
+        \\    const bar = foo;
+        \\};
+        \\const baz = S.bar(.<cursor>);
+    , &.{
+        .{
+            .label = "alpha",
+            .kind = .Field,
+            .detail = "u32",
+        },
+    });
 }
 
 test "generic function" {


### PR DESCRIPTION
before the test case would crash on `param_decl.get` since the node was not `.fn_*`