### PR TITLE
include the body in function document symbol ranges

### DIFF
--- a/src/features/document_symbol.zig
+++ b/src/features/document_symbol.zig
@@ -117,7 +117,9 @@ pub fn getDocumentSymbols(
             .fn_proto_multi,
             .fn_proto_one,
             .fn_proto_simple,
-            => blk: {
+            .fn_decl,
+            => |tag| blk: {
+                if (tag != .fn_decl and tree.nodeTag(walker.parentNode()) == .fn_decl) continue;
                 var buffer: [1]Ast.Node.Index = undefined;
                 const fn_info = tree.fullFnProto(&buffer, node).?;
                 const name_token = fn_info.name_token orelse continue;

--- a/tests/lsp_features/document_symbol.zig
+++ b/tests/lsp_features/document_symbol.zig
@@ -179,6 +179,26 @@ test "decl names that are empty or contain whitespace return non-empty document 
     );
 }
 
+test "nested function declarations" {
+    try testDocumentSymbol(
+        \\fn outer(_: struct {
+        \\    fn foo() void {}
+        \\}) void {
+        \\    _ = struct {
+        \\        fn inner() void {
+        \\            //
+        \\        }
+        \\    };
+        \\}
+    ,
+        \\Function outer (fn outer(_: struct {
+        \\    fn foo() void {}
+        \\}) void)
+        \\  Function foo (fn foo() void)
+        \\  Function inner (fn inner() void)
+    );
+}
+
 fn testDocumentSymbol(source: []const u8, expected: []const u8) !void {
     var ctx: Context = try .init();
     defer ctx.deinit();


### PR DESCRIPTION
zed uses documentSymbol for the outline/breadcrumbs, not including the body meant that it wouldnt show the function the cursor is inside.