### PR TITLE
do not create completion items with empty string as documentation field

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -126,7 +126,12 @@ pub fn getDocCommentTokenIndex(tree: *const Ast, base_token: Ast.TokenIndex) ?As
     } else idx + 1;
 }
 
-pub fn collectDocComments(allocator: std.mem.Allocator, tree: *const Ast, doc_comments: Ast.TokenIndex, container_doc: bool) error{OutOfMemory}![]const u8 {
+pub fn collectDocComments(
+    allocator: std.mem.Allocator,
+    tree: *const Ast,
+    doc_comments: Ast.TokenIndex,
+    container_doc: bool,
+) error{OutOfMemory}!?[]const u8 {
     var lines: std.ArrayList([]const u8) = .empty;
     defer lines.deinit(allocator);
 
@@ -134,13 +139,16 @@ pub fn collectDocComments(allocator: std.mem.Allocator, tree: *const Ast, doc_co
 
     var curr_line_tok = doc_comments;
     while (true) : (curr_line_tok += 1) {
-        const comm = tree.tokenTag(curr_line_tok);
-        if ((container_doc and comm == .container_doc_comment) or (!container_doc and comm == .doc_comment)) {
-            const line = tree.tokenSlice(curr_line_tok)[3..];
-            if (line.len > 1 and line[0] != ' ') lines_start_with_space = false;
-            try lines.append(allocator, line);
-        } else break;
+        switch (tree.tokenTag(curr_line_tok)) {
+            .container_doc_comment => if (!container_doc) break,
+            .doc_comment => if (container_doc) break,
+            else => break,
+        }
+        const line = tree.tokenSlice(curr_line_tok)[3..];
+        if (!std.mem.startsWith(u8, line, " ")) lines_start_with_space = false;
+        try lines.append(allocator, line);
     }
+    if (lines.items.len == 0) return null;
 
     // If all of the lines that aren't empty start with a space, remove the first space
     if (lines_start_with_space) {

--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -231,10 +231,11 @@ fn declToCompletion(builder: *Builder, decl_handle: Analyser.DeclWithHandle) Ana
         }
     }
 
-    const documentation: ?types.Documentation = if (doc_comments.items.len > 0) .{
+    const documentation_string = try std.mem.join(builder.arena, "\n\n", doc_comments.items);
+    const documentation: ?types.Documentation = if (documentation_string.len > 0) .{
         .markup_content = .{
             .kind = if (builder.server.client_capabilities.completion_doc_supports_md) .markdown else .plaintext,
-            .value = try std.mem.join(builder.arena, "\n\n", doc_comments.items),
+            .value = documentation_string,
         },
     } else null;
 

--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -3656,6 +3656,28 @@ test "top-level doc comment" {
     });
 }
 
+test "empty doc comment" {
+    try testCompletion(
+        \\///
+        \\const foo<cursor> = 5;
+    , &.{
+        .{
+            .label = "foo",
+            .kind = .Constant,
+        },
+    });
+    try testCompletion(
+        \\///
+        \\const foo<cursor> = 5;
+    , &.{
+        .{
+            .label = "foo",
+            .kind = .Constant,
+            .documentation = "",
+        },
+    });
+}
+
 test "filesystem" {
     if (@import("builtin").target.cpu.arch.isWasm()) return error.SkipZigTest;
 
@@ -4824,6 +4846,7 @@ fn testCompletionWithOptions(
             } else null;
 
             if (actual_doc != null and std.mem.eql(u8, expected_doc, actual_doc.?)) break :doc_blk;
+            if (actual_doc == null and expected_doc.len == 0) break :doc_blk;
 
             try error_builder.msgAtIndex("completion item '{s}' should have doc '{f}' but was '{?f}'!", test_uri.raw, cursor_idx, .err, .{
                 label,
@@ -4832,8 +4855,9 @@ fn testCompletionWithOptions(
             });
             return error.InvalidCompletionDoc;
         } else blk: {
-            if (!options.check_null_fields) break :blk;
             const actual_doc = actual_completion.documentation orelse break :blk;
+            std.debug.assert(actual_doc.markup_content.value.len > 0); // the whole documentation field should be set to null instead
+            if (!options.check_null_fields) break :blk;
             try error_builder.msgAtIndex("completion item '{s}' has unexpected doc '{f}'", test_uri.raw, cursor_idx, .err, .{
                 label,
                 std.zig.fmtString(actual_doc.markup_content.value),

--- a/tests/lsp_features/signature_help.zig
+++ b/tests/lsp_features/signature_help.zig
@@ -371,6 +371,15 @@ fn testSignatureHelp(source: []const u8, expected_label: []const u8, expected_ac
         return error.InvalidResponse;
     };
 
+    for (response.signatures) |signature| {
+        if (signature.documentation) |documentation| std.debug.assert(documentation.markup_content.value.len > 0); // the whole documentation field should be set to null instead
+        if (signature.parameters) |parameters| {
+            for (parameters) |parameter| {
+                if (parameter.documentation) |documentation| std.debug.assert(documentation.markup_content.value.len > 0); // the whole documentation field should be set to null instead
+            }
+        }
+    }
+
     try std.testing.expectEqual(@as(?u32, 0), response.activeSignature);
     try std.testing.expectEqual(@as(usize, 1), response.signatures.len);
 


### PR DESCRIPTION
Sending an empty string in the documentation field may cause the editor to display an empty text box or empty line.