### PR TITLE
Fix position context of enum/decl literal after break

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -4462,9 +4462,13 @@ pub fn getPositionContext(
                 else => {},
             },
             .period, .period_asterisk => switch (curr_ctx.ctx) {
+                // TODO: only set context to enum literal if token tag is "." (not ".*")
                 .empty, .label_access => curr_ctx.ctx = .{ .enum_literal = tok.loc },
                 .enum_literal => curr_ctx.ctx = .empty,
-                .keyword => curr_ctx.ctx = .other, // no keyword can be `.`/`.*` accessed
+                .keyword => |tag| switch (tag) {
+                    .keyword_break => curr_ctx.ctx = .{ .enum_literal = tok.loc },
+                    else => curr_ctx.ctx = .other,
+                },
                 .comment, .other, .field_access, .global_error_set => {},
                 else => curr_ctx.ctx = .{ .field_access = tokenLocAppend(curr_ctx.ctx.loc() orelse tok.loc, tok) },
             },

--- a/tests/utility/position_context.zig
+++ b/tests/utility/position_context.zig
@@ -428,6 +428,15 @@ test "enum literal" {
     , .enum_literal, .{});
 }
 
+test "enum literal after break" {
+    try testContext(
+        \\break <loc>.<cursor>foo</loc>;
+    , .enum_literal, .{ .lookahead = true });
+    try testContext(
+        \\break <loc>.foo<cursor></loc>;
+    , .enum_literal, .{});
+}
+
 test "enum literal after break label" {
     try testContext(
         \\break :blk <loc>.<cursor>foo</loc>;


### PR DESCRIPTION
Similar to #2248 but for unlabeled `break` statements