### PR TITLE
drop support for Zig versions before 0.15.0-dev.936+fc2c1883b

### DIFF
--- a/.github/workflows/build_runner.yml
+++ b/.github/workflows/build_runner.yml
@@ -15,6 +15,8 @@ on:
 
 jobs:
   check_build_runner:
+    # re-enable once there is a tagged release or mach nominated version that the build runner supports
+    if: false
     strategy:
       fail-fast: false
       matrix:

--- a/build.zig
+++ b/build.zig
@@ -6,7 +6,7 @@ const builtin = @import("builtin");
 const zls_version: std.SemanticVersion = .{ .major = 0, .minor = 15, .patch = 0, .pre = "dev" };
 
 /// Specify the minimum Zig version that is required to compile and test ZLS:
-/// Sema: Stop adding Windows implib link inputs for `extern "..."` syntax.
+/// remove `async` and `await` keywords; remove `usingnamespace`
 ///
 /// If you do not use Nix, a ZLS maintainer can take care of this.
 /// Whenever this version is increased, run the following command:
@@ -15,7 +15,7 @@ const zls_version: std.SemanticVersion = .{ .major = 0, .minor = 15, .patch = 0,
 /// ```
 ///
 /// Also update the `minimum_zig_version` in `build.zig.zon`.
-const minimum_build_zig_version = "0.15.0-dev.920+b461d07a5";
+const minimum_build_zig_version = "0.15.0-dev.936+fc2c1883b";
 
 /// Specify the minimum Zig version that is required to run ZLS:
 /// Release 0.14.0

--- a/build.zig
+++ b/build.zig
@@ -17,15 +17,11 @@ const zls_version: std.SemanticVersion = .{ .major = 0, .minor = 15, .patch = 0,
 /// Also update the `minimum_zig_version` in `build.zig.zon`.
 const minimum_build_zig_version = "0.15.0-dev.936+fc2c1883b";
 
-/// Specify the minimum Zig version that is required to run ZLS:
-/// Release 0.14.0
-///
-/// Examples of reasons that would cause the minimum runtime version to be bumped are:
-///   - breaking change to the Zig Syntax
-///   - breaking change to AstGen (i.e `zig ast-check`)
+/// Specify the minimum Zig version that is usable with ZLS:
+/// remove `async` and `await` keywords; remove `usingnamespace`
 ///
 /// A breaking change to the Zig Build System should be handled by updating ZLS's build runner (see src\build_runner)
-const minimum_runtime_zig_version = "0.14.0";
+const minimum_runtime_zig_version = "0.15.0-dev.936+fc2c1883b";
 
 const release_targets = [_]std.Target.Query{
     .{ .cpu_arch = .aarch64, .os_tag = .linux },

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,7 +4,7 @@
     .version = "0.15.0-dev",
     // Must be kept in line with the `minimum_build_zig_version` in `build.zig`.
     // Should be a Zig version that is downloadable from https://ziglang.org/download/ or a mirror.
-    .minimum_zig_version = "0.15.0-dev.920+b461d07a5",
+    .minimum_zig_version = "0.15.0-dev.936+fc2c1883b",
     // If you do not use Nix, a ZLS maintainer can take care of this.
     // Whenever the dependencies are updated, run the following command:
     // ```bash

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -1176,19 +1176,19 @@ pub fn updateConfiguration(
         if (zig_version_is_tagged) {
             server.showMessage(
                 .Warning,
-                "ZLS {} does not support Zig {}. A ZLS {}.{} release should be used instead.",
+                "ZLS '{}' does not support Zig '{}'. A ZLS '{}.{}' release should be used instead.",
                 .{ zls_version, zig_version, zig_version.major, zig_version.minor },
             );
         } else if (zls_version_is_tagged) {
             server.showMessage(
                 .Warning,
-                "ZLS {} should be used with a Zig {}.{} release but found Zig {}.",
+                "ZLS '{}' should be used with a Zig '{}.{}' release but found Zig '{}'.",
                 .{ zls_version, zls_version.major, zls_version.minor, zig_version },
             );
         } else {
             server.showMessage(
                 .Warning,
-                "ZLS {} requires at least Zig {s} but got Zig {}. Update Zig to avoid unexpected behavior.",
+                "ZLS '{}' requires at least Zig '{s}' but got Zig '{}'. Update Zig to avoid unexpected behavior.",
                 .{ zls_version, build_options.minimum_runtime_zig_version_string, zig_version },
             );
         }

--- a/src/build_runner/BuildRunnerVersion.zig
+++ b/src/build_runner/BuildRunnerVersion.zig
@@ -8,7 +8,7 @@ const build_options = @import("build_options");
 ///
 /// The GitHub matrix in `.github\workflows\build_runner.yml` should be updated to check Zig master with the latest build runner file.
 pub const BuildRunnerVersion = enum {
-    @"0.14.0",
+    master,
 
     pub fn isTaggedRelease(version: BuildRunnerVersion) bool {
         return !@hasField(BuildRunnerVersion, "master") or version != .master;

--- a/src/build_runner/master.zig
+++ b/src/build_runner/master.zig
@@ -1,16 +1,16 @@
 //! PLEASE READ THE FOLLOWING MESSAGE BEFORE EDITING THIS FILE:
 //!
 //! This build runner is targeting compatibility with the following Zig versions:
-//!   - 0.14.0
+//!   - 0.15.0-dev.936+fc2c1883b or later
 //!
 //! Handling multiple Zig versions can be achieved by branching on the `builtin.zig_version` at comptime.
 //!
 //! You can test out the build runner on ZLS's `build.zig` with the following command:
-//! `zig build --build-runner src/build_runner/0.14.0.zig`
+//! `zig build --build-runner src/build_runner/master.zig`
 //!
 //! You can also test the build runner on any other `build.zig` with the following command:
-//! `zig build --build-file /path/to/build.zig --build-runner /path/to/zls/src/build_runner/0.14.0.zig`
-//! `zig build --build-runner /path/to/zls/src/build_runner/0.14.0.zig` (if the cwd contains build.zig)
+//! `zig build --build-file /path/to/build.zig --build-runner /path/to/zls/src/build_runner/master.zig`
+//! `zig build --build-runner /path/to/zls/src/build_runner/master.zig` (if the cwd contains build.zig)
 //!
 
 const root = @import("@build");

--- a/src/tools/langref.html.in
+++ b/src/tools/langref.html.in
@@ -316,7 +316,7 @@
           <a href="https://ziglang.org/documentation/0.11.0/">0.11.0</a> |
           <a href="https://ziglang.org/documentation/0.12.0/">0.12.0</a> |
           <a href="https://ziglang.org/documentation/0.13.0/">0.13.0</a> |
-          <a href="https://ziglang.org/documentation/0.14.0/">0.14.0</a> |
+          <a href="https://ziglang.org/documentation/0.14.1/">0.14.1</a> |
           master
         </nav>
         <nav aria-labelledby="table-of-contents">
@@ -777,7 +777,7 @@
       value. Using this value would be a bug. The value will be unused, or overwritten before being used."
       </p>
       <p>
-      In {#link|Debug#} mode, Zig writes {#syntax#}0xaa{#endsyntax#} bytes to undefined memory. This is to catch
+      In {#link|Debug#} and {#link|ReleaseSafe#} mode, Zig writes {#syntax#}0xaa{#endsyntax#} bytes to undefined memory. This is to catch
       bugs early, and to help detect use of undefined memory in a debugger. However, this behavior is only an
       implementation feature, not a language semantic, so it is not guaranteed to be observable to code.
       </p>
@@ -1649,6 +1649,7 @@ unwrapped == 1234{#endsyntax#}</pre>
               <li>{#link|Floats#}</li>
               <li>{#link|bool|Primitive Types#}</li>
               <li>{#link|type|Primitive Types#}</li>
+              <li>{#link|packed struct#}</li>
             </ul>
           </td>
           <td>
@@ -1925,8 +1926,10 @@ or
       Vector types are created with the builtin function {#link|@Vector#}.
       </p>
       <p>
-      Vectors support the same builtin operators as their underlying base types.
-      These operations are performed element-wise, and return a vector of the same length
+      Vectors generally support the same builtin operators as their underlying base types.
+      The only exception to this is the keywords `and` and `or` on vectors of bools, since
+      these operators affect control flow, which is not allowed for vectors.
+      All other operations are performed element-wise, and return a vector of the same length
       as the input vectors. This includes:
       </p>
       <ul>
@@ -1936,6 +1939,7 @@ or
           <li>Bitwise operators ({#syntax#}>>{#endsyntax#}, {#syntax#}<<{#endsyntax#}, {#syntax#}&{#endsyntax#},
                                  {#syntax#}|{#endsyntax#}, {#syntax#}~{#endsyntax#}, etc.)</li>
           <li>Comparison operators ({#syntax#}<{#endsyntax#}, {#syntax#}>{#endsyntax#}, {#syntax#}=={#endsyntax#}, etc.)</li>
+          <li>Boolean not ({#syntax#}!{#endsyntax#})</li>
       </ul>
       <p>
       It is prohibited to use a math operator on a mixture of scalars (individual numbers)
@@ -2224,20 +2228,24 @@ or
 
       {#header_open|packed struct#}
       <p>
-      Unlike normal structs, {#syntax#}packed{#endsyntax#} structs have guaranteed in-memory layout:
+      {#syntax#}packed{#endsyntax#} structs, like {#syntax#}enum{#endsyntax#}, are based on the concept
+      of interpreting integers differently. All packed structs have a <strong>backing integer</strong>,
+      which is implicitly determined by the total bit count of fields, or explicitly specified.
+      Packed structs have well-defined memory layout - exactly the same ABI as their backing integer.
+      </p>
+      <p>
+      Each field of a packed struct is interpreted as a logical sequence of bits, arranged from
+      least to most significant. Allowed field types:
       </p>
       <ul>
-        <li>Fields remain in the order declared, least to most significant.</li>
-        <li>There is no padding between fields.</li>
-        <li>Zig supports arbitrary width {#link|Integers#} and although normally, integers with fewer
-        than 8 bits will still use 1 byte of memory, in packed structs, they use
-        exactly their bit width.
-        </li>
-        <li>{#syntax#}bool{#endsyntax#} fields use exactly 1 bit.</li>
+        <li>An {#link|integer|Integers#} field uses exactly as many bits as its
+        bit width. For example, a {#syntax#}u5{#endsyntax#} will use 5 bits of
+        the backing integer.</li>
+        <li>A {#link|bool|Primitive Types#} field uses exactly 1 bit.</li>
         <li>An {#link|enum#} field uses exactly the bit width of its integer tag type.</li>
         <li>A {#link|packed union#} field uses exactly the bit width of the union field with
         the largest bit width.</li>
-        <li>Packed structs support equality operators.</li>
+        <li>A {#syntax#}packed struct{#endsyntax#} field uses the bits of its backing integer.</li>
       </ul>
       <p>
       This means that a {#syntax#}packed struct{#endsyntax#} can participate
@@ -2245,10 +2253,11 @@ or
       This even works at {#link|comptime#}:
       </p>
       {#code|test_packed_structs.zig#}
-
       <p>
-      The backing integer is inferred from the fields' total bit width.
-      Optionally, it can be explicitly provided and enforced at compile time:
+      The backing integer can be inferred or explicitly provided. When
+      inferred, it will be unsigned. When explicitly provided, its bit width
+      will be enforced at compile time to exactly match the total bit width of
+      the fields:
       </p>
       {#code|test_missized_packed_struct.zig#}
 
@@ -2289,19 +2298,19 @@ or
       {#code|test_aligned_struct_fields.zig#}
 
       <p>
-      Equating packed structs results in a comparison of the backing integer, 
-      and only works for the `==` and `!=` operators.
+      Equating packed structs results in a comparison of the backing integer,
+      and only works for the {#syntax#}=={#endsyntax#} and {#syntax#}!={#endsyntax#} {#link|Operators#}.
       </p>
       {#code|test_packed_struct_equality.zig#}
 
       <p>
-      Using packed structs with {#link|volatile#} is problematic, and may be a compile error in the future.
-      For details on this subscribe to
-      <a href="https://github.com/ziglang/zig/issues/1761">this issue</a>.
-      TODO update these docs with a recommendation on how to use packed structs with MMIO
-      (the use case for volatile packed structs) once this issue is resolved.
-      Don't worry, there will be a good solution for this use case in zig.
+      Field access and assignment can be understood as shorthand for bitshifts
+      on the backing integer. These operations are not {#link|atomic|Atomics#},
+      so beware using field access syntax when combined with memory-mapped
+      input-output (MMIO). Instead of field access on {#link|volatile#} {#link|Pointers#},
+      construct a fully-formed new value first, then write that value to the volatile pointer.
       </p>
+      {#code|packed_struct_mmio.zig#}
       {#header_close#}
 
       {#header_open|Struct Naming#}
@@ -3679,22 +3688,22 @@ void do_a_thing(struct Foo *foo) {
           <tr>
             <th scope="row">{#syntax#}.{x}{#endsyntax#}</th>
             <td>{#syntax#}T{#endsyntax#}</td>
-            <td>{#syntax#}x{#endsyntax#} is a {#syntax#}std.meta.FieldType(T, .@"0"){#endsyntax#}</td>
+            <td>{#syntax#}x{#endsyntax#} is a {#syntax#}@FieldType(T, "0"){#endsyntax#}</td>
           </tr>
           <tr>
             <th scope="row">{#syntax#}.{ .a = x }{#endsyntax#}</th>
             <td>{#syntax#}T{#endsyntax#}</td>
-            <td>{#syntax#}x{#endsyntax#} is a {#syntax#}std.meta.FieldType(T, .a){#endsyntax#}</td>
+            <td>{#syntax#}x{#endsyntax#} is a {#syntax#}@FieldType(T, "a"){#endsyntax#}</td>
           </tr>
           <tr>
             <th scope="row">{#syntax#}T{x}{#endsyntax#}</th>
             <td>-</td>
-            <td>{#syntax#}x{#endsyntax#} is a {#syntax#}std.meta.FieldType(T, .@"0"){#endsyntax#}</td>
+            <td>{#syntax#}x{#endsyntax#} is a {#syntax#}@FieldType(T, "0"){#endsyntax#}</td>
           </tr>
           <tr>
             <th scope="row">{#syntax#}T{ .a = x }{#endsyntax#}</th>
             <td>-</td>
-            <td>{#syntax#}x{#endsyntax#} is a {#syntax#}std.meta.FieldType(T, .a){#endsyntax#}</td>
+            <td>{#syntax#}x{#endsyntax#} is a {#syntax#}@FieldType(T, "a"){#endsyntax#}</td>
           </tr>
           <tr>
             <th scope="row">{#syntax#}@Type(x){#endsyntax#}</th>
@@ -3832,37 +3841,6 @@ void do_a_thing(struct Foo *foo) {
       </div>
       {#header_close#}
       {#header_close#}
-
-      {#header_open|usingnamespace#}
-      <p>
-      {#syntax#}usingnamespace{#endsyntax#} is a declaration that mixes all the public
-      declarations of the operand, which must be a {#link|struct#}, {#link|union#}, {#link|enum#},
-      or {#link|opaque#}, into the namespace:
-      </p>
-      {#code|test_usingnamespace.zig#}
-
-      <p>
-      {#syntax#}usingnamespace{#endsyntax#} has an important use case when organizing the public
-      API of a file or package. For example, one might have <code class="file">c.zig</code> with all of the
-      {#link|C imports|Import from C Header File#}:
-      </p>
-      {#syntax_block|zig|c.zig#}
-pub usingnamespace @cImport({
-    @cInclude("epoxy/gl.h");
-    @cInclude("GLFW/glfw3.h");
-    @cDefine("STBI_ONLY_PNG", "");
-    @cDefine("STBI_NO_STDIO", "");
-    @cInclude("stb_image.h");
-});
-      {#end_syntax_block#}
-      <p>
-      The above example demonstrates using {#syntax#}pub{#endsyntax#} to qualify the
-      {#syntax#}usingnamespace{#endsyntax#} additionally makes the imported declarations
-      {#syntax#}pub{#endsyntax#}. This can be used to forward declarations, giving precise control
-      over what declarations a given file exposes.
-      </p>
-      {#header_close#}
-
 
       {#header_open|comptime#}
       <p>
@@ -4270,16 +4248,9 @@ pub fn print(self: *Writer, arg0: []const u8, arg1: i32) !void {
       {#header_close#}
 
       {#header_open|Async Functions#}
-      <p>Async functions regressed with the release of 0.11.0. Their future in
-      the Zig language is unclear due to multiple unsolved problems:</p>
-      <ul>
-        <li>LLVM's lack of ability to optimize them.</li>
-        <li>Third-party debuggers' lack of ability to debug them.</li>
-        <li><a href="https://github.com/ziglang/zig/issues/5913">The cancellation problem</a>.</li>
-        <li>Async function pointers preventing the stack size from being known.</li>
-      </ul>
-      <p>These problems are surmountable, but it will take time. The Zig team
-      is currently focused on other priorities.</p>
+      <p>Async functions regressed with the release of 0.11.0. The current plan is to
+      reintroduce them as a lower level primitive that powers I/O implementations.</p>
+      <p>Tracking issue: <a href="https://github.com/ziglang/zig/issues/23446">Proposal: stackless coroutines as low-level primitives</a></p>
       {#header_close#}
 
       {#header_open|Builtin Functions|2col#}
@@ -5143,6 +5114,23 @@ fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_val
       {#syntax#}std.crypto.secureZero{#endsyntax#}</p>
       {#header_close#}
 
+      {#header_open|@memmove#}
+      <pre>{#syntax#}@memmove(dest, source) void{#endsyntax#}</pre>
+      <p>This function copies bytes from one region of memory to another, but unlike
+      {#link|@memcpy#} the regions may overlap.</p>
+      <p>{#syntax#}dest{#endsyntax#} must be a mutable slice, a mutable pointer to an array, or
+        a mutable many-item {#link|pointer|Pointers#}. It may have any
+        alignment, and it may have any element type.</p>
+      <p>{#syntax#}source{#endsyntax#} must be a slice, a pointer to
+        an array, or a many-item {#link|pointer|Pointers#}. It may
+        have any alignment, and it may have any element type.</p>
+      <p>The {#syntax#}source{#endsyntax#} element type must have the same in-memory
+        representation as the {#syntax#}dest{#endsyntax#} element type.</p>
+      <p>Similar to {#link|for#} loops, at least one of {#syntax#}source{#endsyntax#} and
+        {#syntax#}dest{#endsyntax#} must provide a length, and if two lengths are provided,
+        they must be equal.</p>
+      {#header_close#}
+
       {#header_open|@min#}
       <pre>{#syntax#}@min(...) T{#endsyntax#}</pre>
       <p>
@@ -5498,8 +5486,9 @@ fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_val
       {#header_open|@splat#}
       <pre>{#syntax#}@splat(scalar: anytype) anytype{#endsyntax#}</pre>
       <p>
-      Produces a vector where each element is the value {#syntax#}scalar{#endsyntax#}.
-      The return type and thus the length of the vector is inferred.
+      Produces an array or vector where each element is the value
+      {#syntax#}scalar{#endsyntax#}. The return type and thus the length of the
+      vector is inferred.
       </p>
       {#code|test_splat_builtin.zig#}
 
@@ -6525,7 +6514,7 @@ fn cmpxchgWeakButNotAtomic(comptime T: type, ptr: *T, expected_value: T, new_val
       </p>
       <ul>
         <li>If a call to {#syntax#}@import{#endsyntax#} is analyzed, the file being imported is analyzed.</li>
-        <li>If a type (including a file) is analyzed, all {#syntax#}comptime{#endsyntax#}, {#syntax#}usingnamespace{#endsyntax#}, and {#syntax#}export{#endsyntax#} declarations within it are analyzed.</li>
+        <li>If a type (including a file) is analyzed, all {#syntax#}comptime{#endsyntax#} and {#syntax#}export{#endsyntax#} declarations within it are analyzed.</li>
         <li>If a type (including a file) is analyzed, and the compilation is for a {#link|test|Zig Test#}, and the module the type is within is the root module of the compilation, then all {#syntax#}test{#endsyntax#} declarations within it are also analyzed.</li>
         <li>If a reference to a named declaration (i.e. a usage of it) is analyzed, the declaration being referenced is analyzed. Declarations are order-independent, so this reference may be above or below the declaration being referenced, or even in another file entirely.</li>
       </ul>
@@ -7347,29 +7336,6 @@ fn readU32Be() u32 {}
         </tr>
         <tr>
           <th scope="row">
-            <pre>{#syntax#}async{#endsyntax#}</pre>
-          </th>
-          <td>
-            {#syntax#}async{#endsyntax#} can be used before a function call to get a pointer to the function's frame when it suspends.
-            <ul>
-              <li>See also {#link|Async Functions#}</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <th scope="row">
-            <pre>{#syntax#}await{#endsyntax#}</pre>
-          </th>
-          <td>
-            {#syntax#}await{#endsyntax#} can be used to suspend the current function until the frame provided after the {#syntax#}await{#endsyntax#} completes.
-            {#syntax#}await{#endsyntax#} copies the value returned from the target function's frame to the caller.
-            <ul>
-              <li>See also {#link|Async Functions#}</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <th scope="row">
             <pre>{#syntax#}break{#endsyntax#}</pre>
           </th>
           <td>
@@ -7787,18 +7753,6 @@ fn readU32Be() u32 {}
         </tr>
         <tr>
           <th scope="row">
-            <pre>{#syntax#}usingnamespace{#endsyntax#}</pre>
-          </th>
-          <td>
-            {#syntax#}usingnamespace{#endsyntax#} is a top-level declaration that imports all the public declarations of the operand,
-            which must be a struct, union, or enum, into the current scope.
-            <ul>
-              <li>See also {#link|usingnamespace#}</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <th scope="row">
             <pre>{#syntax#}var{#endsyntax#}</pre>
           </th>
           <td>
@@ -7866,7 +7820,6 @@ ComptimeDecl <- KEYWORD_comptime Block
 Decl
     <- (KEYWORD_export / KEYWORD_extern STRINGLITERALSINGLE? / KEYWORD_inline / KEYWORD_noinline)? FnProto (SEMICOLON / Block)
      / (KEYWORD_export / KEYWORD_extern STRINGLITERALSINGLE?)? KEYWORD_threadlocal? GlobalVarDecl
-     / KEYWORD_usingnamespace Expr SEMICOLON
 
 FnProto <- KEYWORD_fn IDENTIFIER? LPAREN ParamDeclList RPAREN ByteAlign? AddrSpace? LinkSection? CallConv? EXCLAMATIONMARK? TypeExpr
 
@@ -7979,8 +7932,7 @@ TypeExpr <- PrefixTypeOp* ErrorUnionExpr
 ErrorUnionExpr <- SuffixExpr (EXCLAMATIONMARK TypeExpr)?
 
 SuffixExpr
-    <- KEYWORD_async PrimaryTypeExpr SuffixOp* FnCallArguments
-     / PrimaryTypeExpr (SuffixOp / FnCallArguments)*
+    <- PrimaryTypeExpr (SuffixOp / FnCallArguments)*
 
 PrimaryTypeExpr
     <- BUILTINIDENTIFIER FnCallArguments
@@ -8156,7 +8108,6 @@ PrefixOp
      / MINUSPERCENT
      / AMPERSAND
      / KEYWORD_try
-     / KEYWORD_await
 
 PrefixTypeOp
     <- QUESTIONMARK
@@ -8377,8 +8328,6 @@ KEYWORD_and         <- 'and'         end_of_word
 KEYWORD_anyframe    <- 'anyframe'    end_of_word
 KEYWORD_anytype     <- 'anytype'     end_of_word
 KEYWORD_asm         <- 'asm'         end_of_word
-KEYWORD_async       <- 'async'       end_of_word
-KEYWORD_await       <- 'await'       end_of_word
 KEYWORD_break       <- 'break'       end_of_word
 KEYWORD_callconv    <- 'callconv'    end_of_word
 KEYWORD_catch       <- 'catch'       end_of_word
@@ -8415,14 +8364,13 @@ KEYWORD_threadlocal <- 'threadlocal' end_of_word
 KEYWORD_try         <- 'try'         end_of_word
 KEYWORD_union       <- 'union'       end_of_word
 KEYWORD_unreachable <- 'unreachable' end_of_word
-KEYWORD_usingnamespace <- 'usingnamespace' end_of_word
 KEYWORD_var         <- 'var'         end_of_word
 KEYWORD_volatile    <- 'volatile'    end_of_word
 KEYWORD_while       <- 'while'       end_of_word
 
 keyword <- KEYWORD_addrspace / KEYWORD_align / KEYWORD_allowzero / KEYWORD_and
-         / KEYWORD_anyframe / KEYWORD_anytype / KEYWORD_asm / KEYWORD_async
-         / KEYWORD_await / KEYWORD_break / KEYWORD_callconv / KEYWORD_catch
+         / KEYWORD_anyframe / KEYWORD_anytype / KEYWORD_asm
+         / KEYWORD_break / KEYWORD_callconv / KEYWORD_catch
          / KEYWORD_comptime / KEYWORD_const / KEYWORD_continue / KEYWORD_defer
          / KEYWORD_else / KEYWORD_enum / KEYWORD_errdefer / KEYWORD_error / KEYWORD_export
          / KEYWORD_extern / KEYWORD_fn / KEYWORD_for / KEYWORD_if
@@ -8431,7 +8379,7 @@ keyword <- KEYWORD_addrspace / KEYWORD_align / KEYWORD_allowzero / KEYWORD_and
          / KEYWORD_pub / KEYWORD_resume / KEYWORD_return / KEYWORD_linksection
          / KEYWORD_struct / KEYWORD_suspend / KEYWORD_switch / KEYWORD_test
          / KEYWORD_threadlocal / KEYWORD_try / KEYWORD_union / KEYWORD_unreachable
-         / KEYWORD_usingnamespace / KEYWORD_var / KEYWORD_volatile / KEYWORD_while
+         / KEYWORD_var / KEYWORD_volatile / KEYWORD_while
       {#end_syntax_block#}
       {#header_close#}
       {#header_open|Zen#}


### PR DESCRIPTION
The removal of `async`, `await` and `usingnamespace` is a change to Zig syntax that cannot be easily supported by ZLS.

This means that the latest nightly versions of ZLS should not be used with Zig '0.14.x'.