### PR TITLE
fix import folding including imports separated by blank lines

### DIFF
--- a/src/features/folding_range.zig
+++ b/src/features/folding_range.zig
@@ -199,6 +199,22 @@ pub fn generateFoldingRanges(allocator: std.mem.Allocator, tree: *const Ast, enc
             };
 
             if (is_import) {
+                // Check if there is a blank line between the previous import and this one.
+                // If so, treat them as separate folding groups.
+                if (end_import) |prev| {
+                    const prev_end = offsets.tokenToLoc(tree, ast.lastToken(tree, prev)).end;
+                    const curr_start = tree.tokenStart(tree.firstToken(node));
+                    if (prev_end < curr_start) {
+                        const between = tree.source[prev_end..curr_start];
+                        if (std.mem.indexOf(u8, between, "\n\n") != null) {
+                            // Blank line found: emit the current group and start a new one
+                            if (start_import) |s| {
+                                try builder.add(.imports, tree.firstToken(s), ast.lastToken(tree, prev), .inclusive, .inclusive);
+                            }
+                            start_import = node;
+                        }
+                    }
+                }
                 if (start_import == null) {
                     start_import = node;
                 }

--- a/tests/lsp_features/folding_range.zig
+++ b/tests/lsp_features/folding_range.zig
@@ -484,6 +484,45 @@ test "imports" {
             .collapsedText = "@import(...)",
         },
     });
+    // Imports separated by blank line should create separate folding ranges (issue #2622)
+    try testFoldingRange(
+        \\const Threaded = @import("Threaded.zig");
+        \\const posix = @import("posix.zig");
+        \\
+        \\const fiber = @import("fiber");
+        \\const pike = @import("pike");
+    , &.{
+        .{
+            .startLine = 0,
+            .startCharacter = 0,
+            .endLine = 1,
+            .endCharacter = 34,
+            .kind = .imports,
+            .collapsedText = "@import(...)",
+        },
+        .{
+            .startLine = 3,
+            .startCharacter = 0,
+            .endLine = 4,
+            .endCharacter = 27,
+            .kind = .imports,
+            .collapsedText = "@import(...)",
+        },
+    });
+    // Imports without blank line should still fold together
+    try testFoldingRange(
+        \\const Threaded = @import("Threaded.zig");
+        \\const fiber = @import("fiber");
+    , &.{
+        .{
+            .startLine = 0,
+            .startCharacter = 0,
+            .endLine = 1,
+            .endCharacter = 30,
+            .kind = .imports,
+            .collapsedText = "@import(...)",
+        },
+    });
 }
 
 fn testFoldingRange(source: []const u8, expect: []const types.FoldingRange) !void {


### PR DESCRIPTION
## Summary

Consecutive imports separated by a blank line were incorrectly grouped into a single folding range, causing unrelated imports to be folded under the first group.

## Why this matters

- [#2622](https://github.com/zigtools/zls/issues/2622) reports that folding an import block pulls in unrelated imports from below a blank line
- As @mochalins [clarified](https://github.com/zigtools/zls/issues/2622#issuecomment-2738820478): "the 'Threaded' import shouldn't be folding 'fiber' under it, especially considering there is an empty line between the two statements"

## Changes

In the import folding loop in `folding_range.zig`, detect blank lines (`\n\n`) between consecutive import declarations. When a blank line is found, emit the current folding range and start a new group.

## Testing

Added two test cases to `tests/lsp_features/folding_range.zig`:
- Imports separated by blank line produce separate folding ranges
- Imports without blank line still fold together (regression check)

Note: could not run tests locally (ZLS master requires Zig 0.16.0-dev). CI will verify.

Fixes #2622

This contribution was developed with AI assistance (Claude Code).