### PR TITLE
feat(goto): goto definition prefers builtin This()

### DIFF
--- a/tests/lsp_features/definition.zig
+++ b/tests/lsp_features/definition.zig
@@ -350,9 +350,19 @@ test "type definition unwraps error unions, optionals, pointers" {
 
 test "builtins" {
     try testDefinition(
-        \\const S = <def><decl>struct</decl></def> {
-        \\    const Self = <>@This();
+        \\const S = struct {
+        \\    const <def><decl>Self</decl></def> = <>@This();
         \\};
+    );
+    try testDefinition(
+        \\const <decl>S</decl> = struct {
+        \\    const <def>Self</def> = @This();
+        \\};
+        \\const foo: <>S = .{};
+    );
+    try testDefinition(
+        \\const <def><decl>S</decl></def> = @This();
+        \\const foo: <>S = .{};
     );
 }
 


### PR DESCRIPTION
closes #1596

consider goto on `Io` from `std.Io`. goto definition currently goes to the beginning of the file, but it's typically more helpful to go to `Io` in its internal declaration `const Io = @This()`.

contrary to the issue description, this PR also goes-to such definitions for non-file container definitions. Note that goto-declaration still goes to the outer declaration, while goto-definition now goes to the `@This()` declaration if it exists.