### PR TITLE
Add error set value rename

### DIFF
--- a/src/analyser/InternPool.zig
+++ b/src/analyser/InternPool.zig
@@ -111,6 +111,7 @@ pub const Key = union(enum) {
     pub const ErrorSet = struct {
         owner_decl: Decl.OptionalIndex,
         names: StringSlice,
+        source_node: u32,
     };
 
     pub const Function = struct {
@@ -346,6 +347,7 @@ pub const Key = union(enum) {
             .error_set_type => |error_set_type| {
                 std.hash.autoHash(hasher, error_set_type.owner_decl);
                 error_set_type.names.hashWithHasher(hasher, ip);
+                std.hash.autoHash(hasher, error_set_type.source_node);
             },
             .function_type => |function_type| {
                 std.hash.autoHash(hasher, function_type.args_is_comptime);
@@ -435,6 +437,7 @@ pub const Key = union(enum) {
                 const b_info = b.error_set_type;
 
                 if (a_info.owner_decl != b_info.owner_decl) return false;
+                if (a_info.source_node != b_info.source_node) return false;
 
                 if (a_info.names.len != b_info.names.len) return false;
 
@@ -3545,6 +3548,7 @@ pub fn errorSetMerge(ip: *InternPool, gpa: Allocator, a_ty: Index, b_ty: Index) 
         .error_set_type = .{
             .owner_decl = .none,
             .names = try ip.getStringSlice(gpa, set.keys()),
+            .source_node = 0,
         },
     });
 }

--- a/src/features/references.zig
+++ b/src/features/references.zig
@@ -311,7 +311,7 @@ fn symbolReferences(
         => |payload| payload.node,
         .function_parameter => |payload| payload.func,
         .label => unreachable, // handled separately by labelReferences
-        .error_token => return .empty,
+        .error_token => null,
     };
 
     var builder: Builder = .{


### PR DESCRIPTION
This PR adds the rename symbol capability for error set values. There's most likely a more performant way of implementing it I'm not aware of.

```zig
const ServiceError = error{ QuotaExceeded } // rename symbol to 'ChangedValue'
//...
_ = ServiceError.QuotaExceeded
```

```zig
const ServiceError = error{ ChangedValue }
//...
_ = ServiceError.ChangedValue // carries over, works in reverse too
```

This doesn't work for `_ = error.QuotaExceeded`