### PR TITLE
Limit generating top level imports folding ranges to .zig files only

### DIFF
--- a/src/features/folding_range.zig
+++ b/src/features/folding_range.zig
@@ -182,7 +182,7 @@ pub fn generateFoldingRanges(allocator: std.mem.Allocator, tree: *const Ast, enc
     // TODO add folding range normal comments
 
     // Folding range for top level imports
-    {
+    if (tree.mode == .zig) {
         var start_import: ?Ast.Node.Index = null;
         var end_import: ?Ast.Node.Index = null;
 


### PR DESCRIPTION
Fixes #2543 