### PR TITLE
Improve peer type resolution with `noreturn` and `@compileError`

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -1545,6 +1545,7 @@ fn resolvePeerTypesIP(analyser: *Analyser, a: InternPool.Index, b: InternPool.In
 
 fn resolvePeerTypesInternal(analyser: *Analyser, a: Type, b: Type) error{OutOfMemory}!?Type {
     switch (a.data) {
+        .compile_error => return b,
         .optional => |a_type| {
             if (a_type.eql(try b.typeOf(analyser))) {
                 return a;

--- a/tests/analysis/peer_type_resolution.zig
+++ b/tests/analysis/peer_type_resolution.zig
@@ -148,3 +148,9 @@ const comptime_bool: bool = true;
 
 const comptime_int_and_void = if (comptime_bool) 0 else {};
 //    ^^^^^^^^^^^^^^^^^^^^^ (either type)()
+
+const compile_error_0 = if (comptime_bool) s else @compileError("Foo");
+//    ^^^^^^^^^^^^^^^ (S)()
+
+const compile_error_1 = if (comptime_bool) @compileError("Foo") else s;
+//    ^^^^^^^^^^^^^^^ (S)()


### PR DESCRIPTION
```zig
const noreturn_0 = if (runtime_bool) s else return;
//    ^^^^^^^^^^ S
```

```zig
const compile_error_0 = if (comptime_bool) s else @compileError("Foo");
//    ^^^^^^^^^^^^^^^ S
```