### PR TITLE
fix compile error on v0.16.0-dev.70+73a0b5441

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -101,11 +101,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755864794,
-        "narHash": "sha256-hgnov6RLA+DD4Uocs/vCbiH3/3sKvqiJOKHpdhGyVAI=",
+        "lastModified": 1756555914,
+        "narHash": "sha256-7yoSPIVEuL+3Wzf6e7NHuW3zmruHizRrYhGerjRHTLI=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "5cd601f8760d2383210b7b8c8a45fc79388f3ddf",
+        "rev": "d0df3a2fd0f11134409d6d5ea0e510e5e477f7d6",
         "type": "github"
       },
       "original": {

--- a/src/configuration.zig
+++ b/src/configuration.zig
@@ -614,7 +614,7 @@ pub fn getZigEnv(
         const source = try allocator.dupeZ(u8, zig_env_result.stdout);
         defer allocator.free(source);
 
-        return std.zon.parse.fromSlice(
+        return std.zon.parse.fromSliceAlloc(
             Env,
             result_arena,
             source,


### PR DESCRIPTION
Fixes #2470 with the solution suggested in a comment there.

`zig build test` passes for me on a linux x86-64 machine. I have not tested this on any other machines.

I have also updated the flake.nix zig version to the latest unstable version available on zig-overlay as of today. I'm happy to undo that change if desired.