### PR TITLE
feat: inlay hints for decl literal functions

### DIFF
--- a/src/features/inlay_hints.zig
+++ b/src/features/inlay_hints.zig
@@ -399,7 +399,7 @@ fn writeCallNodeHint(builder: *Builder, call: Ast.full.Call) !void {
     const tree = &handle.tree;
 
     switch (tree.nodeTag(call.ast.fn_expr)) {
-        .identifier, .field_access => try writeCallHint(builder, call),
+        .identifier, .field_access, .enum_literal => try writeCallHint(builder, call),
         else => {
             log.debug("cannot deduce fn expression with tag '{}'", .{tree.nodeTag(call.ast.fn_expr)});
         },

--- a/tests/analysis/decl_literal.zig
+++ b/tests/analysis/decl_literal.zig
@@ -22,6 +22,13 @@ const TaggedUnionType = union(EnumType) {
     const baz: TaggedUnionType = .{ .foo = 1 };
 };
 
+const OpaqueType = opaque {
+    pub fn init() *OpaqueType {
+        var value: void = {};
+        return @ptrCast(&value);
+    }
+};
+
 const some_struct: StructType = .baz;
 //                              ^^^^ (StructType)()
 
@@ -33,3 +40,6 @@ const some_union: UnionType = .baz;
 
 const some_tagged_union: TaggedUnionType = .baz;
 //                                         ^^^^ (TaggedUnionType)()
+
+const some_opaque: *OpaqueType = .init();
+//                               ^^^^^ (fn () *OpaqueType)()

--- a/tests/lsp_features/inlay_hints.zig
+++ b/tests/lsp_features/inlay_hints.zig
@@ -584,6 +584,15 @@ test "tuple fields" {
     , .{ .kind = .Type });
 }
 
+test "declaration literals" {
+    try testInlayHints(
+        \\const X = opaque { fn init(a_thing: u32, b_thing: u32) *X { _ = .{a_thing, b_thing}; const ignore: void = {}; return @ptrCast(&ignore); } };
+        \\test {
+        \\    const x: *X = .init(<a_thing>0, <b_thing>1);
+        \\}
+    , .{ .kind = .Parameter });
+}
+
 const Options = struct {
     kind: types.InlayHint.Kind,
     show_builtin: bool = true,


### PR DESCRIPTION
This started when i noticed a bunch of output in the lsp logs that say `cannot deduce fn expression with tag '.enum_literal'`

This PR accomplishes the following:
- opaque types are now also searched for decl literals
- enum literal types are now resolved if there's a binding type
- inlay hints are now printed for declaration literal function calls