### PR TITLE
handle relative paths from the build system

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -6,7 +6,7 @@ const builtin = @import("builtin");
 const zls_version: std.SemanticVersion = .{ .major = 0, .minor = 15, .patch = 0, .pre = "dev" };
 
 /// Specify the minimum Zig version that is required to compile and test ZLS:
-/// compiler: Allow configuring UBSan mode at the module level.
+/// std.Build: resolved generated paths are cwd-relative
 ///
 /// If you do not use Nix, a ZLS maintainer can take care of this.
 /// Whenever this version is increased, run the following command:
@@ -15,7 +15,7 @@ const zls_version: std.SemanticVersion = .{ .major = 0, .minor = 15, .patch = 0,
 /// ```
 ///
 /// Also update the `minimum_zig_version` in `build.zig.zon`.
-const minimum_build_zig_version = "0.15.0-dev.393+5668c8b7b";
+const minimum_build_zig_version = "0.15.0-dev.631+9a3540d61";
 
 /// Specify the minimum Zig version that is required to run ZLS:
 /// Release 0.14.0

--- a/build.zig
+++ b/build.zig
@@ -84,7 +84,6 @@ pub fn build(b: *Build) !void {
         test_options.step.name = "ZLS test options";
 
         test_options.addOptionPath("zig_exe_path", .{ .cwd_relative = b.graph.zig_exe });
-        // TODO these paths may be relative
         test_options.addOptionPath("zig_lib_path", .{ .cwd_relative = b.fmt("{}", .{b.graph.zig_lib_directory}) });
         test_options.addOptionPath("global_cache_path", .{ .cwd_relative = b.cache_root.join(b.allocator, &.{"zls"}) catch @panic("OOM") });
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,7 +4,7 @@
     .version = "0.15.0-dev",
     // Must be kept in line with the `minimum_build_zig_version` in `build.zig`.
     // Should be a Zig version that is downloadable from https://ziglang.org/download/ or a mirror.
-    .minimum_zig_version = "0.15.0-dev.441+c1649d586",
+    .minimum_zig_version = "0.15.0-dev.631+9a3540d61",
     // If you do not use Nix, a ZLS maintainer can take care of this.
     // Whenever the dependencies are updated, run the following command:
     // ```bash

--- a/flake.lock
+++ b/flake.lock
@@ -56,11 +56,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1746055187,
-        "narHash": "sha256-3dqArYSMP9hM7Qpy5YWhnSjiqniSaT2uc5h2Po7tmg0=",
+        "lastModified": 1748037224,
+        "narHash": "sha256-92vihpZr6dwEMV6g98M5kHZIttrWahb9iRPBm1atcPk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3e362ce63e16b9572d8c2297c04f7c19ab6725a5",
+        "rev": "f09dede81861f3a83f7f06641ead34f02f37597f",
         "type": "github"
       },
       "original": {
@@ -101,11 +101,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746187975,
-        "narHash": "sha256-/WWBE1zNJyVDkUkbslqkHJYR0Oens9znaZSXUZ5qT2o=",
+        "lastModified": 1748478866,
+        "narHash": "sha256-RB/qJiZbwaTlSI1FcwFGhfOK9k6zY0uacdR3WvBwnmI=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "efc4c87cce0e2dcdf52435147d1d8d514ab47bf2",
+        "rev": "6cec3b5519bd3fce4623ce0b570fa6f7c1d76584",
         "type": "github"
       },
       "original": {

--- a/tests/lifecycle.zig
+++ b/tests/lifecycle.zig
@@ -9,10 +9,24 @@ test "LSP lifecycle" {
     var server = try zls.Server.create(allocator);
     defer server.destroy();
 
+    var zig_exe_path: ?[]const u8 = null;
+    var global_cache_path: ?[]const u8 = null;
+
+    defer if (builtin.target.os.tag != .wasi) {
+        if (zig_exe_path) |path| allocator.free(path);
+        if (global_cache_path) |path| allocator.free(path);
+    };
+    if (builtin.target.os.tag != .wasi) {
+        const cwd = try std.process.getCwdAlloc(allocator);
+        defer allocator.free(cwd);
+        zig_exe_path = try std.fs.path.resolve(allocator, &.{ cwd, test_options.zig_exe_path });
+        global_cache_path = try std.fs.path.resolve(allocator, &.{ cwd, test_options.global_cache_path });
+    }
+
     try server.updateConfiguration2(.{
-        .zig_exe_path = if (builtin.target.os.tag != .wasi) test_options.zig_exe_path else null,
+        .zig_exe_path = zig_exe_path,
         .zig_lib_path = null,
-        .global_cache_path = if (builtin.target.os.tag != .wasi) test_options.global_cache_path else null,
+        .global_cache_path = global_cache_path,
     }, .{});
 
     var arena_allocator: std.heap.ArenaAllocator = .init(allocator);


### PR DESCRIPTION
The build system now more often uses relative paths which would break ZLS's tests because it expected absolute paths for the zig library path for example.