### PR TITLE
speed up reference finding

### DIFF
--- a/src/features/signature_help.zig
+++ b/src/features/signature_help.zig
@@ -78,7 +78,14 @@ pub fn getSignatureInfo(
     markup_kind: types.MarkupKind,
 ) !?types.SignatureInformation {
     const document_scope = try handle.getDocumentScope();
-    const innermost_block = Analyser.innermostBlockScope(document_scope, absolute_index);
+    const innermost_block_scope = Analyser.innermostScopeAtIndexWithTag(document_scope, absolute_index, .init(.{
+        .block = true,
+        .container = true,
+        .container_usingnamespace = true,
+        .function = true,
+        .other = false,
+    })).unwrap().?;
+    const innermost_block = document_scope.getScopeAstNode(innermost_block_scope).?;
     const tree = handle.tree;
 
     // Use the innermost scope to determine the earliest token we would need


### PR DESCRIPTION
a lot of this is pretty low hanging fruit but gives some serious improvement. basically everything was searching for references starting from the root of the file despite that being completely redundant for e.g. captures.
in my testing using [a perfectly reasonable file](<https://github.com/ziglang/zig/blob/1a08c83eb3a6c739c75b8ec3eb291ac15a69ed7a/src/arch/x86_64/CodeGen.zig>) it took ~27 seconds to find references for just about everything since they were all checking the same stuff. 
with this pr its ~1 second worst case and 0ms in some extreme examples like a small branch with a capture which means i can say i sped up references by 30000x