### PR TITLE
complete dot after `try` keyword

### DIFF
--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -1117,6 +1117,8 @@ fn getEnumLiteralContext(
     // Allow using `1.` (parser workaround)
     var token_index = if (tree.tokenTag(dot_token_index - 1) == .number_literal)
         (dot_token_index - 2)
+    else if (tree.tokenTag(dot_token_index - 1) == .keyword_try)
+        (dot_token_index - 2)
     else
         (dot_token_index - 1);
     if (token_index == 0) return null;

--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -4567,6 +4567,31 @@ test "doctest name" {
     });
 }
 
+test "dot after try" {
+    try testCompletion(
+        \\const E = error{Err};
+        \\const Foo = struct {
+        \\  fn init() Foo { return undefined; }
+        \\  fn initErr() E!Foo { return undefined; }
+        \\};
+        \\
+        \\fn foo() !void {
+        \\  const f: Foo = try .<cursor>
+        \\}
+    , &.{
+        .{
+            .label = "initErr",
+            .kind = .Function,
+            .detail = "fn () error{Err}!Foo",
+        },
+        .{
+            .label = "init",
+            .kind = .Function,
+            .detail = "fn () Foo",
+        },
+    });
+}
+
 fn testCompletion(source: []const u8, expected_completions: []const Completion) !void {
     try testCompletionWithOptions(source, expected_completions, .{});
 }


### PR DESCRIPTION
Closes #2627

Looks like simply ignoring `try` and looking back at the token before that achieves the goal.

I considered implementing the second request in the issue (to sort fallible functions to be first in the completion list if we're in the context of a `try` keyword), but it looks to be a bit less trivial since it would require storing something like

```zig
const ItemWithExtras = struct {
    item: types.completion.Item,
    is_err_fn: bool,
};
```
instead of plain `types.completion.Item` in the `Builder` for it to produce correct sorting, which is a bit invasive and might warrant a separate PR, so I've left it for now.