### PR TITLE
complete error values for enum_literal in switch on error type

### DIFF
--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -828,6 +828,9 @@ fn completeDot(builder: *Builder, loc: offsets.Loc) Analyser.Error!void {
     const containers = try collectContainerNodes(builder, builder.orig_handle, dot_context);
     for (containers) |container| {
         try collectContainerFields(builder, dot_context.likely, container, used_members_set);
+        // Also offer error set values when the expected type is an error set.
+        // This handles `switch(err) { .<cursor> }` where err is an error type.
+        try collectErrorSetNames(builder, container, used_members_set);
     }
 }
 

--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -2063,6 +2063,19 @@ test "switch on error set - Works in a function of a container" {
     });
 }
 
+test "switch on error set - enum literal dot completion" {
+    // Issue #2624: typing `. ` in switch on error should suggest error values
+    try testCompletion(
+        \\const err: error{E1, E2} = undefined;
+        \\switch(err) {
+        \\    .<cursor>
+        \\}
+    , &.{
+        .{ .label = "error.E1", .kind = .Constant },
+        .{ .label = "error.E2", .kind = .Constant },
+    });
+}
+
 test "error set" {
     try testCompletion(
         \\const E = error {


### PR DESCRIPTION
## Summary

Adds error set value completions when typing `.` (enum_literal context) in a switch on an error type.

## Why this matters

- [#2624](https://github.com/zigtools/zls/issues/2624) requests that `.E1` should be suggested in `switch(err) { .<cursor> }` when `err` is an error type
- PR [#2619](https://github.com/zigtools/zls/pull/2619) (merged 2026-02-26) added error completions for `error.` but not for `.`
- In Zig, `.E1` is valid syntax for error values in switch expressions, just like enum literals

## Changes

Call `collectErrorSetNames` alongside `collectContainerFields` in `completeDot`. `collectErrorSetNames` safely returns early for non-error-set types (`if (key != .error_set_type) return`), so this has no impact on regular enum or struct field completions.

## Testing

Added test case: `switch(err) { .<cursor> }` where `err: error{E1, E2}` expects `error.E1` and `error.E2` completions.

Note: could not run tests locally (ZLS master requires Zig 0.16.0-dev). CI will verify.

Fixes #2624

This contribution was developed with AI assistance (Claude Code).