### PR TITLE
Allow C pointers as valid self parameters in method detection

### DIFF
--- a/src/analysis.zig
+++ b/src/analysis.zig
@@ -461,16 +461,16 @@ pub fn firstParamIs(
 
     const deref_type = switch (resolved_type.data) {
         .pointer => |info| switch (info.size) {
-            .one => info.elem_ty.*,
-            .many, .slice, .c => return false,
+            .one, .c => info.elem_ty.*,
+            .many, .slice => return false,
         },
         else => resolved_type,
     };
 
     const deref_expected_type = switch (expected_type.data) {
         .pointer => |info| switch (info.size) {
-            .one => info.elem_ty.*,
-            .many, .slice, .c => return false,
+            .one, .c => info.elem_ty.*,
+            .many, .slice => return false,
         },
         else => expected_type,
     };

--- a/tests/lsp_features/completion.zig
+++ b/tests/lsp_features/completion.zig
@@ -1337,11 +1337,13 @@ test "struct" {
         \\fn fooImpl(_: Foo) void {}
         \\fn barImpl(_: *const Foo) void {}
         \\fn bazImpl(_: u32) void {}
+        \\fn quxImpl(_: [*c]const Foo) void {}
         \\const Foo = struct {
         \\    alpha: u32,
         \\    pub const foo = fooImpl;
         \\    pub const bar = barImpl;
         \\    pub const baz = bazImpl;
+        \\    pub const qux = quxImpl;
         \\};
         \\const foo = Foo{};
         \\const baz = foo.<cursor>;
@@ -1349,6 +1351,7 @@ test "struct" {
         .{ .label = "alpha", .kind = .Field, .detail = "u32" },
         .{ .label = "foo", .kind = .Method, .detail = "fn (_: Foo) void" },
         .{ .label = "bar", .kind = .Method, .detail = "fn (_: *const Foo) void" },
+        .{ .label = "qux", .kind = .Method, .detail = "fn (_: [*c]const Foo) void" },
     });
     try testCompletion(
         \\alpha: u32,


### PR DESCRIPTION
The language server was not recognizing methods with C pointer receivers (`[*c]T`) as valid methods on their container types. This meant that when working with C interop code, functions like `fuse_opt_parse` declared with `[*c]struct_fuse_args` parameters were not being offered as method completions on instances of `struct_fuse_args`.

Example of generated `cimport.zig`:
```zig
pub const struct_fuse_args = extern struct {
    argc: c_int = 0,
    argv: [*c][*c]u8 = null,
    allocated: c_int = 0,
    pub const fuse_opt_parse = __root.fuse_opt_parse;
    pub const parse = __root.fuse_opt_parse;
};
// Here, generated with `[*c]` pointer.
pub extern fn fuse_opt_parse(args: [*c]struct_fuse_args, data: ?*anyopaque, opts: [*c]const struct_fuse_opt, proc: fuse_opt_proc_t) c_int;
```

```zig
var fuse_args: c.struct_fuse_args = .{};

// This compiles, but no method completion was offered:
_ = fuse_args.parse(&options, &option_spec, null);
```

## Solution

Updated firstParamIs to treat .c pointers the same as .one pointers when matching the container type.