### PR TITLE
Update known-folders dependency to fix breakage in 0.16.0-dev.2535+b5bd49460

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -19,8 +19,8 @@
     // The `deps.nix` should also be updated to not fetch `tracy`.
     .dependencies = .{
         .known_folders = .{
-            .url = "https://github.com/ziglibs/known-folders/archive/82027007c0eb199a3242c167a5cffd83b6ee571b.tar.gz",
-            .hash = "known_folders-0.0.0-Fy-PJqHJAAB43zDJmOdlr3nViu69IFI9pNFt7hkHjKk4",
+            .url = "git+https://github.com/ziglibs/known-folders#d002ad87b1f8c238eb080c185bb0b93cfd946b9d",
+            .hash = "known_folders-0.0.0-Fy-PJiXKAACLbIUjxVqJRTSLc6HNnMkCSBnC5LW0Lx_v",
         },
         .diffz = .{
             .url = "https://github.com/ziglibs/diffz/archive/aa11caef328a3f20f2493f8fd676a1dfa7819246.tar.gz",


### PR DESCRIPTION
Using zig version `0.16.0-dev.2535+b5bd49460` on Windows 11 causes the following error. This error is fixed by updating the known-folders dependency.

```bash
❯ zig build -Doptimize=ReleaseSafe
install
└─ install zls
   └─ compile exe zls ReleaseSafe native 1 errors
zig-pkg\known_folders-0.0.0-Fy-PJqHJAAB43zDJmOdlr3nViu69IFI9pNFt7hkHjKk4\known-folders.zig:167:39: error: root
source file struct 'os.windows' has no member named 'KF_FLAG_CREATE'
                        std.os.windows.KF_FLAG_CREATE, // TODO: Chose sane option here?
                        ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
C:\Users\reshen\gamedev\tools\zig-x86_64-windows-0.16.0-dev.2535+b5bd49460\lib\std\os\windows.zig:1:1: note: struct declared here
//! This file contains thin wrappers around Windows-specific APIs, with these
^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
referenced by:
    getPath: zig-pkg\known_folders-0.0.0-Fy-PJqHJAAB43zDJmOdlr3nViu69IFI9pNFt7hkHjKk4\known-folders.zig:139:24
    loadConfiguration: src\main.zig:412:57
    5 reference(s) hidden; use '-freference-trace=7' to see all references
error: 1 compilation errors
```