### PR TITLE
Ensure that workspace/Configuration is always used with editors that support it (again)

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -615,7 +615,9 @@ fn initializedHandler(server: *Server, arena: std.mem.Allocator, notification: t
 
     server.status = .initialized;
 
-    if (server.client_capabilities.supports_workspace_did_change_configuration_dynamic_registration) {
+    if (server.client_capabilities.supports_configuration and
+        server.client_capabilities.supports_workspace_did_change_configuration_dynamic_registration)
+    {
         try server.registerCapability("workspace/didChangeConfiguration", null);
     }
 
@@ -946,13 +948,26 @@ fn didChangeWorkspaceFoldersHandler(server: *Server, arena: std.mem.Allocator, n
 fn didChangeConfigurationHandler(server: *Server, arena: std.mem.Allocator, notification: types.DidChangeConfigurationParams) Error!void {
     const settings = switch (notification.settings) {
         .null => {
-            if (server.client_capabilities.supports_configuration) {
+            if (server.client_capabilities.supports_configuration and
+                server.client_capabilities.supports_workspace_did_change_configuration_dynamic_registration)
+            {
+                // The client has informed us that the configuration options have
+                // changed. The will request them with `workspace/configuration`.
                 try server.requestConfiguration();
             }
             return;
         },
-        .object => |object| object.get("zls") orelse notification.settings,
-        else => notification.settings,
+        .object => |object| blk: {
+            if (server.client_capabilities.supports_configuration and
+                server.client_capabilities.supports_workspace_did_change_configuration_dynamic_registration)
+            {
+                log.debug("Ignoring 'workspace/didChangeConfiguration' notification in favor of 'workspace/configuration'", .{});
+                try server.requestConfiguration();
+                return;
+            }
+            break :blk object.get("zls") orelse notification.settings;
+        },
+        else => notification.settings, // We will definitely fail to parse this
     };
 
     const new_config = std.json.parseFromValueLeaky(


### PR DESCRIPTION
It turns out that ZLS has been relying on the outdated `workspace/didChangeConfiguration` request even in editors that supported `workspace/Configuration`. 

This change may require updating the user config to ensure ZLS options set in the editor config continue to work.

<details>

<summary>Sublime Text</summary>

```patch
{
  "clients": {
    "zls": {
      "enabled": true,
      // ...
      "settings": {
-        "zig_exe_path": "/path/to/zig_executable"
-        "enable_build_on_save": true
+        "zls": {
+          "zig_exe_path": "/path/to/zig_executable"
+          "enable_build_on_save": true
+        }
      }
    }
  }
}
```

</details>

<details>

<summary>Helix</summary>

```patch
[language-server.zls]
command = "/path/to/zls_executable"
- config.enable_build_on_save = true
- config.zig_exe_path = "/path/to/zig_executable"
+ config.zls.enable_build_on_save = true
+ config.zls.zig_exe_path = "/path/to/zig_executable"
```

</details>

<details>

<summary>Zed</summary>

```patch
{
  "lsp": {
    "zls": {
      "binary": {...},
      "settings": {
-       "enable_build_on_save": true,
-       "zig_exe_path": "/path/to/zig_executable"
+       "zls": {
+         "enable_build_on_save": true,
+         "zig_exe_path": "/path/to/zig_executable"
+       }
      }
    }
  }
}
```

</details>

<details>

<summary>Neovim</summary>

```patch
lspconfig.zls.setup {
  cmd = { '/path/to/zls_executable' },
  settings = {
-   enable_build_on_save = true,
-   zig_exe_path = '/path/to/zig_executable'
+   zls = {
+     enable_build_on_save = true,
+     zig_exe_path = '/path/to/zig_executable'
+   }
  }
}
```

</details>

To work in VS Code, this depends on https://github.com/ziglang/vscode-zig/pull/442 (released in `0.6.12`)

Previous PR that had to be reverted: #2416
