### PR TITLE
fix various code completion text edits

### DIFF
--- a/src/ast.zig
+++ b/src/ast.zig
@@ -400,6 +400,24 @@ fn findMatchingRBrace(tree: *const Ast, start: Ast.TokenIndex) ?Ast.TokenIndex {
     return if (std.mem.findScalarPos(std.zig.Token.Tag, tree.tokens.items(.tag), start, .r_brace)) |index| @intCast(index) else null;
 }
 
+pub fn isKeyword(tag: std.zig.Token.Tag) bool {
+    const tags = std.zig.Token.keywords.values();
+    var first_keyword: std.meta.Tag(std.zig.Token.Tag) = @intFromEnum(tags[0]);
+    var last_keyword: std.meta.Tag(std.zig.Token.Tag) = @intFromEnum(tags[tags.len - 1]);
+    for (std.zig.Token.keywords.values()) |token_tag| {
+        first_keyword = @min(@intFromEnum(token_tag), first_keyword);
+        last_keyword = @max(@intFromEnum(token_tag), last_keyword);
+    }
+    return first_keyword <= @intFromEnum(tag) and @intFromEnum(tag) <= last_keyword;
+}
+
+test isKeyword {
+    try std.testing.expect(!isKeyword(.invalid));
+    try std.testing.expect(!isKeyword(.container_doc_comment));
+    try std.testing.expect(isKeyword(.keyword_addrspace));
+    try std.testing.expect(isKeyword(.keyword_while));
+}
+
 /// Similar to `std.zig.Ast.lastToken` but also handles ASTs with syntax errors.
 pub fn lastToken(tree: *const Ast, node: Node.Index) Ast.TokenIndex {
     var n = node;

--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -4295,6 +4295,54 @@ test "insert replace behaviour - file system completions" {
     // zig fmt: on
 }
 
+test "insert replace behaviour - expression inside parens/braces/brackets" {
+    try testCompletionTextEdit(.{
+        .source =
+        \\const foo = 5;
+        \\const bar = foo(<cursor>);
+        ,
+        .label = "foo",
+        .expected_insert_line = "const bar = foo(foo);",
+        .expected_replace_line = "const bar = foo(foo);",
+    });
+    try testCompletionTextEdit(.{
+        .source =
+        \\const foo = 5;
+        \\const bar = foo(f<cursor>oo);
+        ,
+        .label = "foo",
+        .expected_insert_line = "const bar = foo(foooo);",
+        .expected_replace_line = "const bar = foo(foo);",
+    });
+    try testCompletionTextEdit(.{
+        .source =
+        \\const foo = 5;
+        \\const bar = foo(<cursor>foo);
+        ,
+        .label = "foo",
+        .expected_insert_line = "const bar = foo(foofoo);",
+        .expected_replace_line = "const bar = foo(foo);",
+    });
+    try testCompletionTextEdit(.{
+        .source =
+        \\const foo = 5;
+        \\const bar = foo{<cursor>};
+        ,
+        .label = "foo",
+        .expected_insert_line = "const bar = foo{foo};",
+        .expected_replace_line = "const bar = foo{foo};",
+    });
+    try testCompletionTextEdit(.{
+        .source =
+        \\const foo = 5;
+        \\const bar = foo[<cursor>];
+        ,
+        .label = "foo",
+        .expected_insert_line = "const bar = foo[foo];",
+        .expected_replace_line = "const bar = foo[foo];",
+    });
+}
+
 test "generic function with @This() as self param" {
     try testCompletion(
         \\const Foo = struct {


### PR DESCRIPTION
```zig
// selecting the "src" completion item will add another "/"
const foo = @import("src<cursor>/main.zig");
```

```zig
// Completion items for modules will contain invalid text edits.
// The observable behavior varies between editors.
const known_folders = @import("<cursor>");
```

```zig
// The "foo" completion items will contain invalid text edits.
// The observable behavior varies between editors.
const foo = 5;
const bar = foo(<cursor>);
```
