### PR TITLE
Rename `Type` to `Expr`

### DIFF
--- a/src/features/semantic_tokens.zig
+++ b/src/features/semantic_tokens.zig
@@ -247,7 +247,7 @@ fn fieldTokenType(
 
 fn colorIdentifierBasedOnType(
     builder: *Builder,
-    type_node: Analyser.Type,
+    type_node: Analyser.Expr,
     target_tok: Ast.TokenIndex,
     is_parameter: bool,
     tok_mod: TokenModifiers,
@@ -1025,7 +1025,7 @@ fn writeContainerField(builder: *Builder, node: Ast.Node.Index, container_decl: 
     }
 }
 
-fn writeVarDecl(builder: *Builder, var_decl_node: Ast.Node.Index, resolved_type: ?Analyser.Type) error{OutOfMemory}!void {
+fn writeVarDecl(builder: *Builder, var_decl_node: Ast.Node.Index, resolved_type: ?Analyser.Expr) error{OutOfMemory}!void {
     const tree = builder.handle.tree;
 
     const var_decl = tree.fullVarDecl(var_decl_node).?;

--- a/src/features/signature_help.zig
+++ b/src/features/signature_help.zig
@@ -17,7 +17,7 @@ fn fnProtoToSignatureInfo(
     arena: std.mem.Allocator,
     commas: u32,
     skip_self_param: bool,
-    func_type: Analyser.Type,
+    func_type: Analyser.Expr,
     markup_kind: types.MarkupKind,
 ) !types.SignatureInformation {
     const info = func_type.data.function;


### PR DESCRIPTION
In ZLS, a `Type` represents one of two things:
- a type (`is_type_val == true`) or
- an expression of some type (`is_type_val == false`).

Furthermore, a `Type` may be interned.

For example, the primitive type `u8` is
- a type (`is_type_val == true`) whose
- interned type (`data.ip_index.type`) is `type` and
- interned value (`data.ip_index.index`) is `u8`.

In special cases such as number literals, a non-type expression may be interned with a specific value.

For example, the number `42` is
- an expression (`is_type_val == false`) whose
- interned type (`data.ip_index.type`) is `comptime_int` and
- interned value (`data.ip_index.index`) is `42`.

Thus, a `Type` is really just an expression that may or may not be a type, so the name `Type` isn’t quite accurate.

I propose renaming `Type` to `Expr` (short for `Expression`).

- `u8` and `ArrayList(u8)` are expressions that resolve to types
- A `usize` variable is an expression with a runtime-known value (`data.ip_index.index == null`)
- A number literal is an expression with a comptime-known value (`data.ip_index.index != null`)

Granted, this will be quite an invasive change, and many variables/fields/parameters will have to be renamed.