### PR TITLE
Fix resolved type in hover for alias with different type

### DIFF
--- a/tests/lsp_features/hover.zig
+++ b/tests/lsp_features/hover.zig
@@ -1037,6 +1037,16 @@ test "var decl alias" {
     );
 }
 
+test "alias with different type" {
+    try testHoverWithOptions(
+        \\const foo: i32 = 1;
+        \\const bar<cursor>: ?i32 = foo;
+    ,
+        \\const foo: i32 = 1
+        \\(?i32)
+    , .{ .markup_kind = .plaintext });
+}
+
 test "escaped identifier" {
     try testHoverWithOptions(
         \\const @"f<cursor>oo" = 42;


### PR DESCRIPTION
```zig
const foo: i32 = 1;
const bar: ?i32 = foo;
```

The resolved type of `bar` should be `?i32`