### PR TITLE
Improvements for switch captures

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -5517,6 +5517,14 @@ pub const DeclWithHandle = struct {
                 if (switch_expr_type.isEnumType()) break :blk switch_expr_type;
                 if (!switch_expr_type.isUnionType()) return switch_expr_type;
 
+                if (case.ast.values.len == 0) {
+                    if (case.inline_token == null) {
+                        return switch_expr_type;
+                    }
+                    // TODO either type
+                    return null;
+                }
+
                 // TODO Peer type resolution, we just use the first resolvable item for now.
                 for (case.ast.values) |case_value| {
                     if (tree.nodeTag(case_value) != .enum_literal) continue;

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -5515,7 +5515,7 @@ pub const DeclWithHandle = struct {
                 }
 
                 if (switch_expr_type.isEnumType()) break :blk switch_expr_type;
-                if (!switch_expr_type.isUnionType()) return null;
+                if (!switch_expr_type.isUnionType()) return switch_expr_type;
 
                 // TODO Peer type resolution, we just use the first resolvable item for now.
                 for (case.ast.values) |case_value| {

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -5265,6 +5265,7 @@ pub const DeclWithHandle = struct {
             .error_union_error,
             .for_loop_payload,
             .switch_payload,
+            .switch_inline_tag_payload,
             => return null, // the payloads can't have a type specifier
 
             .label,
@@ -5315,6 +5316,7 @@ pub const DeclWithHandle = struct {
             .error_union_payload,
             .error_union_error,
             .switch_payload,
+            .switch_inline_tag_payload,
             .label,
             .error_token,
             => true,
@@ -5330,6 +5332,7 @@ pub const DeclWithHandle = struct {
             .assign_destructure,
             .label,
             .error_token,
+            .switch_inline_tag_payload,
             => false,
             inline .optional_payload,
             .for_loop_payload,
@@ -5492,7 +5495,9 @@ pub const DeclWithHandle = struct {
                 };
             },
             .label => |decl| try analyser.resolveTypeOfNodeInternal(.of(decl.block, self.handle)),
-            .switch_payload => |payload| blk: {
+            .switch_payload,
+            .switch_inline_tag_payload,
+            => |payload| blk: {
                 const cond = tree.nodeData(payload.node).node_and_extra[0];
                 const case = payload.getCase(tree);
 

--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -232,6 +232,7 @@ fn declToCompletion(builder: *Builder, decl_handle: Analyser.DeclWithHandle) err
         .for_loop_payload,
         .assign_destructure,
         .switch_payload,
+        .switch_inline_tag_payload,
         => {
             var kind: types.CompletionItemKind = blk: {
                 const parent_is_type_val = if (decl_handle.container_type) |container_ty| container_ty.is_type_val else null;

--- a/src/features/hover.zig
+++ b/src/features/hover.zig
@@ -94,6 +94,7 @@ fn hoverSymbolRecursive(
         .for_loop_payload,
         .assign_destructure,
         .switch_payload,
+        .switch_inline_tag_payload,
         .label,
         .error_token,
         => tree.tokenSlice(decl_handle.nameToken()),

--- a/src/features/references.zig
+++ b/src/features/references.zig
@@ -307,7 +307,9 @@ fn symbolReferences(
         .for_loop_payload,
         .assign_destructure,
         => scope_node,
-        .switch_payload => |payload| payload.node,
+        .switch_payload,
+        .switch_inline_tag_payload,
+        => |payload| payload.node,
         .function_parameter => |payload| payload.func,
         .label => unreachable, // handled separately by labelReferences
         .error_token => return .empty,

--- a/tests/analysis/switch.zig
+++ b/tests/analysis/switch.zig
@@ -47,7 +47,7 @@ const switch_tagged_union = switch (some_tagged_union) {
     .bar => |a| a,
     //       ^ (bool)()
     else => |a| a,
-    //       ^ (unknown)() TODO this should be `TaggedUnion`
+    //       ^ (TaggedUnion)()
 };
 
 const switch_non_exhaustive_enum = switch (some_non_exhaustive_enum) {

--- a/tests/analysis/switch.zig
+++ b/tests/analysis/switch.zig
@@ -1,0 +1,96 @@
+const Enum = enum {
+    foo,
+    bar,
+    baz,
+    qux,
+};
+
+const TaggedUnion = union(Enum) {
+    foo: i32,
+    bar: bool,
+    baz: f64,
+    qux: void,
+};
+
+const NonExhaustiveEnum = enum(u8) {
+    fizz = 0,
+    buzz = 1,
+    _,
+};
+
+const some_u8: u8 = 'e';
+const some_enum: Enum = .baz;
+const some_tagged_union: TaggedUnion = .{ .baz = 3.14 };
+const some_non_exhaustive_enum: NonExhaustiveEnum = @enumFromInt(42);
+
+const switch_u8 = switch (some_u8) {
+    'x' => |a| a,
+    //      ^ (unknown)() TODO this should be `u8`
+    'y' => |a| a,
+    //      ^ (unknown)() TODO this should be `u8`
+    else => |a| a,
+    //       ^ (unknown)() TODO this should be `u8`
+};
+
+const switch_enum = switch (some_enum) {
+    .foo => |a| a,
+    //       ^ (Enum)()
+    .bar => |a| a,
+    //       ^ (Enum)()
+    else => |a| a,
+    //       ^ (Enum)()
+};
+
+const switch_tagged_union = switch (some_tagged_union) {
+    .foo => |a| a,
+    //       ^ (i32)()
+    .bar => |a| a,
+    //       ^ (bool)()
+    else => |a| a,
+    //       ^ (unknown)() TODO this should be `TaggedUnion`
+};
+
+const switch_non_exhaustive_enum = switch (some_non_exhaustive_enum) {
+    .fizz,
+    .buzz,
+    => |a| a,
+    //  ^ (NonExhaustiveEnum)()
+    _ => |a| a,
+    //    ^ (NonExhaustiveEnum)()
+};
+
+const switch_u8_inline = switch (some_u8) {
+    inline 'x' => |a, b| .{ a, b },
+    //             ^ (unknown)() TODO this should be `u8`
+    //                ^ (unknown)()
+    inline 'y' => |a, b| .{ a, b },
+    //             ^ (unknown)() TODO this should be `u8`
+    //                ^ (unknown)()
+    inline else => |a, b| .{ a, b },
+    //              ^ (unknown)() TODO this should be `u8`
+    //                 ^ (unknown)()
+};
+
+const switch_enum_inline = switch (some_enum) {
+    inline .foo => |a, b| .{ a, b },
+    //              ^ (Enum)()
+    //                 ^ (unknown)()
+    inline .bar => |a, b| .{ a, b },
+    //              ^ (Enum)()
+    //                 ^ (unknown)()
+    inline else => |a, b| .{ a, b },
+    //              ^ (Enum)()
+    //                 ^ (unknown)()
+};
+
+const switch_tagged_union_inline = switch (some_tagged_union) {
+    inline .foo => |a, b| .{ a, b },
+    //              ^ (i32)()
+    //                 ^ (Enum)()
+    inline .bar => |a, b| .{ a, b },
+    //              ^ (bool)()
+    //                 ^ (Enum)()
+    inline else => |a, b| .{ a, b },
+    //              ^ (unknown)() TODO this should be `either type`
+    //                 ^ (Enum)()
+};

--- a/tests/analysis/switch.zig
+++ b/tests/analysis/switch.zig
@@ -25,11 +25,11 @@ const some_non_exhaustive_enum: NonExhaustiveEnum = @enumFromInt(42);
 
 const switch_u8 = switch (some_u8) {
     'x' => |a| a,
-    //      ^ (unknown)() TODO this should be `u8`
+    //      ^ (u8)()
     'y' => |a| a,
-    //      ^ (unknown)() TODO this should be `u8`
+    //      ^ (u8)()
     else => |a| a,
-    //       ^ (unknown)() TODO this should be `u8`
+    //       ^ (u8)()
 };
 
 const switch_enum = switch (some_enum) {
@@ -59,15 +59,24 @@ const switch_non_exhaustive_enum = switch (some_non_exhaustive_enum) {
     //    ^ (NonExhaustiveEnum)()
 };
 
+const switch_null = switch (null) {
+    .foo => |a| a,
+    //       ^ (@TypeOf(null))() TODO this should be `unknown`
+    .bar => |a| a,
+    //       ^ (@TypeOf(null))() TODO this should be `unknown`
+    else => |a| a,
+    //       ^ (@TypeOf(null))() TODO this should be `unknown`
+};
+
 const switch_u8_inline = switch (some_u8) {
     inline 'x' => |a, b| .{ a, b },
-    //             ^ (unknown)() TODO this should be `u8`
+    //             ^ (u8)()
     //                ^ (unknown)()
     inline 'y' => |a, b| .{ a, b },
-    //             ^ (unknown)() TODO this should be `u8`
+    //             ^ (u8)()
     //                ^ (unknown)()
     inline else => |a, b| .{ a, b },
-    //              ^ (unknown)() TODO this should be `u8`
+    //              ^ (u8)()
     //                 ^ (unknown)()
 };
 
@@ -93,4 +102,16 @@ const switch_tagged_union_inline = switch (some_tagged_union) {
     inline else => |a, b| .{ a, b },
     //              ^ (unknown)() TODO this should be `either type`
     //                 ^ (Enum)()
+};
+
+const switch_null_inline = switch (null) {
+    inline .foo => |a, b| .{ a, b },
+    //              ^ (@TypeOf(null))() TODO this should be `unknown`
+    //                 ^ (unknown)()
+    inline .bar => |a, b| .{ a, b },
+    //              ^ (@TypeOf(null))() TODO this should be `unknown`
+    //                 ^ (unknown)()
+    inline else => |a, b| .{ a, b },
+    //              ^ (@TypeOf(null))() TODO this should be `unknown`
+    //                 ^ (unknown)()
 };

--- a/tests/lsp_features/references.zig
+++ b/tests/lsp_features/references.zig
@@ -270,6 +270,37 @@ test "function header" {
     );
 }
 
+test "switch case capture - union field" {
+    try testSymbolReferences(
+        \\const foo = switch (undefined) {
+        \\    .foo => |<0>| <0>,
+        \\};
+    );
+    try testSymbolReferences(
+        \\const foo = switch (undefined) {
+        \\    .foo => |<0>, _| <0>,
+        \\};
+    );
+    try testSymbolReferences(
+        \\const foo = switch (undefined) {
+        \\    inline .foo => |<0>, _| <0>,
+        \\};
+    );
+}
+
+test "switch case capture - union tag" {
+    try testSymbolReferences(
+        \\const foo = switch (undefined) {
+        \\    .foo => |_, <0>| <0>,
+        \\};
+    );
+    try testSymbolReferences(
+        \\const foo = switch (undefined) {
+        \\    inline .foo => |_, <0>| <0>,
+        \\};
+    );
+}
+
 test "cross-file reference" {
     if (true) return error.SkipZigTest; // https://github.com/zigtools/zls/issues/1071
     try testMultiFileSymbolReferences(&.{


### PR DESCRIPTION
## Fix resolved type of tag capture in inline switch case

```zig
const Enum = enum {
    foo,
    bar,
    baz,
    qux,
};

const TaggedUnion = union(Enum) {
    foo: i32,
    bar: bool,
    baz: f64,
    qux: void,
};

const some_tagged_union: TaggedUnion = .{ .baz = 3.14 };

const switch_tagged_union_inline = switch (some_tagged_union) {
    inline .foo => |a, b| .{ a, b },
    //                 ^ Enum
    inline .bar => |a, b| .{ a, b },
    //                 ^ Enum
    inline else => |a, b| .{ a, b },
    //                 ^ Enum
};
```

## Fix resolved type of switch capture for non-enum/union types

```zig
const some_u8: u8 = 'e';

const switch_u8 = switch (some_u8) {
    'x' => |a| a,
    //      ^ u8
    'y' => |a| a,
    //      ^ u8
    else => |a| a,
    //       ^ u8
};
```

## Resolve type of else capture in tagged union switch

```zig
const switch_tagged_union = switch (some_tagged_union) {
    .foo => |a| a,
    .bar => |a| a,
    else => |a| a,
    //       ^ TaggedUnion
};
```