### PR TITLE
reference fields in anonymous struct initializers

### DIFF
--- a/tests/lsp_features/references.zig
+++ b/tests/lsp_features/references.zig
@@ -145,15 +145,17 @@ test "struct decl access" {
 
 test "struct one field init" {
     try testSymbolReferences(
-        \\const S = struct {<0>: u32};
-        \\const s = S{.<0> = 0 };
+        \\const S = struct { <0>: u32 };
+        \\const s = S{ .<0> = 0 };
+        \\const s2: S = .{ .<0> = 0 };
     );
 }
 
 test "struct multi-field init" {
     try testSymbolReferences(
-        \\const S = struct {<0>: u32, a: bool};
-        \\const s = S{.<0> = 0, .a = true};
+        \\const S = struct { <0>: u32, a: bool };
+        \\const s = S{ .<0> = 0, .a = true };
+        \\const s2: S = .{ .<0> = 0, .a = true };
     );
 }
 


### PR DESCRIPTION
closes #1837 
i was worried about potential performance problems but it seems to be working fine and the same was being done for the `.enum_literal` case anyway
also fixes a bug where quoted field names weren't renamed since it was getting the entire token loc