### PR TITLE
Juicy main snippet

### DIFF
--- a/src/snippets.zig
+++ b/src/snippets.zig
@@ -21,7 +21,7 @@ pub const top_level: []const Item = &.{
     .{ .label = "union", .snippet = "const $1 = union {$0};" },
     .{ .label = "union tagged", .snippet = "const $1 = union(${2:enum}) {$0};" },
     .{ .label = "test", .snippet = "test \"$1\" {$0}" },
-    .{ .label = "main", .snippet = "pub fn main() !void {$0}" },
+    .{ .label = "main", .snippet = "pub fn main(init: std.process.Init) !void {$0}" },
     .{ .label = "std_options", .snippet = "pub const std_options: std.Options = .{$0};" },
     .{ .label = "panic", .snippet =
     \\pub fn panic(


### PR DESCRIPTION
I'm a heavy `main` snippet user, mostly for one-off playground scripts, but also for the occasional new project. Since juicy main PR, I've found myself getting annoyed by having to manually add the `std.process.Init` parameter.

Decided to go with `init` as the parameter name, since it seems to have become the convention. Also, the zig compiler uses that name for its entry point.

So that's it, just a little PR, which hopefully will make life of heavy LSP users like me a tiny bit more convenient.
I also expect this to expose new zig users to juicy main, which is a plus, and will probably reduce help questions like "where do you find command line arguments and environment variables?"

Thank you for your work keeping ZLS updated, I appreciate it.