### PR TITLE
Deprecate the 'semantic_tokens' config option in favor of 'augmentsSyntaxTokens'

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -33,7 +33,7 @@
             "default": []
         },
         "semantic_tokens": {
-            "description": "Set level of semantic tokens. `partial` only includes information that requires semantic analysis.",
+            "description": "Deprecated. The client should set the 'augmentsSyntaxTokens' capability.\n\nSet level of semantic tokens. `partial` only includes information that requires semantic analysis.",
             "type": "string",
             "enum": [
                 "none",

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -23,6 +23,8 @@ enable_build_on_save: ?bool = null,
 /// If the `build.zig` has declared a 'check' step, it will be preferred over the default 'install' step.
 build_on_save_args: []const []const u8 = &.{},
 
+/// Deprecated. The client should set the 'augmentsSyntaxTokens' capability.
+///
 /// Set level of semantic tokens. `partial` only includes information that requires semantic analysis.
 semantic_tokens: enum {
     none,

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -72,6 +72,7 @@ const ClientCapabilities = struct {
     supports_publish_diagnostics: bool = false,
     supports_code_action_fixall: bool = false,
     supports_semantic_tokens_overlapping: bool = false,
+    semantic_tokens_augment_syntax_tokens: bool = false,
     hover_supports_md: bool = false,
     signature_help_supports_md: bool = false,
     completion_doc_supports_md: bool = false,
@@ -458,6 +459,7 @@ fn initializeHandler(server: *Server, arena: std.mem.Allocator, request: types.I
         }
         if (textDocument.semanticTokens) |semanticTokens| {
             server.client_capabilities.supports_semantic_tokens_overlapping = semanticTokens.overlappingTokenSupport orelse false;
+            server.client_capabilities.semantic_tokens_augment_syntax_tokens = semanticTokens.augmentsSyntaxTokens orelse false;
         }
     }
 
@@ -1254,7 +1256,7 @@ fn semanticTokensFullHandler(server: *Server, arena: std.mem.Allocator, request:
         handle,
         null,
         server.offset_encoding,
-        server.config_manager.config.semantic_tokens == .partial,
+        server.client_capabilities.semantic_tokens_augment_syntax_tokens or server.config_manager.config.semantic_tokens == .partial,
         server.client_capabilities.supports_semantic_tokens_overlapping,
     );
 }
@@ -1281,7 +1283,7 @@ fn semanticTokensRangeHandler(server: *Server, arena: std.mem.Allocator, request
         handle,
         loc,
         server.offset_encoding,
-        server.config_manager.config.semantic_tokens == .partial,
+        server.client_capabilities.semantic_tokens_augment_syntax_tokens or server.config_manager.config.semantic_tokens == .partial,
         server.client_capabilities.supports_semantic_tokens_overlapping,
     );
 }

--- a/src/tools/config.json
+++ b/src/tools/config.json
@@ -32,7 +32,7 @@
         },
         {
             "name": "semantic_tokens",
-            "description": "Set level of semantic tokens. `partial` only includes information that requires semantic analysis.",
+            "description": "Deprecated. The client should set the 'augmentsSyntaxTokens' capability.\n\nSet level of semantic tokens. `partial` only includes information that requires semantic analysis.",
             "type": "enum",
             "enum": [
                 "none",


### PR DESCRIPTION
The [augmentsSyntaxTokens](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#semanticTokensClientCapabilities) client capability can be used to indicate that the client is going to combine existing syntax tokens with the semantic tokens of the server. This can not only reduce the amount of data that is transferred over the protocol but can also lead to better highlighting as syntax tokens often more accurately distinguish between different language constructs on the syntax level. An example would be keywords where the LSP protocol has a single standard token type compared to syntax highlighting where different keywords are often differentiated between based on their purpose.

The `semantic_tokens` config had been added for this purpose. The `partial` option is used to prevent LSP semantic tokens to override existing syntax highlighting of the editor. The benefit of the client capability is that this decision is automatically made by supported editors instead of relying on user to select the right configuration.

The following editors should be unaffected:

- VS Code: enables `partial` by default
- LSP4IJ (JetBrains): does not enable `augmentsSyntaxTokens`
- Helix: does not use semantic tokens
- Zed: does not use semantic tokens
- Kate: does not enable `augmentsSyntaxTokens`
- Eglot (Emacs): does not use semantic tokens
- lsp-mode (Emacs): does not enable `augmentsSyntaxTokens`

The following editors are affected:

<details>

<summary>Sublime Text</summary>

Requires the `semantic_highlighting` config option to be enabled.

Before:
![sublime-text-before](https://github.com/user-attachments/assets/86ba49ca-ed2a-4017-9cae-bbb6d93ced35)
After:
![sublime-text-after](https://github.com/user-attachments/assets/c6e3b3a9-8eb0-469a-8103-9f9aa972405e)

The new output more closely matches the result when disabling semantic highlighting:

![sublime-text-none](https://github.com/user-attachments/assets/aa8997af-9cc8-4436-91ed-3c2bd63ecda8)

</details>

<details>

<summary>Neovim</summary>

Tested with [tokyonight.nvim](https://github.com/folke/tokyonight.nvim)

Before:
![neovim-before](https://github.com/user-attachments/assets/6c81fc63-7d14-461e-a075-7db5be6587ce)

After:
![neovim-after](https://github.com/user-attachments/assets/123f6278-122d-49d4-a711-4d580f5ce1d4)

The [zig.vim](https://github.com/ziglang/zig.vim) plugin maps the `var`, `const`, `comptime` and `threadlocal` keywords to `Function` which doesn't seem right. Possible fix: https://github.com/ziglang/zig.vim/pull/110

</details>

<details>

<summary>CoC (neovim)</summary>

Tested with [tokyonight.nvim](https://github.com/folke/tokyonight.nvim)

Before:
![coc-before](https://github.com/user-attachments/assets/81a05d2a-f838-4b31-92cc-8b45c7f6c2e2)

After:
![coc-after](https://github.com/user-attachments/assets/7b4d9bcb-e5de-4d67-b129-9557d2b4c907)

</details>

Vim defines preferred [highlighting groups](https://neovim.io/doc/user/syntax.html#group-name) to share group names between many languages. The conventions that have been established by many syntax highlighting configurations are incompatible with LSP semantic highlighting and will result in poor highlighting when mixed together. Because of this, `augmentsSyntaxTokens` should be disabled in (Neo)vim when not using tree-sitter based syntax highlighting.
