### PR TITLE
remove deprecated pool logic and replaced with async

### DIFF
--- a/src/analyser/InternPool.zig
+++ b/src/analyser/InternPool.zig
@@ -4839,8 +4839,7 @@ test "test thread safety of InternPool" {
     if (builtin.single_threaded) return error.SkipZigTest;
 
     const gpa = std.testing.allocator;
-    var pool: std.Thread.Pool = undefined;
-    try pool.init(.{ .allocator = gpa });
+    var pool: std.Io.Threaded = .init(gpa);
     defer pool.deinit();
 
     var ip: InternPool = try .init(gpa);
@@ -4853,11 +4852,9 @@ test "test thread safety of InternPool" {
     const funcs = struct {
         fn do(
             intern_pool: *InternPool,
-            wait_group: *std.Thread.WaitGroup,
             allocator: std.mem.Allocator,
             count: usize,
         ) void {
-            defer wait_group.finish();
             // insert float_32_value from 0 to count + random work
             for (0..count) |i| {
                 _ = intern_pool.get(allocator, .{ .float_32_value = @floatFromInt(i) }) catch @panic("OOM");
@@ -4869,12 +4866,12 @@ test "test thread safety of InternPool" {
         }
     };
 
-    var wait_group: std.Thread.WaitGroup = .{};
-    for (0..pool.threads.len) |_| {
-        wait_group.start();
-        try pool.spawn(funcs.do, .{ &ip, &wait_group, gpa, size });
+    var wait_group: std.Io.Group = .init;
+    const io = pool.ioBasic();
+    for (0..@max(1, pool.async_limit.minInt(4))) |_| {
+        wait_group.async(io, funcs.do, .{ &ip, gpa, size });
     }
-    pool.waitAndWork(&wait_group);
+    wait_group.wait(io);
 
     try std.testing.expectEqual(index_start + size, ip.map.count());
 

--- a/tests/analysis_check.zig
+++ b/tests/analysis_check.zig
@@ -94,8 +94,7 @@ pub fn main() Error!void {
         }
     }
 
-    var thread_pool: std.Thread.Pool = undefined;
-    thread_pool.init(.{ .allocator = gpa }) catch std.debug.panic("failed to initalize thread pool", .{});
+    var thread_pool: std.Io.Threaded = .init(gpa);
     defer thread_pool.deinit();
 
     var ip: InternPool = try .init(gpa);


### PR DESCRIPTION
The current 0.16 branch of zig has deprecated Pool in favor of Io.Thread and Io.Group . This just updates all the threading logic with this change.

https://codeberg.org/ziglang/zig/commit/985a3565c6130c7279319e9c36642f0b958e6944#diff-f192d18f39c389fafe62a3a341b75c760701fcae