### PR TITLE
Remove the concept of top level snippets

### DIFF
--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -859,15 +859,6 @@ pub fn completionAtIndex(
     };
     const source = handle.tree.source;
 
-    // Provide `top_level_decl_data` only if `offsets.lineSliceUntilIndex(handle.tree.source, source_index).len` is
-    // 0 => Empty new line, manually triggered
-    // 1 => This is the very first char on a given line
-    const at_line_start = offsets.lineSliceUntilIndex(source, source_index).len < 2;
-    if (at_line_start) {
-        try populateSnippedCompletions(&builder, &snipped_data.top_level_decl_data);
-        return .{ .isIncomplete = false, .items = builder.completions.items };
-    }
-
     const pos_context = try Analyser.getPositionContext(arena, handle.tree, source_index, false);
 
     switch (pos_context) {

--- a/src/snippets.zig
+++ b/src/snippets.zig
@@ -8,29 +8,6 @@ pub const Snipped = struct {
     text: ?[]const u8 = null,
 };
 
-pub const top_level_decl_data = [_]Snipped{
-    .{ .label = "std", .kind = .Snippet, .text = "const std = @import(\"std\");" },
-    .{ .label = "root", .kind = .Snippet, .text = "const root = @import(\"root\");" },
-    .{ .label = "import", .kind = .Snippet, .text = "const $1 = @import(\"$2\")" },
-    .{ .label = "fn", .kind = .Snippet, .text = "fn ${1:name}($2) ${3:!void} {$0}" },
-    .{ .label = "pub fn", .kind = .Snippet, .text = "pub fn ${1:name}($2) ${3:!void} {$0}" },
-    .{ .label = "struct", .kind = .Snippet, .text = "const $1 = struct {$0};" },
-    .{ .label = "error set", .kind = .Snippet, .text = "const ${1:Error} = error {$0};" },
-    .{ .label = "enum", .kind = .Snippet, .text = "const $1 = enum {$0};" },
-    .{ .label = "union", .kind = .Snippet, .text = "const $1 = union {$0};" },
-    .{ .label = "union tagged", .kind = .Snippet, .text = "const $1 = union(${2:enum}) {$0};" },
-    .{ .label = "test", .kind = .Snippet, .text = "test \"$1\" {$0}" },
-    .{ .label = "main", .kind = .Snippet, .text = "pub fn main() !void {$0}" },
-    .{ .label = "std_options", .kind = .Snippet, .text = "pub const std_options: std.Options = .{$0};" },
-    .{ .label = "panic", .kind = .Snippet, .text = 
-    \\pub fn panic(
-    \\    msg: []const u8,
-    \\    trace: ?*std.builtin.StackTrace,
-    \\    ret_addr: ?usize,
-    \\) noreturn {$0}
-    },
-};
-
 pub const generic = [_]Snipped{
     // keywords
     .{ .label = "align", .kind = .Keyword },
@@ -84,6 +61,27 @@ pub const generic = [_]Snipped{
     .{ .label = "catch switch", .kind = .Snippet, .text = "catch |${1:err}| switch (${1:err}) {$0};" },
 
     // snippets
+    .{ .label = "std", .kind = .Snippet, .text = "const std = @import(\"std\");" },
+    .{ .label = "root", .kind = .Snippet, .text = "const root = @import(\"root\");" },
+    .{ .label = "import", .kind = .Snippet, .text = "const $1 = @import(\"$2\")" },
+    .{ .label = "fn", .kind = .Snippet, .text = "fn ${1:name}($2) ${3:!void} {$0}" },
+    .{ .label = "pub fn", .kind = .Snippet, .text = "pub fn ${1:name}($2) ${3:!void} {$0}" },
+    .{ .label = "struct", .kind = .Snippet, .text = "const $1 = struct {$0};" },
+    .{ .label = "error set", .kind = .Snippet, .text = "const ${1:Error} = error {$0};" },
+    .{ .label = "enum", .kind = .Snippet, .text = "const $1 = enum {$0};" },
+    .{ .label = "union", .kind = .Snippet, .text = "const $1 = union {$0};" },
+    .{ .label = "union tagged", .kind = .Snippet, .text = "const $1 = union(${2:enum}) {$0};" },
+    .{ .label = "test", .kind = .Snippet, .text = "test \"$1\" {$0}" },
+    .{ .label = "main", .kind = .Snippet, .text = "pub fn main() !void {$0}" },
+    .{ .label = "std_options", .kind = .Snippet, .text = "pub const std_options: std.Options = .{$0};" },
+    .{ .label = "panic", .kind = .Snippet, .text = 
+    \\pub fn panic(
+    \\    msg: []const u8,
+    \\    trace: ?*std.builtin.StackTrace,
+    \\    ret_addr: ?usize,
+    \\) noreturn {$0}
+    },
+
     .{ .label = "print", .kind = .Snippet, .text = "std.debug.print(\"$1\", .{$0});" },
     .{ .label = "log err", .kind = .Snippet, .text = "std.log.err(\"$1\", .{$0});" },
     .{ .label = "log warn", .kind = .Snippet, .text = "std.log.warn(\"$1\", .{$0});" },


### PR DESCRIPTION
The limit of being at the beginning of the line or at the first character of a line is too limiting. In the editor I use (`kakoune`), snippets are part of the auto completion menu that pops up as I type. If I type `print`, the `print` snippet can be selected, but not if I type `std` because of this limitation.

`print`
<img width="768" height="75" alt="image" src="https://github.com/user-attachments/assets/acabd092-d451-454b-be56-27128657580e" />

`std`
<img width="768" height="75" alt="image" src="https://github.com/user-attachments/assets/638d1c4c-286c-4618-9d77-8049650da99b" />

I could not find a reason for why it works like this in any commits or the PR that implemented it, so I suggest removing it and just always provide these snippets.