### PR TITLE
Fix string escaping in flake.nix regex

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
     parseVersionFieldFromZon = name:
       lib.pipe ./build.zig.zon [
         builtins.readFile
-        (builtins.match ".*\n[[:space:]]*\.${name}[[:space:]]=[[:space:]]\"([^\"]+)\".*")
+        (builtins.match ".*\n[[:space:]]*\\.${name}[[:space:]]=[[:space:]]\"([^\"]+)\".*")
         builtins.head
       ];
     zlsVersionShort = parseVersionFieldFromZon "version";


### PR DESCRIPTION
`\.` in a Nix string is interpreted as an invalid escape sequence,
which currently ignores the backslash and evaluates simply to `.`.

This is not the desired behavior, and also a deprecated features of Nix.
The recent release of Lix 2.95 introduced a warning for these cases.