### PR TITLE
fix: EnumSet initFull/Empty are deprecated

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -10,7 +10,7 @@
     // nix flake update --commit-lock-file
     // ```
     // If you do not use Nix, a ZLS maintainer can take care of this.
-    .minimum_zig_version = "0.16.0-dev.2984+cb7d2b056",
+    .minimum_zig_version = "0.16.0-dev.3133+5ec8e45f3",
     // Must be kept in sync with the `deps.nix` for the Nix flake.
     // If you do not use Nix, a ZLS maintainer can take care of this.
     .dependencies = .{

--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1774388614,
-        "narHash": "sha256-tFwzTI0DdDzovdE9+Ras6CUss0yn8P9XV4Ja6RjA+nU=",
+        "lastModified": 1775595990,
+        "narHash": "sha256-OEf7YqhF9IjJFYZJyuhAypgU+VsRB5lD4DuiMws5Ltc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1073dad219cb244572b74da2b20c7fe39cb3fa9e",
+        "rev": "4e92bbcdb030f3b4782be4751dc08e6b6cb6ccf2",
         "type": "github"
       },
       "original": {
@@ -63,11 +63,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1774441590,
-        "narHash": "sha256-8cMeRjQOqOzwYmZdH7cV75PeXOGf74RDGR9IsFX+7j0=",
+        "lastModified": 1775651458,
+        "narHash": "sha256-Vin1+HI1TJvBXS4d3rcflfCWL9MmJJjjoZ2ATsPHAqg=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "e8d24a6b03faf3824103b6fc986c1afa7c90c7c1",
+        "rev": "e9ed260913d18b2973a86eabc8e46642c4e04c75",
         "type": "github"
       },
       "original": {

--- a/src/Server.zig
+++ b/src/Server.zig
@@ -1535,7 +1535,7 @@ fn codeActionHandler(server: *Server, arena: std.mem.Allocator, request: types.C
     defer analyser.deinit();
 
     const only_kinds = if (request.context.only) |kinds| blk: {
-        var set: std.EnumSet(std.meta.Tag(types.CodeAction.Kind)) = .initEmpty();
+        var set: std.EnumSet(std.meta.Tag(types.CodeAction.Kind)) = .empty;
         for (kinds) |kind| {
             set.setPresent(kind, true);
         }

--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -6215,7 +6215,7 @@ pub fn innermostScopeAtIndex(
     document_scope: *const DocumentScope,
     source_index: usize,
 ) Scope.Index {
-    return innermostScopeAtIndexWithTag(document_scope, source_index, .initFull()).unwrap().?;
+    return innermostScopeAtIndexWithTag(document_scope, source_index, .full).unwrap().?;
 }
 
 pub fn innermostScopeAtIndexWithTag(


### PR DESCRIPTION
Replaces the [recently deprecated](https://codeberg.org/ziglang/zig/pulls/31469) `EnumSet.initFull` and `EnumSet.initEmpty` with their new declaration literal counterparts.

Fixes https://github.com/zigtools/zls/issues/3169.