### PR TITLE
CI: temporarily pin Zig version to `0.16.0-dev.1484+d0ba6642b`

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: mlugg/setup-zig@v2
         if: env.SKIP_DEPLOY != 'true'
         with:
-          version: master
+          version: 0.16.0-dev.1484+d0ba6642b
 
       - name: Install APT packages
         if: env.SKIP_DEPLOY != 'true'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: mlugg/setup-zig@v2
         with:
-          version: master
+          version: 0.16.0-dev.1484+d0ba6642b
 
       - name: prefetch dependencies (workaround)
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: mlugg/setup-zig@v2
         with:
-          version: master
+          version: 0.16.0-dev.1484+d0ba6642b
 
       - name: Run zig fmt
         if: matrix.os == 'ubuntu-22.04'


### PR DESCRIPTION
Zig tarballs are in hibernation