### PR TITLE
fix: make never mutated local vars const

### DIFF
--- a/src/Uri.zig
+++ b/src/Uri.zig
@@ -20,7 +20,7 @@ fn parseWithOs(
     text: []const u8,
     comptime is_windows: bool,
 ) (std.Uri.ParseError || error{OutOfMemory})!Uri {
-    var uri: std.Uri = try .parse(text);
+    const uri: std.Uri = try .parse(text);
 
     const capacity = capacity: {
         var capacity: usize = 0;

--- a/src/configuration.zig
+++ b/src/configuration.zig
@@ -697,7 +697,7 @@ comptime {
 
 /// The same struct as `Config` but every field is optional.
 pub const UnresolvedConfig = blk: {
-    var struct_info: std.builtin.Type.Struct = @typeInfo(Config).@"struct";
+    const struct_info: std.builtin.Type.Struct = @typeInfo(Config).@"struct";
     var field_types: [struct_info.fields.len]type = undefined;
     var field_attrs: [struct_info.fields.len]std.builtin.Type.StructField.Attributes = undefined;
     for (&field_types, &field_attrs, struct_info.fields) |*ty, *attr, field| {


### PR DESCRIPTION
Resolves not being able to compile ZLS with [latest Zig](https://codeberg.org/ziglang/zig/pulls/31534).