### PR TITLE
fix: import path resolution

### DIFF
--- a/src/features/goto.zig
+++ b/src/features/goto.zig
@@ -266,7 +266,7 @@ fn gotoDefinitionString(
                 const path = try std.Io.Dir.path.join(arena, &.{ dir, import_str });
                 std.Io.Dir.accessAbsolute(io, path, .{}) catch |err| switch (err) {
                     error.Canceled => return error.Canceled,
-                    else => {},
+                    else => continue,
                 };
                 break :blk .{ .one = try .fromPath(arena, path) };
             }


### PR DESCRIPTION
this is a fix for some `@cInclude` resolution issues.

on helix, hitting `goto definition` on `@cInclude` was leading me to paths like `/nix/store/h8z9vbggppvs1nnk43bmhqa8d7mciln4-python3-3.12.13-env/include/portaudio.h`, which obviously did not make sense.
on debugging, i found that commit e1afcf7 introduced a bug in goto.zig:263

related issues:
#2593

minimal example: https://github.com/thrombe/zls/tree/import-bugs/examples/import_bug