### PR TITLE
fix building as a dependency when build root is inside cwd

### DIFF
--- a/tests/add_analysis_cases.zig
+++ b/tests/add_analysis_cases.zig
@@ -26,7 +26,7 @@ pub fn addCases(
     });
 
     // https://github.com/ziglang/zig/issues/20605
-    var dir = std.fs.openDirAbsolute(b.pathFromRoot(cases_path_from_root), .{ .iterate = true }) catch |err|
+    var dir = std.fs.cwd().openDir(cases_path_from_root, .{ .iterate = true }) catch |err|
         std.debug.panic("failed to open '{s}': {}", .{ cases_path_from_root, err });
     defer dir.close();
 

--- a/tests/add_build_runner_cases.zig
+++ b/tests/add_build_runner_cases.zig
@@ -23,7 +23,7 @@ pub fn addCases(
     });
 
     // https://github.com/ziglang/zig/issues/20605
-    var dir = std.fs.openDirAbsolute(b.pathFromRoot(cases_path_from_root), .{ .iterate = true }) catch |err|
+    var dir = std.fs.cwd().openDir(cases_path_from_root, .{ .iterate = true }) catch |err|
         std.debug.panic("failed to open '{s}': {}", .{ cases_path_from_root, err });
     defer dir.close();
 


### PR DESCRIPTION
If ZLS is built as a dependency while the zig cache/dependency cache is inside the cwd then `b.pathFromRoot` will give a relative path.