### PR TITLE
iterate operand of `continue` in ast

### DIFF
--- a/src/ast.zig
+++ b/src/ast.zig
@@ -1230,7 +1230,9 @@ fn iterateChildrenTypeErased(
         },
         .test_decl, .@"errdefer" => try callback(context, tree, tree.nodeData(node).opt_token_and_node[1]),
         .anyframe_type => try callback(context, tree, tree.nodeData(node).token_and_node[1]),
-        .@"break" => {
+        .@"break",
+        .@"continue",
+        => {
             if (tree.nodeData(node).opt_token_and_opt_node[1].unwrap()) |rhs| {
                 try callback(context, tree, rhs);
             }
@@ -1470,7 +1472,6 @@ fn iterateChildrenTypeErased(
         .asm_input,
         => unreachable,
 
-        .@"continue",
         .anyframe_literal,
         .char_literal,
         .number_literal,

--- a/tests/lsp_features/references.zig
+++ b/tests/lsp_features/references.zig
@@ -96,6 +96,18 @@ test "for/while capture" {
     );
 }
 
+test "break/continue operands" {
+    try testReferences(
+        \\comptime {
+        \\    const <0> = 0;
+        \\    sw: switch (0) {
+        \\        0 => continue :sw <0>,
+        \\        else => break :sw <0>,
+        \\    }
+        \\}
+    );
+}
+
 test "enum field access" {
     try testReferences(
         \\const E = enum {


### PR DESCRIPTION
fixes #2330 