### PR TITLE
Fix position context of enum/decl literal in `if`/`while`/`for`

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -4571,6 +4571,7 @@ pub fn getPositionContext(
                 if (curr_ctx.ctx == .empty) curr_ctx.ctx = .{ .parens_expr = tok.loc };
                 const stack_id: StackId = switch (curr_ctx.ctx) {
                     .keyword => |tag| switch (tag) {
+                        .keyword_for,
                         .keyword_if,
                         .keyword_while,
                         => .global,
@@ -4608,6 +4609,7 @@ pub fn getPositionContext(
             .keyword_continue,
             .keyword_callconv,
             .keyword_addrspace,
+            .keyword_for,
             .keyword_if,
             .keyword_while,
             => curr_ctx.ctx = .{ .keyword = tok.tag },

--- a/tests/utility/position_context.zig
+++ b/tests/utility/position_context.zig
@@ -507,6 +507,36 @@ test "enum literal in 'else' expression of 'while' loop" {
     , .enum_literal, .{});
 }
 
+test "enum literal in body of 'for' loop" {
+    try testContext(
+        \\var foo = for (bar) <loc>.<cursor>foo</loc> else .bar;
+    , .enum_literal, .{ .lookahead = true });
+    try testContext(
+        \\var foo = for (bar) <loc>.foo<cursor></loc> else .bar;
+    , .enum_literal, .{});
+    try testContext(
+        \\var foo = for (bar) |baz| <loc>.<cursor>foo</loc> else .bar;
+    , .enum_literal, .{ .lookahead = true });
+    try testContext(
+        \\var foo = for (bar) |baz| <loc>.foo<cursor></loc> else .bar;
+    , .enum_literal, .{});
+}
+
+test "enum literal in 'else' expression of 'for' loop" {
+    try testContext(
+        \\var foo = for (bar) .foo else <loc>.<cursor>bar</loc>;
+    , .enum_literal, .{ .lookahead = true });
+    try testContext(
+        \\var foo = for (bar) .foo else <loc>.bar<cursor></loc>;
+    , .enum_literal, .{});
+    try testContext(
+        \\var foo = for (bar) |baz| .foo else <loc>.<cursor>bar</loc>;
+    , .enum_literal, .{ .lookahead = true });
+    try testContext(
+        \\var foo = for (bar) |baz| .foo else <loc>.bar<cursor></loc>;
+    , .enum_literal, .{});
+}
+
 test "label access" {
     try testContext(
         \\var foo = blk: { break :<loc><cursor>blk</loc> null };


### PR DESCRIPTION
For example:

```zig
var foo = if (bar) .foo else .bar;
//                 ^^^^
```