### PR TITLE
completion: dont complete function call for doctest name

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -4886,6 +4886,7 @@ pub const PositionContext = union(enum) {
     parens_expr: offsets.Loc,
     keyword: Ast.TokenIndex,
     error_access,
+    test_doctest_name,
     comment,
     other,
     empty,
@@ -4908,6 +4909,7 @@ pub const PositionContext = union(enum) {
             => |l| return l,
             .keyword => |token_index| return offsets.tokenToLoc(tree, token_index),
             .error_access,
+            .test_doctest_name,
             .comment,
             .other,
             .empty,
@@ -5164,6 +5166,7 @@ pub fn getPositionContext(
                     .{ .label_access = tok.loc }
                 else
                     .{ .var_access = tok.loc },
+                .test_doctest_name => curr_ctx.ctx = .test_doctest_name,
                 else => curr_ctx.ctx = .{ .var_access = tok.loc },
             },
             .builtin => curr_ctx.ctx = .{ .builtin = tok.loc },
@@ -5230,6 +5233,7 @@ pub fn getPositionContext(
                 std.debug.assert(tree.tokenTag(current_token) == tag);
                 curr_ctx.ctx = .{ .keyword = current_token };
             },
+            .keyword_test => curr_ctx.ctx = .test_doctest_name,
             .container_doc_comment => curr_ctx.ctx = .comment,
             .doc_comment => {
                 if (!curr_ctx.isErrSetDef()) curr_ctx.ctx = .comment; // Intent is to skip everything between the `error{...}` braces

--- a/src/features/goto.zig
+++ b/src/features/goto.zig
@@ -316,7 +316,7 @@ pub fn gotoHandler(
 
     const response: types.Definition.Link = blk: switch (pos_context) {
         .builtin => |loc| try gotoDefinitionBuiltin(&analyser, handle, loc, server.offset_encoding),
-        .var_access => try gotoDefinitionGlobal(&analyser, handle, source_index, kind, server.offset_encoding),
+        .var_access, .test_doctest_name => try gotoDefinitionGlobal(&analyser, handle, source_index, kind, server.offset_encoding),
         .label_access, .label_decl => |loc| try gotoDefinitionLabel(&analyser, handle, source_index, loc, kind, server.offset_encoding),
         .enum_literal => try gotoDefinitionEnumLiteral(&analyser, handle, source_index, kind, server.offset_encoding),
 

--- a/src/features/hover.zig
+++ b/src/features/hover.zig
@@ -516,7 +516,7 @@ pub fn hover(
 
     const response = switch (pos_context) {
         .builtin => |loc| try hoverDefinitionBuiltin(analyser, arena, handle, source_index, loc, markup_kind, offset_encoding),
-        .var_access => try hoverDefinitionGlobal(analyser, arena, handle, source_index, markup_kind, offset_encoding),
+        .var_access, .test_doctest_name => try hoverDefinitionGlobal(analyser, arena, handle, source_index, markup_kind, offset_encoding),
         .field_access => |loc| try hoverDefinitionFieldAccess(analyser, arena, handle, source_index, loc, markup_kind, offset_encoding),
         .label_access, .label_decl => |loc| try hoverDefinitionLabel(analyser, arena, handle, source_index, loc, markup_kind, offset_encoding),
         .enum_literal => try hoverDefinitionEnumLiteral(analyser, arena, handle, source_index, markup_kind, offset_encoding),

--- a/src/features/references.zig
+++ b/src/features/references.zig
@@ -682,7 +682,7 @@ pub fn referencesHandler(server: *Server, arena: std.mem.Allocator, request: Gen
         const name = offsets.locToSlice(handle.tree.source, name_loc);
 
         const decl = switch (pos_context) {
-            .var_access => try analyser.lookupSymbolGlobal(handle, name, source_index),
+            .var_access, .test_doctest_name => try analyser.lookupSymbolGlobal(handle, name, source_index),
             .field_access => |loc| z: {
                 const held_loc = offsets.locMerge(loc, name_loc);
                 const a = try analyser.getSymbolFieldAccesses(arena, handle, source_index, held_loc, name);

--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -4266,7 +4266,6 @@ test "insert replace behaviour - tagged union - zero-bit field" {
 }
 
 test "insert replace behaviour - doc test name" {
-    if (true) return error.SkipZigTest; // TODO
     try testCompletionTextEdit(.{
         .source =
         \\fn foo() void {};
@@ -4398,6 +4397,15 @@ test "methods of branching type" {
             .kind = .Function,
             .detail = "fn (_: *either type) bool",
         },
+    });
+}
+
+test "doctest name" {
+    try testCompletion(
+        \\fn foo() void {};
+        \\test <cursor>
+    , &.{
+        .{ .label = "foo", .kind = .Function, .detail = "fn () void" },
     });
 }
 

--- a/tests/lsp_features/hover.zig
+++ b/tests/lsp_features/hover.zig
@@ -1398,6 +1398,20 @@ test "pointer dereference" {
     });
 }
 
+test "doctest" {
+    try testHover(
+        \\fn foo() void {}
+        \\test <cursor>foo {}
+    ,
+        \\```zig
+        \\fn foo() void
+        \\```
+        \\```zig
+        \\(fn () void)
+        \\```
+    );
+}
+
 fn testHover(source: []const u8, expected: []const u8) !void {
     try testHoverWithOptions(source, expected, .{ .markup_kind = .markdown });
 }


### PR DESCRIPTION
this has been bothering me...

when typing the name of a function for a doctest, the current behavior appends call syntax (`(...)`) for the doctest. for example:

```zig
fn foo() void {}
test f<complete>
```

the current behavior results in:
```zig
test foo()
```

but the behavior _should_ be:
```zig
test foo
```