### PR TITLE
fix: `NativePaths.detect` expects a `Target` not a `*const Target`

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -15,7 +15,7 @@ const zls_version: std.SemanticVersion = .{ .major = 0, .minor = 15, .patch = 0,
 /// ```
 ///
 /// Also update the `minimum_zig_version` in `build.zig.zon`.
-const minimum_build_zig_version = "0.15.0-dev.864+75d0ec9c0";
+const minimum_build_zig_version = "0.15.0-dev.847+850655f06";
 
 /// Specify the minimum Zig version that is required to run ZLS:
 /// Release 0.14.0

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,7 +4,7 @@
     .version = "0.15.0-dev",
     // Must be kept in line with the `minimum_build_zig_version` in `build.zig`.
     // Should be a Zig version that is downloadable from https://ziglang.org/download/ or a mirror.
-    .minimum_zig_version = "0.15.0-dev.864+75d0ec9c0",
+    .minimum_zig_version = "0.15.0-dev.847+850655f06",
     // If you do not use Nix, a ZLS maintainer can take care of this.
     // Whenever the dependencies are updated, run the following command:
     // ```bash

--- a/src/DocumentStore.zig
+++ b/src/DocumentStore.zig
@@ -1687,7 +1687,7 @@ pub fn collectIncludeDirs(
         .ofmt = comptime std.Target.ObjectFormat.default(builtin.os.tag, builtin.cpu.arch),
         .dynamic_linker = std.Target.DynamicLinker.none,
     };
-    const native_paths: std.zig.system.NativePaths = try .detect(arena_allocator.allocator(), &target_info);
+    const native_paths: std.zig.system.NativePaths = try .detect(arena_allocator.allocator(), target_info);
 
     try include_dirs.ensureUnusedCapacity(allocator, native_paths.include_dirs.items.len);
     for (native_paths.include_dirs.items) |native_include_dir| {


### PR DESCRIPTION
this commit also fixes an apparent typo in the required zig version? at least, the currently available-for-download version of zig master is 0.15.0-dev.847, but this repo claims a minimum required version of 0.15.0-dev.864.