### PR TITLE
Don't tie `force_autofix` to client capabilities

### DIFF
--- a/src/features/diagnostics.zig
+++ b/src/features/diagnostics.zig
@@ -62,7 +62,7 @@ pub fn generateDiagnostics(
 
         var diagnostics: std.ArrayListUnmanaged(types.Diagnostic) = .empty;
 
-        if (server.getAutofixMode() != .none and handle.tree.mode == .zig) {
+        if (handle.tree.mode == .zig) {
             var analyser = server.initAnalyser(arena, handle);
             defer analyser.deinit();
             try code_actions.collectAutoDiscardDiagnostics(&analyser, handle, arena, &diagnostics, server.offset_encoding);


### PR DESCRIPTION
The `force_autofix` config option would previously be ignored if the client capabilities indicated support for code actions. The intent was to prevent this config option from being enabled in editors that could natively run code action on save. However, there is no reliable way to detect whether a client supports code actions on save so this prevented autofix from being accessible in some editors (Helix).