### PR TITLE
fix: param placeholders for types with right brace

### DIFF
--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -3930,6 +3930,48 @@ test "insert replace behaviour - function with snippets" {
     });
 }
 
+test "insert replace behaviour - function with snippets - placeholder for argument with type containing '}'" {
+    try testCompletionTextEdit(.{
+        .source =
+        \\fn func(x: struct {u32}, y: struct {a:i32}) void {}
+        \\const foo = <cursor>;
+        ,
+        .label = "func",
+        .expected_insert_line = "const foo = func(${1:x: struct { u32 \\}}, ${2:y: struct {...\\}});",
+        .expected_replace_line = "const foo = func(${1:x: struct { u32 \\}}, ${2:y: struct {...\\}});",
+        .enable_snippets = true,
+        .enable_argument_placeholders = true,
+    });
+    try testCompletionTextEdit(.{
+        .source =
+        \\const @"SomeType}" = struct {};
+        \\fn func(x: @"SomeType}") void {}
+        \\const foo = <cursor>;
+        ,
+        .label = "func",
+        .expected_insert_line =
+        \\const foo = func(${1:x: @"SomeType\}"});
+        ,
+        .expected_replace_line =
+        \\const foo = func(${1:x: @"SomeType\}"});
+        ,
+        .enable_snippets = true,
+        .enable_argument_placeholders = true,
+    });
+    try testCompletionTextEdit(.{
+        .source =
+        \\fn Type(comptime T: type) type { return opaque {}; }
+        \\fn func(x: Type(struct {})) void {}
+        \\const foo = <cursor>;
+        ,
+        .label = "func",
+        .expected_insert_line = "const foo = func(${1:x: Type(struct {\\})});",
+        .expected_replace_line = "const foo = func(${1:x: Type(struct {\\})});",
+        .enable_snippets = true,
+        .enable_argument_placeholders = true,
+    });
+}
+
 test "insert replace behaviour - function with snippets - 'self parameter' with placeholder" {
     try testCompletionTextEdit(.{
         .source =


### PR DESCRIPTION
Completions for functions with snippet placeholders are broken when an argument's type is rendered with a right brace (`}`). The right brace symbol is rendered unescaped, which causes snippet parsers to interpret it as the end of the placeholder, leaving an extra trailing `}`.


Example:

```zig
fn foo(x: struct { x: i32 }) void {
    _ = x;
}
```
```
When expanding the completion item for a function call of `foo` with snippet placeholders,
we get the following:

     selected region
     ______________
    |              |
foo(|x: struct {...|})


The snippet is parsed as follows:

      __ placeholder start
     |
foo(${1:x: struct {...}})
                  ^   ^^
                 /    | \_____ not part of snippet placeholder
            ignored   |
                     placeholder end

```

This occurs (at least) in the following cases:
1. type is an anonymous container literal (`enum { ... }`)
2. type's name is a raw identifier with a `}` (`@"Evil}Name"`)
3. type is a generic function with a type argument that is itself problematic (`std.ArrayList(struct {})`, ...)

Fixed by adding an `escape_r_braces` option to `FormatOptions` and escaping '`}`' symbols (as specified by [LSP protocol - Snippet syntax](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#snippet_syntax)) in `Type.rawStringify()` when this option is set to `true`. When `rawStringifyParameter` calls this function, it sets `options.escape_r_braces` to `true` if snippet placeholders are enabled.

In `Type.rawStringify`, I only specifically handle `escape_r_braces` in cases where I've encountered this bug. There are a few lines in that function that render strings as is (without potentially escaping r-braces) which I didn't touch because I haven't encountered errors related to those code paths (and in most cases, wasn't sure if those code paths are reachable with snippet placeholders and/or can ever yield `}` symbols).

I did this so that the changes map nicely onto the added test cases (removing any change causes at least one of the added tests to fail).
