### PR TITLE
fix organizeImports returning edits when imports are already sorted

### DIFF
--- a/src/features/code_actions.zig
+++ b/src/features/code_actions.zig
@@ -623,13 +623,60 @@ fn handleUnorganizedImport(builder: *Builder) error{OutOfMemory}!void {
 
     if (imports.len == 0) return;
 
-    // The optimization is disabled because it does not detect the case where imports and other decls are mixed
-    // if (std.sort.isSorted(ImportDecl, imports.items, tree, ImportDecl.lessThan)) return;
-
     const placement = analyzeImportPlacement(tree, imports);
 
     const sorted_imports = try builder.arena.dupe(ImportDecl, imports);
     std.mem.sort(ImportDecl, sorted_imports, tree, ImportDecl.lessThan);
+
+    // Check if imports are already organized (correct order, contiguous, correct separators).
+    // A simple isSorted check is insufficient because it misses mixed imports and incorrect separators.
+    {
+        const already_organized = organized: {
+            // Check sort order matches original
+            for (sorted_imports, imports) |sorted, original| {
+                if (sorted.var_decl != original.var_decl) break :organized false;
+            }
+
+            // Check imports are contiguous in root_decls (no non-import decls between them)
+            const root_decls = tree.rootDecls();
+            var import_range_start: ?usize = null;
+            var import_range_end: usize = 0;
+            for (root_decls, 0..) |decl, i| {
+                for (imports) |imp| {
+                    if (decl == imp.var_decl) {
+                        if (import_range_start == null) import_range_start = i;
+                        import_range_end = i;
+                        break;
+                    }
+                }
+            }
+            const start = import_range_start orelse break :organized true;
+            if (import_range_end - start + 1 != imports.len) break :organized false;
+
+            // Check imports are at the expected position
+            if (placement == .top) {
+                if (start != 0) break :organized false;
+            } else {
+                if (import_range_end != root_decls.len - 1) break :organized false;
+            }
+
+            // Check separators between import groups are correct
+            for (1..sorted_imports.len) |i| {
+                const needs_sep = ImportDecl.addSeperator(sorted_imports[i - 1], sorted_imports[i]);
+                const prev_end = imports[i - 1].getSourceEndIndex(tree, false);
+                const curr_start = imports[i].getSourceStartIndex(tree);
+                if (prev_end < curr_start) {
+                    const between = tree.source[prev_end..curr_start];
+                    const has_blank_line = std.mem.indexOf(u8, between, "\n\n") != null;
+                    if (needs_sep != has_blank_line) break :organized false;
+                }
+            }
+
+            break :organized true;
+        };
+
+        if (already_organized) return;
+    }
 
     var edits: std.ArrayList(types.TextEdit) = .empty;
 

--- a/tests/lsp_features/code_actions.zig
+++ b/tests/lsp_features/code_actions.zig
@@ -762,6 +762,30 @@ test "organize imports - edge cases" {
     );
 }
 
+test "organize imports - already organized" {
+    // Single import (issue #2523)
+    try testOrganizeImportsNoop(
+        \\const a = @import("a");
+        \\
+    );
+    // Multiple imports, already sorted
+    try testOrganizeImportsNoop(
+        \\const std = @import("std");
+        \\const builtin = @import("builtin");
+        \\
+        \\const abc = @import("abc.zig");
+        \\const xyz = @import("xyz.zig");
+        \\
+    );
+    // Single import with code after it
+    try testOrganizeImportsNoop(
+        \\const std = @import("std");
+        \\
+        \\pub fn main() void {}
+        \\
+    );
+}
+
 test "convert multiline string literal" {
     try testConvertString(
         \\const foo = \\Hell<cursor>o
@@ -958,6 +982,35 @@ fn testAutofix(before: []const u8, after: []const u8) !void {
 
 fn testOrganizeImports(before: []const u8, after: []const u8) !void {
     try testDiagnostic(before, after, .{ .filter_kind = .@"source.organizeImports" });
+}
+
+fn testOrganizeImportsNoop(source: []const u8) !void {
+    var ctx: Context = try .init();
+    defer ctx.deinit();
+
+    const uri = try ctx.addDocument(.{ .source = source });
+
+    const params: types.CodeAction.Params = .{
+        .textDocument = .{ .uri = uri.raw },
+        .range = .{
+            .start = .{ .line = 0, .character = 0 },
+            .end = offsets.indexToPosition(source, source.len, ctx.server.offset_encoding),
+        },
+        .context = .{
+            .diagnostics = &.{},
+            .only = &.{.@"source.organizeImports"},
+        },
+    };
+
+    @setEvalBranchQuota(5000);
+    const response = try ctx.server.sendRequestSync(ctx.arena.allocator(), "textDocument/codeAction", params) orelse return;
+
+    for (response) |action| {
+        const code_action: types.CodeAction = action.code_action;
+        if (code_action.kind != null and code_action.kind.? == .@"source.organizeImports") {
+            return error.TestUnexpectedResult;
+        }
+    }
 }
 
 fn testConvertString(before: []const u8, after: []const u8) !void {


### PR DESCRIPTION
## Summary

When imports are already sorted, contiguous, and have correct separators, the `organizeImports` code action still returns TextEdit operations that result in no visible changes. This causes editors like Neovim to unnecessarily dirty the buffer, add to the undo stack, and flicker diagnostics.

## Why this matters

- [#2523](https://github.com/zigtools/zls/issues/2523) documents the problem with LSP logs showing no-op edits being sent
- Neovim's LSP client treats these edits as real changes, adding to the undo stack and triggering buffer-dirty state
- [gopls](https://github.com/golang/tools/tree/master/gopls) handles this correctly by returning no edits when imports are already organized

## Changes

Replace the disabled `isSorted` optimization (which didn't handle mixed imports or separators) with a check that verifies:
1. Sort order matches the original order
2. Imports are contiguous in root decls (no non-import decls interleaved)
3. Imports are at the expected position (top or bottom)
4. Separators between import groups are correct

If all checks pass, the function returns early without generating any code action.

## Testing

Added `testOrganizeImportsNoop` test function and three test cases:
- Single import (the exact case from #2523)
- Multiple imports across different groups, already sorted with separators
- Single import followed by non-import code

Note: could not run tests locally because ZLS master requires Zig 0.16.0-dev which is not available via Homebrew. CI will verify.

Fixes #2523

This contribution was developed with AI assistance (Claude Code).