### PR TITLE
feat: support 0.16.0-dev.1976+8e091047b

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -345,7 +345,7 @@ fn getVersion(b: *Build) std.SemanticVersion {
         "git", "-C", b.pathFromRoot("."), "--git-dir", ".git", "describe", "--match", "*.*.*", "--tags",
     };
     var code: u8 = undefined;
-    const git_describe_untrimmed = b.runAllowFail(argv, &code, .Ignore) catch |err| {
+    const git_describe_untrimmed = b.runAllowFail(argv, &code, .ignore) catch |err| {
         const argv_joined = std.mem.join(b.allocator, " ", argv) catch @panic("OOM");
         std.log.warn(
             \\Failed to run git describe to resolve ZLS version: {}

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -10,7 +10,7 @@
     // nix flake update --commit-lock-file
     // ```
     // If you do not use Nix, a ZLS maintainer can take care of this.
-    .minimum_zig_version = "0.16.0-dev.1912+0cbaaa5eb",
+    .minimum_zig_version = "0.16.0-dev.1976+8e091047b",
     // If you do not use Nix, a ZLS maintainer can take care of this.
     // Whenever the dependencies are updated, run the following command:
     // ```bash

--- a/src/tools/config_gen.zig
+++ b/src/tools/config_gen.zig
@@ -1010,7 +1010,7 @@ fn generateVersionDataFile(
     try file_writer.end();
 }
 
-pub fn main() !void {
+pub fn main(init: std.process.Init.Minimal) !void {
     var debug_allocator: std.heap.DebugAllocator(.{}) = .init;
     defer _ = debug_allocator.deinit();
     const gpa = debug_allocator.allocator();
@@ -1018,7 +1018,7 @@ pub fn main() !void {
     var threaded: std.Io.Threaded = .init_single_threaded;
     const io = threaded.io();
 
-    var args_it = try std.process.argsWithAllocator(gpa);
+    var args_it = try init.args.iterateAllocator(gpa);
     defer args_it.deinit();
 
     _ = args_it.skip();


### PR DESCRIPTION
i'm not sure exactly _which_ master release is associated with which changes, so this is best-guess

- `std.process.SpawnOptions.StdIo.Ignore` -> `std.process.SpawnOptions.StdIo.ignore`
- use `std.process.Init.Minimal`
  - `build_runner.zig` detects whether this usage is necessary or not and selects an entrypoint function based on the zig release version
- `std.Build.Graph` has a new field `cwd` for the path of the cwd
- `std.Build.Watch` also gained a new param `cwd_path` which is now propagated