### PR TITLE
support `libc_runtimes` in the build runner

### DIFF
--- a/src/build_runner/0.14.0.zig
+++ b/src/build_runner/0.14.0.zig
@@ -219,8 +219,12 @@ pub fn main() !void {
                 // but it is handled by the parent process. The build runner
                 // only sees this flag.
                 graph.system_package_mode = true;
-            } else if (mem.eql(u8, arg, "--glibc-runtimes")) {
-                builder.glibc_runtimes_dir = nextArgOrFatal(args, &arg_idx);
+            } else if (mem.eql(u8, arg, "--libc-runtimes") or mem.eql(u8, arg, "--glibc-runtimes")) {
+                if (@hasField(std.Build, "glibc_runtimes_dir")) {
+                    builder.glibc_runtimes_dir = nextArgOrFatal(args, &arg_idx);
+                } else {
+                    builder.libc_runtimes_dir = nextArgOrFatal(args, &arg_idx);
+                }
             } else if (mem.eql(u8, arg, "--verbose-link")) {
                 builder.verbose_link = true;
             } else if (mem.eql(u8, arg, "--verbose-air")) {


### PR DESCRIPTION
`glibc_runtimes_dir` was renamed to `libc_runtimes_dir` by https://github.com/ziglang/zig/pull/23810.