### PR TITLE
fix: cancel stale completion requests

### DIFF
--- a/src/Server.zig
+++ b/src/Server.zig
@@ -1342,6 +1342,23 @@ fn isBlockingMessage(msg: Message) bool {
     }
 }
 
+fn invalidatesPendingRequests(msg: Message) bool {
+    return switch (msg) {
+        .notification => |notification| switch (notification.params) {
+            .@"textDocument/didOpen",
+            .@"textDocument/didChange",
+            .@"textDocument/didSave",
+            .@"textDocument/didClose",
+            .@"workspace/didChangeWatchedFiles",
+            .@"workspace/didChangeWorkspaceFolders",
+            .@"workspace/didChangeConfiguration",
+            => true,
+            else => false,
+        },
+        else => false,
+    };
+}
+
 pub const CreateOptions = struct {
     /// An implementation that doesn't support `concurrent` is permitted but will not be able to provide some features like build on save.
     io: std.Io,
@@ -1446,6 +1463,7 @@ pub fn loop(server: *Server) LoopError!void {
         };
 
         if (isBlockingMessage(message)) {
+            if (invalidatesPendingRequests(message)) server.wait_group.cancel(server.io);
             try server.wait_group.await(server.io);
             server.wait_group = .init;
             try server.processMessageReportError(arena_allocator.state, message);

--- a/src/features/completions.zig
+++ b/src/features/completions.zig
@@ -186,6 +186,7 @@ fn typeToCompletion(builder: *Builder, ty: Analyser.Type) Analyser.Error!void {
             try builder.analyser.collectDeclarationsOfContainer(ty, builder.orig_handle, !ty.is_type_val, &decls);
 
             for (decls.items) |decl_with_handle| {
+                try builder.server.io.checkCancel();
                 try declToCompletion(builder, decl_with_handle);
             }
         },
@@ -686,6 +687,7 @@ fn completeGlobal(builder: *Builder) Analyser.Error!void {
     var decls: std.ArrayList(Analyser.DeclWithHandle) = .empty;
     try builder.analyser.collectAllSymbolsAtSourceIndex(builder.orig_handle, builder.source_index, &decls);
     for (decls.items) |decl_with_handle| {
+        try builder.server.io.checkCancel();
         try declToCompletion(builder, decl_with_handle);
     }
     try populateSnippedCompletions(builder, .generic);
@@ -1497,6 +1499,7 @@ fn collectContainerFields(
     const scope_decls = document_scope.getScopeDeclarationsConst(scope_handle.scope);
 
     for (scope_decls) |decl_index| {
+        try builder.server.io.checkCancel();
         const decl = document_scope.declarations.get(@backingInt(decl_index));
         if (decl != .ast_node) continue;
         const decl_handle: Analyser.DeclWithHandle = .{ .decl = decl, .handle = scope_handle.handle, .container_type = container };


### PR DESCRIPTION
## Description

I cancel outstanding completion requests when a document-changing notification arrives. Completion declaration loops now check for cancellation, so stale requests release before the document refreshes.

Fixes #3251

## Why

Large generated C bindings can make completion enumeration expensive. The response should reflect the latest document instead of waiting for earlier edits to finish.

## Verification

- before, on current `master`: a 30,000-declaration import with eight rapid `textDocument/didChange` and completion pairs left the newest response pending for 19.523 seconds
- after: the same session returned the newest response in 0.694 seconds
- `zig build test -Dtest-filter=completion`
- `zig build test`
