### PR TITLE
fix `paramFirstToken` on variadic function

### DIFF
--- a/src/ast.zig
+++ b/src/ast.zig
@@ -859,7 +859,10 @@ pub fn paramFirstToken(tree: *const Ast, param: Ast.full.FnProto.Param, include_
     return (if (include_doc_comment) param.first_doc_comment else null) orelse
         param.comptime_noalias orelse
         param.name_token orelse
-        tree.firstToken(param.type_expr.?);
+        if (param.type_expr) |te|
+            tree.firstToken(te)
+        else
+            param.anytype_ellipsis3.?;
 }
 
 pub fn paramLastToken(tree: *const Ast, param: Ast.full.FnProto.Param) Ast.TokenIndex {

--- a/tests/lsp_features/selection_range.zig
+++ b/tests/lsp_features/selection_range.zig
@@ -23,6 +23,15 @@ test "between nodes" {
     , &.{});
 }
 
+test "variadic function" {
+    try testSelectionRange(
+        \\fn foo(...<>) void {}
+    , &.{
+        "...",
+        "fn foo(...) void",
+    });
+}
+
 test "expression inside function" {
     try testSelectionRange(
         \\fn main() void {


### PR DESCRIPTION
fixes #3206