### PR TITLE
handle import to module without a root source file

### DIFF
--- a/src/build_runner/build_runner.zig
+++ b/src/build_runner/build_runner.zig
@@ -1101,10 +1101,11 @@ fn extractBuildInformation(
             });
 
             for (module.import_table.keys(), module.import_table.values()) |name, import| {
+                const import_root_source_file = import.root_source_file orelse continue;
                 const gop_import = try gop.value_ptr.import_table.map.getOrPut(allocator, name);
                 // This does not account for the possibility of collisions (i.e. modules with same root source file import different modules under the same name).
                 if (!gop_import.found_existing) {
-                    gop_import.value_ptr.* = try std.fs.path.resolve(allocator, &.{ cwd, import.root_source_file.?.getPath2(import.owner, null) });
+                    gop_import.value_ptr.* = try std.fs.path.resolve(allocator, &.{ cwd, import_root_source_file.getPath2(import.owner, null) });
                 }
             }
             gop.value_ptr.c_macros = try std.mem.concat(allocator, []const u8, &.{ gop.value_ptr.c_macros, c_macros.keys() });

--- a/tests/build_runner_cases/no_root_source_file.json
+++ b/tests/build_runner_cases/no_root_source_file.json
@@ -1,0 +1,23 @@
+{
+  "dependencies": {},
+  "modules": {
+    "baz.zig": {
+      "import_table": {},
+      "c_macros": [],
+      "include_dirs": []
+    },
+    "bar.zig": {
+      "import_table": {
+        "with-root-source-file": "baz.zig"
+      },
+      "c_macros": [],
+      "include_dirs": []
+    }
+  },
+  "compilations": [],
+  "top_level_steps": [
+    "install",
+    "uninstall"
+  ],
+  "available_options": {}
+}

--- a/tests/build_runner_cases/no_root_source_file.zig
+++ b/tests/build_runner_cases/no_root_source_file.zig
@@ -1,0 +1,19 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const with_root_source_file = b.createModule(.{ .root_source_file = b.path("baz.zig") });
+    const without_root_source_file = b.createModule(.{});
+    _ = b.addModule("foo", .{
+        .imports = &.{
+            .{ .name = "with-root-source-file", .module = with_root_source_file },
+            .{ .name = "without-root-source-file", .module = without_root_source_file },
+        },
+    });
+    _ = b.addModule("bar", .{
+        .root_source_file = b.path("bar.zig"),
+        .imports = &.{
+            .{ .name = "with-root-source-file", .module = with_root_source_file },
+            .{ .name = "without-root-source-file", .module = without_root_source_file },
+        },
+    });
+}


### PR DESCRIPTION
fixes #2658

First time I've seen [addImport](https://github.com/allyourcodebase/opus/blob/21f900838ede6b5fa42b359cd80bf9dfd74698af/build.zig#L184-L185) used instead of `linkLibrary` to link c code.