### PR TITLE
improve zig exe lookup when using symlinks, scripts or version managers

### DIFF
--- a/src/configuration.zig
+++ b/src/configuration.zig
@@ -183,11 +183,12 @@ pub const Manager = struct {
             };
 
             manager.zig_exe = .{
-                .path = exe_path,
+                .path = zig_env.zig_exe,
                 .version = zig_version,
                 .env = zig_env,
             };
         }
+        config.zig_exe_path = if (manager.zig_exe) |exe| exe.path else null;
 
         if (config.zig_lib_path == null) blk: {
             if (!std.process.can_spawn) break :blk;


### PR DESCRIPTION
The zig executable may be some kind of proxy that internally forwards to different Zig versions. When ZLS runs the zig executable in different locations (e.g. packages in the global zig cache), this may cause multiple Zig versions to be downloaded and used which can cause all kinds of issues.

This change will ensure that the proxy will only ever be queried once by using the `zig_exe` field from the `zig env` output. If `zig env` fails, the zig exe path will be unset and any zig compiler integrated will be disabled.