### PR TITLE
Adapt new standard library usages for compatibility with Zig 0.15.0

### DIFF
--- a/.github/workflows/publish_release.zig
+++ b/.github/workflows/publish_release.zig
@@ -60,7 +60,7 @@ pub fn main() !void {
         std.process.fatal("response {s} ({d}): {s}", .{
             result.status.phrase() orelse "",
             @intFromEnum(result.status),
-            aw.getWritten(),
+            aw.written(),
         });
     }
 }

--- a/src/features/diagnostics.zig
+++ b/src/features/diagnostics.zig
@@ -112,7 +112,7 @@ fn collectParseDiagnostics(tree: Ast, eb: *std.zig.ErrorBundle.Wip) error{OutOfM
         aw.clearRetainingCapacity();
         tree.renderError(err, &aw.writer) catch return error.OutOfMemory;
         try notes.append(allocator, try eb.addErrorMessage(.{
-            .msg = try eb.addString(aw.getWritten()),
+            .msg = try eb.addString(aw.written()),
             .src_loc = try errorBundleSourceLocationFromToken(tree, eb, err.token),
         }));
     }
@@ -120,7 +120,7 @@ fn collectParseDiagnostics(tree: Ast, eb: *std.zig.ErrorBundle.Wip) error{OutOfM
     aw.clearRetainingCapacity();
     tree.renderError(current_error, &aw.writer) catch return error.OutOfMemory;
     try eb.addRootErrorMessage(.{
-        .msg = try eb.addString(aw.getWritten()),
+        .msg = try eb.addString(aw.written()),
         .src_loc = try errorBundleSourceLocationFromToken(tree, eb, current_error.token),
         .notes_len = @intCast(notes.items.len),
     });

--- a/src/print_ast.zig
+++ b/src/print_ast.zig
@@ -913,7 +913,7 @@ test PrintAst {
         \\    }, // :2:5
         \\};
         \\
-    , aw.getWritten());
+    , aw.written());
 
     // The output itself is syntactically valid Zig code.
 

--- a/src/tools/config_gen.zig
+++ b/src/tools/config_gen.zig
@@ -951,7 +951,7 @@ fn generateVersionDataFile(allocator: std.mem.Allocator, version: []const u8, ou
         writeMarkdownFromHtml(html, &markdown.writer) catch return error.OutOfMemory;
 
         try writer.writeAll("            .documentation =\n");
-        var line_it = std.mem.splitScalar(u8, std.mem.trim(u8, markdown.getWritten(), "\n"), '\n');
+        var line_it = std.mem.splitScalar(u8, std.mem.trim(u8, markdown.written(), "\n"), '\n');
         while (line_it.next()) |line| {
             try writer.print("            \\\\{s}\n", .{std.mem.trimRight(u8, line, " ")});
         }

--- a/tests/build_runner_check.zig
+++ b/tests/build_runner_check.zig
@@ -31,7 +31,7 @@ pub fn main() !u8 {
         try std.json.Stringify.encodeJsonStringChars(&.{std.fs.path.sep}, .{}, &aw.writer);
 
         // The build runner will produce absolute paths in the output so we remove them here.
-        const actual = try std.mem.replaceOwned(u8, gpa, actual_unsanitized, aw.getWritten(), "");
+        const actual = try std.mem.replaceOwned(u8, gpa, actual_unsanitized, aw.written(), "");
 
         // We also convert windows style '\\' path separators to posix style '/'.
         switch (std.fs.path.sep) {


### PR DESCRIPTION
This PR updates **zls** to match recent Zig standard library changes:

### 1. Adapt to `std.ArrayList` default change ([ziglang/zig#24801](https://github.com/ziglang/zig/pull/24801))
In **Zig 0.15.0-dev.1519**, `std.ArrayList` now defaults to the **unmanaged** variant, breaking code that assumed the **managed** version.

Changes:
- Added per-file aliases:
  - `ArrayListUnmanaged` → `std.ArrayList`
  - `ArrayListManaged` → `std.array_list.Managed`
- Replaced `std.ArrayList` with `ArrayListManaged` where memory management is required.
- Replaced with `ArrayListUnmanaged` where unmanaged behavior is desired.

---

### 2. Migrate `std.getWritten()` to `std.written()` ([ziglang/zig#24826](https://github.com/ziglang/zig/pull/24826))
Zig replaced `std.getWritten()` with `std.written()`, deprecating the old function name.

Changes:
- Updated all occurrences of `std.getWritten()` to `std.written()` for consistency with the current API.
