### PR TITLE
Completion for errors

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -4754,7 +4754,7 @@ pub const PositionContext = union(enum) {
     /// XXX: Internal use only, currently points to the loc of the first l_paren
     parens_expr: offsets.Loc,
     keyword: Ast.TokenIndex,
-    error_access,
+    error_access: offsets.Loc,
     comment,
     other,
     empty,
@@ -5100,7 +5100,7 @@ pub fn getPositionContext(
                 stack.pop(curr_ctx.scope == .braces);
                 continue;
             },
-            .keyword_error => .error_access,
+            .keyword_error => .{ .error_access = tok.loc },
             .number_literal => {
                 if (tok.loc.start <= source_index and tok.loc.end >= source_index) {
                     return .{ .number_literal = tok.loc };


### PR DESCRIPTION
This adds completion for errors.

There are issues demonstrated by tests

## Issue test 11
"switch on error set - 11" is `catch |err| switch (err)` construct.

I suspect that scope detection might be wrong which is why "switch on error set - 11" does not work. `innermostScopeAtIndex` in  `lookupSymbolGlobal` returns scope that looks garbage when printed out.

This:
```zig
    var current_scope = innermostScopeAtIndex(document_scope, source_index);
    const node = document_scope.getScopeAstNode(current_scope);
    if (node) |nod| {
        const src = handle.tree.getNodeSource(nod);
        std.debug.print("\nSRC=---\n{s}\n---\n", .{src});
    }
```
Prints out
```
       SRC=---
       {
         idk
```

Trying to tackle the issue is intimidating to me as I don't even know where I would start. Maybe someone more experienced could give some leads how to solve the issue?

---

## Issue test 13
"switch on error set - 13"  is completion in a function in a structure. 

This also feels like issue with scopes. I started digging into how scopes are created. I found DocumentScope where it walks the document. It seems like structure declarations are completely ignored, seemingly on the std side, because  the `walkContainerDecl` just walks the `const std = @import("std")` and then just stops. When I print out `container_decl.ast.members.len` , it gives 1. When I delete the std import, there is 0. Nothing gets walked.

---

After some more digging, it seems both issues are basically the same one. The 13 is structure member that is not given to zls from std. The 11 seems like a block statement that is not given to zls from std (the walker sees test_decl and its block, but nothing else). Is there any chance of fixing this from zls side, or does this need to be fixed on std side?

EDIT: Okay, I found out that the Ast parser is not error-prone enough for zls. Both issues are caused by that the parser refuses to give us these specific members/blocks that contain invalid syntax. So this is to be improved on the stdlib side. But here we can at least add completions for "empty"  context to auto-complete errors. Those should work with both of the problematic cases, and honestly, even be the most ergonomic completions. I'll see if I can do that.