### PR TITLE
Set minimum zig version to 0.15.0-dev.828+3ce8d19f7

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -6,7 +6,7 @@ const builtin = @import("builtin");
 const zls_version: std.SemanticVersion = .{ .major = 0, .minor = 15, .patch = 0, .pre = "dev" };
 
 /// Specify the minimum Zig version that is required to compile and test ZLS:
-/// std.Build: resolved generated paths are cwd-relative
+/// llvm.ir: fix subrange version
 ///
 /// If you do not use Nix, a ZLS maintainer can take care of this.
 /// Whenever this version is increased, run the following command:
@@ -15,7 +15,7 @@ const zls_version: std.SemanticVersion = .{ .major = 0, .minor = 15, .patch = 0,
 /// ```
 ///
 /// Also update the `minimum_zig_version` in `build.zig.zon`.
-const minimum_build_zig_version = "0.15.0-dev.631+9a3540d61";
+const minimum_build_zig_version = "0.15.0-dev.828+3ce8d19f7";
 
 /// Specify the minimum Zig version that is required to run ZLS:
 /// Release 0.14.0

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,7 +4,7 @@
     .version = "0.15.0-dev",
     // Must be kept in line with the `minimum_build_zig_version` in `build.zig`.
     // Should be a Zig version that is downloadable from https://ziglang.org/download/ or a mirror.
-    .minimum_zig_version = "0.15.0-dev.769+4d7980645",
+    .minimum_zig_version = "0.15.0-dev.828+3ce8d19f7",
     // If you do not use Nix, a ZLS maintainer can take care of this.
     // Whenever the dependencies are updated, run the following command:
     // ```bash


### PR DESCRIPTION
Related: #2359

```console
$ zig version   
0.15.0-dev.769+4d7980645
$ zig build test
test
└─ run test 383/393 passed, 1 failed, 9 skipped
error: 'lsp_features.semantic_tokens.test.weird code' failed:  
error. .foo
^^^^^ error: unexpected `features.semantic_tokens.TokenType.keyword` token here
```