### PR TITLE
fix error bundle source locations with non utf8 encoding

### DIFF
--- a/src/DocumentStore.zig
+++ b/src/DocumentStore.zig
@@ -1134,7 +1134,12 @@ fn loadBuildConfiguration(self: *DocumentStore, build_file_uri: Uri, build_file_
             .{ cwd, joined, zig_run_result.stderr },
         );
 
-        var error_bundle = try @import("features/diagnostics.zig").getErrorBundleFromStderr(self.allocator, zig_run_result.stderr, false, null);
+        var error_bundle = try @import("features/diagnostics.zig").getErrorBundleFromStderr(
+            self.allocator,
+            zig_run_result.stderr,
+            false,
+            self.getOrLoadHandle(build_file_uri).?.tree.source,
+        );
         defer error_bundle.deinit(self.allocator);
 
         try self.diagnostics_collection.pushErrorBundle(diagnostic_tag, build_file_version, cwd, error_bundle);

--- a/src/features/diagnostics.zig
+++ b/src/features/diagnostics.zig
@@ -360,7 +360,7 @@ pub fn getErrorBundleFromStderr(
     allocator: std.mem.Allocator,
     stderr_bytes: []const u8,
     ignore_src_path: bool,
-    single_file_source: ?[]const u8,
+    source: [:0]const u8,
 ) !std.zig.ErrorBundle {
     if (stderr_bytes.len == 0) return .empty;
 
@@ -391,36 +391,20 @@ pub fn getErrorBundleFromStderr(
             .character = (std.fmt.parseInt(u32, column_string, 10) catch continue) -| 1,
         };
 
-        const src_loc = if (single_file_source) |source| src_loc: {
-            const source_index = offsets.positionToIndex(source, utf8_position, .@"utf-8");
-            const source_line = offsets.lineSliceAtIndex(source, source_index);
+        const source_index = offsets.positionToIndex(source, utf8_position, .@"utf-8");
+        const source_line = offsets.lineSliceAtIndex(source, source_index);
 
-            var loc: offsets.Loc = .{ .start = source_index, .end = source_index };
+        const loc = offsets.identifierIndexToLoc(source, source_index, .full);
 
-            while (loc.end < source.len and Analyser.isSymbolChar(source[loc.end])) {
-                loc.end += 1;
-            }
-
-            break :src_loc try error_bundle.addSourceLocation(.{
-                .src_path = eb_src_path,
-                .line = utf8_position.line,
-                .column = utf8_position.character,
-                .span_start = @intCast(loc.start),
-                .span_main = @intCast(source_index),
-                .span_end = @intCast(loc.end),
-                .source_line = try error_bundle.addString(source_line),
-            });
-        } else src_loc: {
-            break :src_loc try error_bundle.addSourceLocation(.{
-                .src_path = eb_src_path,
-                .line = utf8_position.line,
-                .column = utf8_position.character,
-                .span_start = 0,
-                .span_main = 0,
-                .span_end = 0,
-                .source_line = eb_empty_string,
-            });
-        };
+        const src_loc = try error_bundle.addSourceLocation(.{
+            .src_path = eb_src_path,
+            .line = utf8_position.line,
+            .column = utf8_position.character,
+            .span_start = @intCast(loc.start),
+            .span_main = @intCast(source_index),
+            .span_end = @intCast(loc.end),
+            .source_line = try error_bundle.addString(source_line),
+        });
 
         if (std.mem.startsWith(u8, msg, " note: ")) {
             try notes.append(allocator, try error_bundle.addErrorMessage(.{


### PR DESCRIPTION
before diagnostics would just be at the first character for things like running the build runner
<img width="977" height="41" alt="image" src="https://github.com/user-attachments/assets/a0a1f67f-a39d-4145-9d81-d9fdc3a0d6b8" />

also fixes a minor bug getting the diagnostic loc when theres a quoted identifier, this would show up with `prefer_ast_check_as_child_process`
<img width="520" height="38" alt="image" src="https://github.com/user-attachments/assets/6e3bbada-4946-45ae-bca4-88a9815a24f7" />
