### PR TITLE
Resolve type of `std.meta.{Tag,ArgsTuple}` call

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -1916,6 +1916,21 @@ fn resolveTypeOfNodeUncached(analyser: *Analyser, options: ResolveOptions) Error
 
             func_ty = try analyser.resolveFunctionTypeFromCall(handle, call, func_ty);
             const func_info = func_ty.data.function;
+            const func_uri = func_info.handle.uri.raw;
+
+            if (std.mem.endsWith(u8, func_uri, "/std/meta.zig") and func_info.name != null) {
+                const func_name = func_info.name.?;
+
+                if (std.mem.eql(u8, func_name, "Tag")) {
+                    if (call.ast.params.len < 1) return .unknown_type;
+                    const arg = call.ast.params[0];
+                    const arg_ty = try analyser.resolveTypeOfNodeInternal(.of(arg, handle)) orelse return .unknown_type;
+                    // TODO: handle enum tag, e.g. `enum(u8)`
+                    const tag_type = try analyser.resolveUnionTag(arg_ty) orelse return .unknown_type;
+                    return try tag_type.typeOf(analyser);
+                }
+            }
+
             return func_info.return_value.*;
         },
         .container_field,
@@ -2747,7 +2762,7 @@ fn resolveTypeOfNodeUncached(analyser: *Analyser, options: ResolveOptions) Error
         .unreachable_literal => return Type.fromIP(analyser, .noreturn_type, null),
         .anyframe_literal => return Type.fromIP(analyser, .anyframe_type, null),
 
-        .anyframe_type => return Type.fromIP(analyser, .type_type, null),
+        .anyframe_type => return .unknown_type,
 
         .mul,
         .div,
@@ -3505,6 +3520,16 @@ pub const Type = struct {
                 },
             }
         }
+    };
+
+    pub const unknown_type: Type = .{
+        .data = .{
+            .ip_index = .{
+                .type = .type_type,
+                .index = null,
+            },
+        },
+        .is_type_val = true,
     };
 
     pub fn hash32(self: Type) u32 {

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -1921,6 +1921,25 @@ fn resolveTypeOfNodeUncached(analyser: *Analyser, options: ResolveOptions) Error
             if (std.mem.endsWith(u8, func_uri, "/std/meta.zig") and func_info.name != null) {
                 const func_name = func_info.name.?;
 
+                if (std.mem.eql(u8, func_name, "ArgsTuple")) {
+                    if (call.ast.params.len < 1) return .unknown_type;
+                    const arg = call.ast.params[0];
+                    const arg_ty = try analyser.resolveTypeOfNodeInternal(.of(arg, handle)) orelse return .unknown_type;
+                    if (!arg_ty.is_type_val or arg_ty.data != .function) return .unknown_type;
+                    const arg_func_info = arg_ty.data.function;
+                    if (arg_func_info.has_varargs) return .unknown_type;
+                    const arg_func_params = arg_func_info.parameters;
+                    const elem_ty_slice = try analyser.arena.alloc(Type, arg_func_params.len);
+                    for (arg_func_params, elem_ty_slice) |param, *elem_ty| {
+                        if (param.type.data == .anytype_parameter) return .unknown_type;
+                        elem_ty.* = param.type;
+                    }
+                    return .{
+                        .data = .{ .tuple = elem_ty_slice },
+                        .is_type_val = true,
+                    };
+                }
+
                 if (std.mem.eql(u8, func_name, "Tag")) {
                     if (call.ast.params.len < 1) return .unknown_type;
                     const arg = call.ast.params[0];

--- a/tests/analysis/meta.zig
+++ b/tests/analysis/meta.zig
@@ -20,3 +20,11 @@ const TagA = std.meta.Tag(TaggedUnionA);
 
 const TagB = std.meta.Tag(TaggedUnionB);
 //    ^^^^ (type)(@typeInfo(TaggedUnionB).@"union".tag_type.?)
+
+const ArgsTupleA = std.meta.ArgsTuple(fn (u8, i32) void);
+//    ^^^^^^^^^^ (type)(struct { u8, i32 })
+
+fn function(_: u16, _: i64) void {}
+
+const ArgsTupleB = std.meta.ArgsTuple(@TypeOf(function));
+//    ^^^^^^^^^^ (type)(struct { u16, i64 })

--- a/tests/analysis/meta.zig
+++ b/tests/analysis/meta.zig
@@ -1,0 +1,22 @@
+const std = @import("std");
+
+const EnumA = enum {
+    foo,
+    bar,
+};
+
+const TaggedUnionA = union(EnumA) {
+    foo: u8,
+    bar: i32,
+};
+
+const TaggedUnionB = union(enum) {
+    fizz: u16,
+    buzz: i64,
+};
+
+const TagA = std.meta.Tag(TaggedUnionA);
+//    ^^^^ (type)(EnumA)
+
+const TagB = std.meta.Tag(TaggedUnionB);
+//    ^^^^ (type)(@typeInfo(TaggedUnionB).@"union".tag_type.?)


### PR DESCRIPTION
```zig
const EnumA = enum {
    foo,
    bar,
};

const TaggedUnionA = union(EnumA) {
    foo: u8,
    bar: i32,
};

const TagA = std.meta.Tag(TaggedUnionA);
//    ^^^^ (type)(EnumA)

const ArgsTupleA = std.meta.ArgsTuple(fn (u8, i32) void);
//    ^^^^^^^^^^ (type)(struct { u8, i32 })
```

- Skipped `std.meta.{Child,Elem,Sentinel}` for now since they require interacting with `InternPool` and overlap with `resolveDerefType`, `resolveBracketAccessType`, etc.
- Skipped `std.meta.{FieldEnum,DeclEnum}` since we can't yet create enums with `InternPool`
- Skipped support for calling `std.meta.Tag` with an enum since (a) the enum tag can be implicit and (b) our type analysis of integer types currently isn't very helpful anyways