### PR TITLE
fix completions replacing punctuation

### DIFF
--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -487,7 +487,6 @@ fn prepareCompletionLoc(tree: *const Ast, source_index: usize) offsets.Loc {
             std.debug.assert(token_loc.start <= source_index and source_index <= token_loc.end);
             return offsets.identifierIndexToLoc(tree.source, token_loc.start, if (tag == .builtin) .name else .full);
         },
-        .colon => return fallback_loc,
         else => {
             const token_start = tree.tokenStart(token);
 
@@ -498,6 +497,8 @@ fn prepareCompletionLoc(tree: *const Ast, source_index: usize) offsets.Loc {
                     if (token_start + 1 < source_index) return fallback_loc;
                     break :start .{ token_start + 1, token_start + 1 };
                 } else {
+                    if (!offsets.isSymbolChar(tree.source[token_start]))
+                        return fallback_loc;
                     break :start .{ token_start, token_start };
                 }
             };

--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -4348,6 +4348,36 @@ test "doctest name" {
     });
 }
 
+test "completions don't replace punctuation" {
+    try testCompletionTextEdit(.{
+        .source =
+        \\const foo = 0;
+        \\const bar = foo[<cursor>];
+        ,
+        .label = "foo",
+        .expected_insert_line = "const bar = foo[foo];",
+        .expected_replace_line = "const bar = foo[foo];",
+    });
+    try testCompletionTextEdit(.{
+        .source =
+        \\const foo = 0;
+        \\const bar = foo(<cursor>);
+        ,
+        .label = "foo",
+        .expected_insert_line = "const bar = foo(foo);",
+        .expected_replace_line = "const bar = foo(foo);",
+    });
+    try testCompletionTextEdit(.{
+        .source =
+        \\const foo = 0;
+        \\const bar = foo{<cursor>};
+        ,
+        .label = "foo",
+        .expected_insert_line = "const bar = foo{foo};",
+        .expected_replace_line = "const bar = foo{foo};",
+    });
+}
+
 fn testCompletion(source: []const u8, expected_completions: []const Completion) !void {
     try testCompletionWithOptions(source, expected_completions, .{});
 }


### PR DESCRIPTION
basically the same as https://github.com/zigtools/zls/pull/2605, the `(`,`[`,`{` would get replaced when completions were manually triggered
this affected a lot more than what I added tests for but it seems unlikely that any one in particular would uniquely regress so I just did some more likely cases to keep it small