### PR TITLE
always add an authority component to URIs

### DIFF
--- a/tests/context.zig
+++ b/tests/context.zig
@@ -89,15 +89,15 @@ pub const Context = struct {
         mode: std.zig.Ast.Mode = .zig,
     }) !zls.Uri {
         const fmt = switch (builtin.os.tag) {
-            .windows => "file:/c:/Untitled-{d}.{t}",
-            else => "file:/Untitled-{d}.{t}",
+            .windows => "file:///c:/Untitled-{d}.{t}",
+            else => "file:///Untitled-{d}.{t}",
         };
 
         const arena = self.arena.allocator();
         const path = if (options.use_file_scheme)
             try std.fmt.allocPrint(arena, fmt, .{ self.file_id, options.mode })
         else
-            try std.fmt.allocPrint(arena, "untitled:/Untitled-{d}.{t}", .{ self.file_id, options.mode });
+            try std.fmt.allocPrint(arena, "untitled:///Untitled-{d}.{t}", .{ self.file_id, options.mode });
         const uri: zls.Uri = try .parse(arena, path);
 
         const params: types.TextDocument.DidOpenParams = .{

--- a/tests/lsp_features/diagnostics.zig
+++ b/tests/lsp_features/diagnostics.zig
@@ -143,7 +143,7 @@ test "autofix comment" {
             .relatedInformation = &.{
                 .{
                     .location = .{
-                        .uri = "untitled:/Untitled-0.zig",
+                        .uri = "untitled:///Untitled-0.zig",
                         .range = .{
                             .start = .{ .line = 1, .character = 10 },
                             .end = .{ .line = 1, .character = 13 },

--- a/tests/lsp_features/hover.zig
+++ b/tests/lsp_features/hover.zig
@@ -337,7 +337,7 @@ test "root struct" {
         \\(Untitled-0)
         \\```
         \\
-        \\Go to [Untitled-0](untitled:/Untitled-0.zig#L1)
+        \\Go to [Untitled-0](untitled:///Untitled-0.zig#L1)
     );
 }
 
@@ -353,7 +353,7 @@ test "inferred struct init" {
         \\(type)
         \\```
         \\
-        \\Go to [S](untitled:/Untitled-0.zig#L1)
+        \\Go to [S](untitled:///Untitled-0.zig#L1)
     );
     try testHover(
         \\const S = struct { foo: u32 };
@@ -367,7 +367,7 @@ test "inferred struct init" {
         \\(type)
         \\```
         \\
-        \\Go to [S](untitled:/Untitled-0.zig#L1)
+        \\Go to [S](untitled:///Untitled-0.zig#L1)
     );
 }
 
@@ -385,7 +385,7 @@ test "decl literal" {
         \\(S)
         \\```
         \\
-        \\Go to [S](untitled:/Untitled-0.zig#L1)
+        \\Go to [S](untitled:///Untitled-0.zig#L1)
     );
     try testHover(
         \\const S = struct {
@@ -410,7 +410,7 @@ test "decl literal function" {
         \\(fn () S)
         \\```
         \\
-        \\Go to [S](untitled:/Untitled-0.zig#L1)
+        \\Go to [S](untitled:///Untitled-0.zig#L1)
     );
 
     try testHover(
@@ -428,7 +428,7 @@ test "decl literal function" {
         \\(fn () !S)
         \\```
         \\
-        \\Go to [S](untitled:/Untitled-0.zig#L1)
+        \\Go to [S](untitled:///Untitled-0.zig#L1)
     );
     try testHover(
         \\const Inner = struct {
@@ -448,7 +448,7 @@ test "decl literal function" {
         \\(fn () Inner)
         \\```
         \\
-        \\Go to [Inner](untitled:/Untitled-0.zig#L1)
+        \\Go to [Inner](untitled:///Untitled-0.zig#L1)
     );
 }
 
@@ -471,7 +471,7 @@ test "decl literal on generic type" {
         \\(Box(u8))
         \\```
         \\
-        \\Go to [Box](untitled:/Untitled-0.zig#L1)
+        \\Go to [Box](untitled:///Untitled-0.zig#L1)
     );
 }
 
@@ -495,7 +495,7 @@ test "decl literal on generic type - alias" {
         \\(Box(u8))
         \\```
         \\
-        \\Go to [Box](untitled:/Untitled-0.zig#L1)
+        \\Go to [Box](untitled:///Untitled-0.zig#L1)
     );
 }
 
@@ -585,7 +585,7 @@ test "enum member" {
         \\(Enum)
         \\```
         \\
-        \\Go to [Enum](untitled:/Untitled-0.zig#L1)
+        \\Go to [Enum](untitled:///Untitled-0.zig#L1)
     );
 }
 
@@ -607,7 +607,7 @@ test "generic type" {
         \\(GenericType(StructType,EnumType))
         \\```
         \\
-        \\Go to [GenericType](untitled:/Untitled-0.zig#L3) | [StructType](untitled:/Untitled-0.zig#L1) | [EnumType](untitled:/Untitled-0.zig#L2)
+        \\Go to [GenericType](untitled:///Untitled-0.zig#L3) | [StructType](untitled:///Untitled-0.zig#L1) | [EnumType](untitled:///Untitled-0.zig#L2)
     );
 }
 
@@ -652,7 +652,7 @@ test "enum literal" {
         \\(E)
         \\```
         \\
-        \\Go to [E](untitled:/Untitled-0.zig#L1)
+        \\Go to [E](untitled:///Untitled-0.zig#L1)
     );
 }
 
@@ -671,7 +671,7 @@ test "function" {
         \\(fn (A, B) error{A,B}!C)
         \\```
         \\
-        \\Go to [A](untitled:/Untitled-0.zig#L1) | [B](untitled:/Untitled-0.zig#L2) | [C](untitled:/Untitled-0.zig#L3)
+        \\Go to [A](untitled:///Untitled-0.zig#L1) | [B](untitled:///Untitled-0.zig#L2) | [C](untitled:///Untitled-0.zig#L3)
     );
     try testHover(
         \\const S = struct { a: i32 };
@@ -685,7 +685,7 @@ test "function" {
         \\(fn (S, S) error{A,B}!S)
         \\```
         \\
-        \\Go to [S](untitled:/Untitled-0.zig#L1)
+        \\Go to [S](untitled:///Untitled-0.zig#L1)
     );
     try testHover(
         \\const E = error { A, B, C };
@@ -768,7 +768,7 @@ test "optional" {
         \\(?S)
         \\```
         \\
-        \\Go to [S](untitled:/Untitled-0.zig#L1)
+        \\Go to [S](untitled:///Untitled-0.zig#L1)
     );
 }
 
@@ -785,7 +785,7 @@ test "error union" {
         \\(error{A,B}!S)
         \\```
         \\
-        \\Go to [S](untitled:/Untitled-0.zig#L1)
+        \\Go to [S](untitled:///Untitled-0.zig#L1)
     );
 }
 
@@ -1130,7 +1130,7 @@ test "escaped identifier in enum literal" {
         \\(E)
         \\```
         \\
-        \\Go to [E](untitled:/Untitled-0.zig#L1)
+        \\Go to [E](untitled:///Untitled-0.zig#L1)
     , .{
         .highlight = "@\"hello world\"",
         .markup_kind = .markdown,


### PR DESCRIPTION
Even if it is technically valid to have a URI like `file:/foo/bar`, we cannot guarantee that the client is able to parse these kinds of Uris. To be safe, we will just always add an authority component with an empty host.