### PR TITLE
collect module imports of public modules

### DIFF
--- a/src/build_runner/build_runner.zig
+++ b/src/build_runner/build_runner.zig
@@ -1078,9 +1078,11 @@ fn extractBuildInformation(
         var modules: std.array_hash_map.Auto(*std.Build.Module, void) = .empty;
         defer modules.deinit(gpa);
 
-        try modules.ensureUnusedCapacity(gpa, b.modules.count());
+        // collect all modules of root modules
         for (b.modules.values()) |root_module| {
-            modules.putAssumeCapacity(root_module, {});
+            const graph = root_module.getGraph();
+            try modules.ensureUnusedCapacity(gpa, graph.modules.len);
+            for (graph.modules) |module| modules.putAssumeCapacity(module, {});
         }
 
         // collect all modules of `Step.Compile`

--- a/tests/build_runner_cases/add_options.json
+++ b/tests/build_runner_cases/add_options.json
@@ -1,0 +1,19 @@
+{
+  "dependencies": {},
+  "modules": {
+    "root.zig": {
+      "import_table": {
+        "options": ".zig-local-cache/options.zig"
+      }
+    },
+    ".zig-local-cache/options.zig": {
+      "import_table": {}
+    }
+  },
+  "compilations": [],
+  "top_level_steps": [
+    "install",
+    "uninstall"
+  ],
+  "available_options": {}
+}

--- a/tests/build_runner_cases/add_options.zig
+++ b/tests/build_runner_cases/add_options.zig
@@ -1,0 +1,11 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const module = b.addModule("root", .{
+        .root_source_file = b.path("root.zig"),
+    });
+
+    const options = b.addOptions();
+    options.addOption(bool, "enabled", true);
+    module.addOptions("options", options);
+}

--- a/tests/build_runner_check.zig
+++ b/tests/build_runner_check.zig
@@ -88,13 +88,13 @@ fn sanitizePath(
         }
         if (stripBasePath(local_cache_dir, path)) |to| {
             var it = std.Io.Dir.path.componentIterator(to);
-            std.debug.assert(std.mem.eql(u8, it.next().?.name, "o"));
+            _ = it.next().?; // skip cache namespace (o, c, h, z, tmp, ...)
             std.debug.assert(it.next().?.name.len == std.Build.Cache.hex_digest_len);
             break :new try std.fmt.allocPrint(arena, ".zig-local-cache/{s}", .{to[it.end_index + 1 ..]});
         }
         if (stripBasePath(global_cache_dir, path)) |to| {
             var it = std.Io.Dir.path.componentIterator(to);
-            std.debug.assert(std.mem.eql(u8, it.next().?.name, "o"));
+            _ = it.next().?; // skip cache namespace (o, c, h, z, tmp, ...)
             std.debug.assert(it.next().?.name.len == std.Build.Cache.hex_digest_len);
             break :new try std.fmt.allocPrint(arena, ".zig-global-cache/{s}", .{to[it.end_index + 1 ..]});
         }


### PR DESCRIPTION
Currently, zls only collects module imports of Step.Compile. For public modules, it only collect the root_modules, not their module imports.

This commit makes the build_runner also collects the module imports and also adds one regression test case when one does `addOptions` on a public module, which is my original motivation (and confusion why my `@import("options")` was not working).

The generated options.zig file is generated in the `c/` instead of `o/` namespace, so I also removed the namespace assertion. I assume the original assertion is only for reminding reader of what that component is, and not an actual useful property of the path, so I keep the intent as a comment.

---

Please let me know if this is the correct fix, or was there a reason `b.modules` are treated differently from `Step.Compile`.

Also, without the fix, the added test case with fail with:

```
getPath() was called on a GeneratedFile that wasn't built yet.
  source package path: /workspace/zls/tests/build_runner_cases
  Is there a missing Step dependency on step 'options'?
```