### PR TITLE
Test if versions in build.zon and build.zig.zon match.

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,14 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 
-/// Must match the `version` in `build.zig.zon`.
-/// Remove `.pre` when tagging a new ZLS release and add it back on the next development cycle.
-const zls_version: std.SemanticVersion = .{ .major = 0, .minor = 16, .patch = 0, .pre = "dev" };
-
-comptime {
-    const version_in_build_zig_zon = std.SemanticVersion.parse(@import("build.zig.zon").version) catch unreachable;
-    std.debug.assert(zls_version.order(version_in_build_zig_zon) == .eq);
-}
+const zls_version = std.SemanticVersion.parse(@import("build.zig.zon").version) catch unreachable;
 
 /// Specify the minimum Zig version that is required to compile and test ZLS:
 /// Add error bundle support to `translate-c`, unify `cmdTranslateC` and `cImport`
@@ -18,15 +11,7 @@ comptime {
 /// ```bash
 /// nix flake update --commit-lock-file
 /// ```
-///
-/// Also update the `minimum_zig_version` in `build.zig.zon`.
-const minimum_build_zig_version = "0.16.0-dev.728+87c18945c";
-
-comptime {
-    const parsed_minimum_build_zig_version = std.SemanticVersion.parse(minimum_build_zig_version) catch unreachable;
-    const version_in_build_zig_zon = std.SemanticVersion.parse(@import("build.zig.zon").minimum_zig_version) catch unreachable;
-    std.debug.assert(parsed_minimum_build_zig_version.order(version_in_build_zig_zon) == .eq);
-}
+const minimum_build_zig_version = @import("build.zig.zon").minimum_zig_version;
 
 /// Specify the minimum Zig version that is usable with ZLS:
 /// Release 0.15.1

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,8 +1,9 @@
 .{
     .name = .zls,
-    // Must match the `zls_version` in `build.zig`
+    // Used by build.zig.
+    // Remove `-dev` when tagging a new ZLS release and add it back on the next development cycle.
     .version = "0.16.0-dev",
-    // Must be kept in line with the `minimum_build_zig_version` in `build.zig`.
+    // Used by build.zig.
     // Should be a Zig version that is downloadable from https://ziglang.org/download/ or a mirror.
     .minimum_zig_version = "0.16.0-dev.728+87c18945c",
     // If you do not use Nix, a ZLS maintainer can take care of this.


### PR DESCRIPTION
As can be seen without testing they became out of sync and with new ability to import zon files it's pretty easy to do.