### PR TITLE
add `collapsedText` to import folding ranges

### DIFF
--- a/src/features/folding_range.zig
+++ b/src/features/folding_range.zig
@@ -138,6 +138,8 @@ const Builder = struct {
                 .endLine = range.end.line,
                 .endCharacter = range.end.character,
                 .kind = folding_range.kind,
+                // TODO this should be simplified https://codeberg.org/ziglang/zig/issues/30627
+                .collapsedText = if (folding_range.kind != null and folding_range.kind.? == .imports) "@import(...)" else null,
             });
         }
 
@@ -203,7 +205,7 @@ pub fn generateFoldingRanges(allocator: std.mem.Allocator, tree: *const Ast, enc
                 end_import = node;
             } else if (start_import != null and end_import != null) {
                 // We found a non-import after a sequence of imports, create folding range
-                try builder.add(null, tree.firstToken(start_import.?), ast.lastToken(tree, end_import.?), .inclusive, .inclusive);
+                try builder.add(.imports, tree.firstToken(start_import.?), ast.lastToken(tree, end_import.?), .inclusive, .inclusive);
                 start_import = null;
                 end_import = null;
             }
@@ -211,7 +213,7 @@ pub fn generateFoldingRanges(allocator: std.mem.Allocator, tree: *const Ast, enc
 
         // Handle the case where imports continue to the end of the file
         if (start_import != null and end_import != null and start_import.? != end_import.?) {
-            try builder.add(null, tree.firstToken(start_import.?), ast.lastToken(tree, end_import.?), .inclusive, .inclusive);
+            try builder.add(.imports, tree.firstToken(start_import.?), ast.lastToken(tree, end_import.?), .inclusive, .inclusive);
         }
     }
 

--- a/tests/lsp_features/folding_range.zig
+++ b/tests/lsp_features/folding_range.zig
@@ -425,7 +425,14 @@ test "imports" {
         \\const std = @import("std");
         \\const builtin = @import("builtin");
     , &.{
-        .{ .startLine = 0, .startCharacter = 0, .endLine = 1, .endCharacter = 34 },
+        .{
+            .startLine = 0,
+            .startCharacter = 0,
+            .endLine = 1,
+            .endCharacter = 34,
+            .kind = .imports,
+            .collapsedText = "@import(...)",
+        },
     });
     try testFoldingRange(
         \\const std = @import("std");
@@ -435,7 +442,14 @@ test "imports" {
         \\
         \\pub fn main() void {}
     , &.{
-        .{ .startLine = 0, .startCharacter = 0, .endLine = 3, .endCharacter = 23 },
+        .{
+            .startLine = 0,
+            .startCharacter = 0,
+            .endLine = 3,
+            .endCharacter = 23,
+            .kind = .imports,
+            .collapsedText = "@import(...)",
+        },
     });
     // Single import should not create folding range
     try testFoldingRange(
@@ -453,8 +467,22 @@ test "imports" {
         \\const lsp = @import("lsp");
         \\const types = @import("types");
     , &.{
-        .{ .startLine = 0, .startCharacter = 0, .endLine = 1, .endCharacter = 34 },
-        .{ .startLine = 5, .startCharacter = 0, .endLine = 6, .endCharacter = 30 },
+        .{
+            .startLine = 0,
+            .startCharacter = 0,
+            .endLine = 1,
+            .endCharacter = 34,
+            .kind = .imports,
+            .collapsedText = "@import(...)",
+        },
+        .{
+            .startLine = 5,
+            .startCharacter = 0,
+            .endLine = 6,
+            .endCharacter = 30,
+            .kind = .imports,
+            .collapsedText = "@import(...)",
+        },
     });
 }
 


### PR DESCRIPTION
this gives editors something a little nicer to show when folding instead of just the first line or some ellipses like most do by default
<img width="500" height="187" alt="image" src="https://github.com/user-attachments/assets/949a85be-6ad3-4939-a824-520e50ddfd3a" />

<img width="304" height="161" alt="image" src="https://github.com/user-attachments/assets/5ba7aa01-0ab2-4646-afe7-9f02c024aa28" />
