### PR TITLE
walk switch case values in document scope

### DIFF
--- a/src/DocumentScope.zig
+++ b/src/DocumentScope.zig
@@ -1242,6 +1242,10 @@ noinline fn walkSwitchNode(
     for (full.ast.cases, 0..) |case, case_index| {
         const switch_case: Ast.full.SwitchCase = tree.fullSwitchCase(case).?;
 
+        for (switch_case.ast.values) |case_value| {
+            try walkNode(context, tree, case_value);
+        }
+
         if (switch_case.payload_token) |payload_token| {
             const name_token = payload_token + @intFromBool(tree.tokenTag(payload_token) == .asterisk);
 

--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -3296,6 +3296,24 @@ test "either" {
     });
 }
 
+test "container type inside switch case value" {
+    try testCompletion(
+        \\test {
+        \\    switch (undefined) {
+        \\        struct {
+        \\            const This = @This();
+        \\            fn func() void {
+        \\                This.<cursor>
+        \\            }
+        \\        } => {},
+        \\    }
+        \\}
+    , &.{
+        .{ .label = "This", .kind = .Struct, .detail = "type" },
+        .{ .label = "func", .kind = .Function, .detail = "fn () void" },
+    });
+}
+
 // https://github.com/zigtools/zls/issues/1370
 test "cyclic struct init field" {
     try testCompletion(


### PR DESCRIPTION
fixes #2395

A crash doesn't occur anymore in master branch but the underlying issue is still present.
