### PR TITLE
Include comptime-known values in hover info

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -2614,8 +2614,8 @@ fn resolveTypeOfNodeUncached(analyser: *Analyser, options: ResolveOptions) Error
                 return Type.fromIP(analyser, .bool_type, null);
             const typeof = try ty.typeOf(analyser);
 
-            if (typeof.data == .ip_index and typeof.data.ip_index.index != null) {
-                const key = analyser.ip.indexToKey(typeof.data.ip_index.index.?);
+            if (typeof.ipIndex()) |index| {
+                const key = analyser.ip.indexToKey(index);
                 if (key == .vector_type) {
                     const vector_ty_ip_index = try analyser.ip.get(.{
                         .vector_type = .{
@@ -3575,6 +3575,13 @@ pub const Type = struct {
             return a.eql(b);
         }
     };
+
+    pub fn ipIndex(self: Type) ?InternPool.Index {
+        return switch (self.data) {
+            .ip_index => |payload| payload.index,
+            else => null,
+        };
+    }
 
     pub fn fromIP(analyser: *Analyser, ty: InternPool.Index, index: ?InternPool.Index) Type {
         std.debug.assert(analyser.ip.isType(ty));

--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -256,11 +256,12 @@ fn declToCompletion(builder: *Builder, decl_handle: Analyser.DeclWithHandle) Ana
             }
 
             const detail = if (maybe_resolved_ty) |ty| blk: {
-                if (ty.is_type_val and ty.data == .ip_index and ty.data.ip_index.index != null and !builder.analyser.ip.isUnknown(ty.data.ip_index.index.?)) {
-                    break :blk try ty.stringifyTypeVal(builder.analyser, .{ .truncate_container_decls = false });
-                } else {
-                    break :blk try ty.stringifyTypeOf(builder.analyser, .{ .truncate_container_decls = false });
+                if (ty.ipIndex()) |index| {
+                    if (ty.is_type_val and !builder.analyser.ip.isUnknown(index)) {
+                        break :blk try ty.stringifyTypeVal(builder.analyser, .{ .truncate_container_decls = false });
+                    }
                 }
+                break :blk try ty.stringifyTypeOf(builder.analyser, .{ .truncate_container_decls = false });
             } else null;
 
             const label_details: ?types.completion.Item.LabelDetails = blk: {

--- a/src/features/hover.zig
+++ b/src/features/hover.zig
@@ -22,6 +22,10 @@ fn hoverSymbol(
     const tracy_zone = tracy.trace(@src());
     defer tracy_zone.end();
 
+    const old_resolve_number_literal_values = analyser.resolve_number_literal_values;
+    analyser.resolve_number_literal_values = true;
+    defer analyser.resolve_number_literal_values = old_resolve_number_literal_values;
+
     var doc_strings: std.ArrayList([]const u8) = .empty;
 
     var decl_handle: Analyser.DeclWithHandle = param_decl_handle;
@@ -101,17 +105,25 @@ fn hoverSymbolResolvedType(
     if (resolved_type_maybe) |resolved_type| {
         if (try resolved_type.docComments(arena)) |doc|
             try doc_strings.append(arena, doc);
-        const typeof = try resolved_type.typeOf(analyser);
+
         var possible_types: Analyser.Type.ArraySet = .empty;
-        has_more = try typeof.getAllTypesWithHandlesArraySet(analyser, &possible_types);
+        has_more = try resolved_type.getAllTypesWithHandlesArraySet(analyser, &possible_types);
+
+        const options: Analyser.Type.FormatOptions = .{
+            .referenced = &referenced,
+            .truncate_container_decls = possible_types.count() > 1,
+        };
+
         for (possible_types.keys()) |ty| {
-            try resolved_type_strings.append(
-                arena,
-                try ty.stringifyTypeVal(analyser, .{
-                    .referenced = &referenced,
-                    .truncate_container_decls = possible_types.count() > 1,
-                }),
-            );
+            const type_str = try ty.stringifyTypeOf(analyser, options);
+
+            if (ty.ipIndex() != null) {
+                const val_str = try ty.stringifyTypeVal(analyser, options);
+                const combined = try std.fmt.allocPrint(arena, "{s} = {s}", .{ type_str, val_str });
+                try resolved_type_strings.append(arena, combined);
+            } else {
+                try resolved_type_strings.append(arena, type_str);
+            }
         }
     }
     const referenced_types: []const Analyser.ReferencedType = referenced.keys();

--- a/tests/lsp_features/hover.zig
+++ b/tests/lsp_features/hover.zig
@@ -859,7 +859,7 @@ test "either types" {
         \\const T = u32
         \\```
         \\```zig
-        \\(type)
+        \\(type = u32)
         \\```
         \\
         \\small type
@@ -868,7 +868,7 @@ test "either types" {
         \\const T = u64
         \\```
         \\```zig
-        \\(type)
+        \\(type = u64)
         \\```
         \\
         \\large type
@@ -886,12 +886,12 @@ test "either types" {
         \\const bar = either.<cursor>T;
     ,
         \\const T = u32
-        \\(type)
+        \\(type = u32)
         \\
         \\small type
         \\
         \\const T = u64
-        \\(type)
+        \\(type = u64)
         \\
         \\large type
     , .{ .markup_kind = .plaintext });
@@ -902,7 +902,8 @@ test "either type instances" {
         \\const EitherType<cursor> = if (undefined) u32 else f64;
     ,
         \\const EitherType = if (undefined) u32 else f64
-        \\(type)
+        \\(type = u32)
+        \\(type = f64)
     , .{ .markup_kind = .plaintext });
     try testHoverWithOptions(
         \\const EitherType = if (undefined) u32 else f64;
@@ -1009,9 +1010,9 @@ test "either type instances" {
         \\    .d => {},
         \\    .e => error.Foo,
         \\}
-        \\(comptime_int)
-        \\(bool)
-        \\(comptime_float)
+        \\(comptime_int = 42)
+        \\(bool = true)
+        \\(comptime_float = 3.14)
         \\(...)
     , .{ .markup_kind = .plaintext });
 }
@@ -1058,7 +1059,7 @@ test "var decl comments" {
         \\const foo = 0 + 0
         \\```
         \\```zig
-        \\(comptime_int)
+        \\(comptime_int = 0)
         \\```
         \\
         \\this is a comment
@@ -1085,7 +1086,7 @@ test "var decl alias" {
         \\const foo = 5
         \\```
         \\```zig
-        \\(comptime_int)
+        \\(comptime_int = 5)
         \\```
     );
 }
@@ -1108,7 +1109,7 @@ test "escaped identifier" {
         \\const @"foo" = 42
         \\```
         \\```zig
-        \\(comptime_int)
+        \\(comptime_int = 42)
         \\```
     , .{
         .highlight = "@\"foo\"",
@@ -1121,7 +1122,7 @@ test "escaped identifier" {
         \\const @"hello  world" = 42
         \\```
         \\```zig
-        \\(comptime_int)
+        \\(comptime_int = 42)
         \\```
     , .{
         .highlight = "@\"hello  world\"",
@@ -1134,7 +1135,7 @@ test "escaped identifier" {
         \\const @"hello  world" = 42
         \\```
         \\```zig
-        \\(comptime_int)
+        \\(comptime_int = 42)
         \\```
     , .{
         .highlight = "@\"hello  world\"",
@@ -1150,7 +1151,7 @@ test "escaped identifier with same name as primitive" {
         \\const @"true" = 42
         \\```
         \\```zig
-        \\(comptime_int)
+        \\(comptime_int = 42)
         \\```
     , .{
         .highlight = "@\"true\"",
@@ -1163,7 +1164,7 @@ test "escaped identifier with same name as primitive" {
         \\const @"f32" = 42
         \\```
         \\```zig
-        \\(comptime_int)
+        \\(comptime_int = 42)
         \\```
     , .{
         .highlight = "@\"f32\"",
@@ -1318,7 +1319,7 @@ test "array properties" {
         \\const bar = foo.len<cursor>;
     ,
         \\len
-        \\(usize)
+        \\(usize = 3)
     , .{ .markup_kind = .plaintext });
 }
 
@@ -1328,7 +1329,7 @@ test "tuple properties" {
         \\const bar = foo.len<cursor>;
     ,
         \\len
-        \\(usize)
+        \\(usize = 2)
     , .{ .markup_kind = .plaintext });
     try testHoverWithOptions(
         \\const foo: struct { i32, bool } = undefined;


### PR DESCRIPTION
This will be particularly useful if/when we implement a comptime interpreter or, at least, a calculator for comptime arithmetic.