### PR TITLE
customize how builtin function signatures are rendered for each request

### DIFF
--- a/src/features/hover.zig
+++ b/src/features/hover.zig
@@ -250,13 +250,19 @@ fn hoverDefinitionBuiltin(
     }
 
     const builtin = data.builtins.get(name) orelse return null;
+    const signature = try Analyser.renderBuiltinFunctionSignature(
+        arena,
+        name,
+        builtin,
+        builtin.parameters.len > 3,
+    );
 
     switch (markup_kind) {
         .plaintext, .unknown_value => {
             try contents.print(arena,
                 \\{s}
                 \\{s}
-            , .{ builtin.signature, builtin.documentation });
+            , .{ signature, builtin.documentation });
         },
         .markdown => {
             try contents.print(arena,
@@ -264,7 +270,7 @@ fn hoverDefinitionBuiltin(
                 \\{s}
                 \\```
                 \\{s}
-            , .{ builtin.signature, builtin.documentation });
+            , .{ signature, builtin.documentation });
         },
     }
 

--- a/tests/lsp_features/hover.zig
+++ b/tests/lsp_features/hover.zig
@@ -221,6 +221,21 @@ test "builtin" {
     , .{ .markup_kind = .plaintext });
 }
 
+test "builtin with multi line parameters" {
+    try testHoverWithOptions(
+        \\@Un<cursor>ion()
+    ,
+        \\@Union(
+        \\  comptime layout: Type.ContainerLayout,
+        \\  comptime ArgType: ?type,
+        \\  comptime field_names: []const []const u8,
+        \\  comptime field_types: *const [field_names.len]type,
+        \\  comptime field_attrs: *const [field_names.len]Type.UnionField.Attributes,
+        \\) type
+        \\Returns a [union](https://ziglang.org/documentation/master/#union) type with the properties specified by the arguments.
+    , .{ .markup_kind = .plaintext });
+}
+
 test "struct" {
     try testHover(
         \\const Str<cursor>uct = packed struct(u32) {};


### PR DESCRIPTION
- hover & completion detail will be multi line when there >3 parameters
- signature help will report documentation for individual parameters if available
- signature help documentation was incorrectly rendered in plaintext instead of markdown