### PR TITLE
fix: build_runner Watch.wait()

### DIFF
--- a/src/build_runner/build_runner.zig
+++ b/src/build_runner/build_runner.zig
@@ -530,7 +530,7 @@ const Watch = struct {
 
     fn wait(w: *Watch, gpa: Allocator, timeout: Io.Timeout) !std.Build.Watch.WaitResult {
         if (@TypeOf(std.Build.Watch) != void and w.supports_fs_watch) {
-            return try w.fs_watch.wait(gpa, switch (timeout) {
+            return try w.fs_watch.wait(gpa, w.io, switch (timeout) {
                 .none => .none,
                 .duration => |d| .{ .ms = @intCast(d.raw.toMilliseconds()) },
                 .deadline => unreachable,


### PR DESCRIPTION
Passed the missing io required by fs_watch.wait(*Watch, Allocator, Io,Timeout)

Reference issues: Closes #2598