### PR TITLE
fix: prevent renaming aliased functions during rename request

### DIFF
--- a/src/features/references.zig
+++ b/src/features/references.zig
@@ -70,6 +70,7 @@ const Builder = struct {
     did_add_target_symbol: bool = false,
     analyser: *Analyser,
     encoding: offsets.Encoding,
+    resolve_aliases: bool = true,
 
     fn add(self: *Builder, handle: *DocumentStore.Handle, token_index: Ast.TokenIndex) error{OutOfMemory}!void {
         if (self.target_symbol.handle == handle and
@@ -235,8 +236,9 @@ const Builder = struct {
             },
             else => return,
         };
-
-        candidate = try builder.analyser.resolveVarDeclAlias(candidate) orelse candidate;
+        if (builder.resolve_aliases) {
+            candidate = try builder.analyser.resolveVarDeclAlias(candidate) orelse candidate;
+        }
 
         if (builder.target_symbol.eql(candidate)) {
             try builder.add(handle, name_token);
@@ -296,6 +298,7 @@ fn symbolReferences(
         .target_symbol = target_symbol,
         .local_only_decl = local_node != null,
         .encoding = encoding,
+        .resolve_aliases = request != .rename,
     };
 
     blk: {
@@ -735,8 +738,9 @@ pub fn referencesHandler(server: *Server, arena: std.mem.Allocator, request: Gen
             .keyword => null,
             else => null,
         } orelse return null;
-
-        target_decl = try analyser.resolveVarDeclAlias(target_decl) orelse target_decl;
+        if (request != .rename) {
+            target_decl = try analyser.resolveVarDeclAlias(target_decl) orelse target_decl;
+        }
 
         break :locs switch (target_decl.decl) {
             .label => |payload| try labelReferences(


### PR DESCRIPTION
Fixes #3184 

### Description
This fixes an issue where triggering a `textDocument/rename` on a local alias of a function (e.g., `const testName = std.debug.print;`) would incorrectly resolve the alias to its source and rename the original declaration (e.g., renaming `print` inside the Zig standard library).

**Root Cause:**
During a rename request, `referencesHandler` and the reference-gathering `Builder` were aggressively resolving aliases using `analyser.resolveVarDeclAlias`. While this is desired for `textDocument/references` or `highlight`, it results in cross-file destruction during a rename.

**Changes:**
- Added a `resolve_aliases` boolean flag to the `Builder` struct in `src/features/references.zig`.
- Conditionally bypassed `resolveVarDeclAlias` in both `referencesHandler` and `Builder.referenceNode` if `request == .rename`.
- This ensures that a rename operation strictly targets the literal identifier the user initiated the rename on, preserving the underlying source declaration.

### Environment / Tested On
- `zig 0.16.0`
- `zig 0.17.0-dev.215+8c5542bd3`
- `emacs/neovim`

### Test Case Used
```zig
const std = @import("std");

const foo = struct {
    pub fn print(comptime fmt: []const u8, args: anytype) void {
        std.debug.print(fmt, args);
    }
};

const fein = foo.print;

pub fn main() void {
    // Renaming `fein` here no longer renames `foo.print`
    fein("Hello world \n", .{});
}
```